### PR TITLE
Fix event-loop crash in async Twitch callers (add-streamer + tracking monitor)

### DIFF
--- a/backend/stream_sniper/api/tracking_endpoints.py
+++ b/backend/stream_sniper/api/tracking_endpoints.py
@@ -265,8 +265,8 @@ async def add_tracked_streamer(
                 await twitch_api.twitch_api_init()
                 twitch_api.set_streamer_nickname(streamer_data.twitch_username)
                 
-                display_name, profile_image_url = twitch_api.get_creator_info()
-                twitch_creator_id = twitch_api.get_creator_twitch_id()
+                display_name, profile_image_url = await twitch_api.get_creator_info_async()
+                twitch_creator_id = await twitch_api.get_creator_twitch_id_async()
                 
                 creator_id = insert_new_creator_db(
                     streamer_data.twitch_username,

--- a/backend/stream_sniper/collector/twitch_api.py
+++ b/backend/stream_sniper/collector/twitch_api.py
@@ -86,3 +86,33 @@ class TwitchAPI:
             return []
 
         return videos
+
+    # Async variants for callers that already run inside an event loop (the
+    # FastAPI endpoints and the tracking monitor). The sync get_async_result
+    # helper above uses loop.run_until_complete, which raises "This event loop
+    # is already running" when called from async code — and the Twitch client's
+    # aiohttp session is bound to the running loop, so the coroutines must be
+    # awaited on that same loop rather than bridged from a worker thread.
+    async def get_creator_twitch_id_async(self) -> Any:
+        async for user in self.twitch.get_users(logins=[self.streamer_nickname]):
+            return user.id
+        return None
+
+    async def get_creator_info_async(self) -> Tuple[str, str]:
+        async for user in self.twitch.get_users(logins=[self.streamer_nickname]):
+            return user.display_name, user.profile_image_url
+        return None
+
+    async def get_stream_info_async(self) -> Any:
+        async for stream in self.twitch.get_streams(user_login=[self.streamer_nickname]):
+            return stream
+        return None
+
+    async def get_available_video_ids_async(self) -> List[Any]:
+        twitch_user_id = await self.get_creator_twitch_id_async()
+        if twitch_user_id is None:
+            return []
+        videos = []
+        async for video in self.twitch.get_videos(user_id=twitch_user_id, video_type=VideoType.ARCHIVE):
+            videos.append(video)
+        return videos

--- a/backend/stream_sniper/tracking/stream_monitor.py
+++ b/backend/stream_sniper/tracking/stream_monitor.py
@@ -141,7 +141,7 @@ class StreamMonitor:
             self.twitch_api.set_streamer_nickname(twitch_username)
             
             # Get stream info
-            stream_info = self.twitch_api.get_stream_info()
+            stream_info = await self.twitch_api.get_stream_info_async()
             
             if stream_info:
                 return StreamStatus(
@@ -208,7 +208,7 @@ class StreamMonitor:
             self.twitch_api.set_streamer_nickname(twitch_username)
             
             # Get available video IDs (recent streams)
-            videos = self.twitch_api.get_available_video_ids()
+            videos = await self.twitch_api.get_available_video_ids_async()
             
             # Return the most recent videos (limited)
             return videos[:limit] if videos else []


### PR DESCRIPTION
## Problem
`TwitchAPI.get_async_result()` bridges the async twitchAPI client to sync callers with `loop.run_until_complete()`. Fine in the collector (runs in a worker thread via `run_in_executor`), but **three callers invoke the sync getters from inside a live event loop**:
- `add_tracked_streamer` (async endpoint) → `get_creator_info`/`get_creator_twitch_id`
- `stream_monitor._get_stream_status` → `get_stream_info`
- `stream_monitor._get_recent_streams` → `get_available_video_ids`

There it raises **"This event loop is already running"**, so adding a streamer via the API returns 400, and the tracking monitor silently never detects streams (its `except` swallows the error and reports "not live"). This path was never exercised because prod had placeholder Twitch creds until now.

## Fix
Add async variants (`*_async`) and `await` them from the three async call sites. The Twitch client's aiohttp session is bound to the running loop, so the coroutines must be awaited there — not bridged from a worker thread. Sync getters stay for the executor-thread collector.

## Verification
Ruff clean. Exercised the new methods against the **live Twitch API** with valid creds (inside a running loop): resolving a creator + listing archive VODs works (jynxzi → id 411377640, 57 VODs).

Found while verifying prod after #19/#20/#21.

https://claude.ai/code/session_01Xz11FdWuR4kVHWq9MdG56j