### PR TITLE
Pass Twitch creds to the prod api service

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,10 @@ services:
       - CORS_ORIGINS=["*"]
       - REDIS_HOST=stream-sniper-redis
       - REDIS_PORT=6379
+      # Adding a tracked streamer via the API calls the Twitch API (creator
+      # lookup), so the api process needs Twitch creds too — not just tracking.
+      - TWITCH_CLIENT_ID=${TWITCH_CLIENT_ID}
+      - TWITCH_CLIENT_SECRET=${TWITCH_CLIENT_SECRET}
     restart: unless-stopped
     container_name: stream-sniper-api
     networks:


### PR DESCRIPTION
The api process calls the Twitch API when adding a tracked streamer (`POST /admin/tracking/streamers` → creator lookup), but `docker-compose.prod.yml` only passed `TWITCH_CLIENT_ID`/`TWITCH_CLIENT_SECRET` to the **tracking** service. Adding a streamer therefore fails with "TWITCH_CLIENT_ID and TWITCH_CLIENT_SECRET environment variables must be set". This mirrors the tracking service's env block onto the api service.

Discovered while verifying prod after deploying #19/#20. Note: prod `.env.prod` currently holds **placeholder** Twitch values (`your_twitch_client_id`), so real credentials still need to be set there before collection can work — this PR just ensures the api container receives them once they exist.

Validated with `docker compose -f docker-compose.prod.yml config`.

https://claude.ai/code/session_01Xz11FdWuR4kVHWq9MdG56j