### PR TITLE
Add missing creator.twitch_id column to schema

### DIFF
--- a/backend/stream_sniper/database/create_table.sql
+++ b/backend/stream_sniper/database/create_table.sql
@@ -12,6 +12,7 @@ create table stream_sniper.creator
     nick              varchar(255) not null,
     display_name      varchar(255) not null,
     profile_image_url varchar(255) not null,
+    twitch_id         bigint,
     constraint creator_nick_uindex
         unique (nick)
 );


### PR DESCRIPTION
## Problem
The code reads/writes `creator.twitch_id` (`insert_new_creator_db`, `select_creator_twitch_id_db`), but `create_table.sql` never defined it. Any DB built from the schema file — **including production** — lacked the column, so creating a creator (add-streamer API *or* collector) failed with `column "twitch_id" of relation "creator" does not exist`.

## Fix
Add `twitch_id bigint` to the `creator` table. Production has already been patched with the equivalent `ALTER TABLE ADD COLUMN IF NOT EXISTS`; this aligns the schema source of truth for fresh setups.

Schema-only; no image rebuild needed (containers don't manage schema).

https://claude.ai/code/session_01Xz11FdWuR4kVHWq9MdG56j