### PR TITLE
Implement manual /process trigger (single-VOD, queued)

### DIFF
--- a/backend/stream_sniper/api/tracking_endpoints.py
+++ b/backend/stream_sniper/api/tracking_endpoints.py
@@ -13,9 +13,12 @@ from ..database.creator_table_gateway import insert_new_creator_db, select_creat
 from ..database.processing_jobs_table_gateway import (
     count_processing_jobs_db,
     get_processing_stats_db,
+    insert_processing_job_db,
+    job_exists_db,
     select_processing_job_by_id_db,
     select_processing_jobs_db,
 )
+from ..database.stream_table_gateway import select_stream_by_twitch_id_db
 from ..database.tracked_streamers_table_gateway import (
     count_tracked_streamers_db,
     delete_tracked_streamer_db,
@@ -598,13 +601,20 @@ def get_processing_jobs(
     }
 )
 @limiter.limit("5/minute")
-def trigger_processing(
+async def trigger_processing(
     streamer_id: int,
     request: Request,
     response: Response,
     current_user: UserInDB = Depends(get_current_admin_user)
 ):
-    """Manually trigger processing for a streamer (admin only)"""
+    """
+    Queue the streamer's newest not-yet-collected VOD for processing (admin only).
+
+    Finds the most recent archived VOD that isn't already in the database and
+    enqueues a processing job for it. The tracking service's processing queue
+    picks the job up and runs the collector (bounded to that single VOD).
+    Trigger repeatedly to walk back through older un-collected VODs.
+    """
     try:
         # Check if streamer exists
         streamer_tuple = select_tracked_streamer_by_id_db(streamer_id)
@@ -613,13 +623,57 @@ def trigger_processing(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Tracked streamer not found"
             )
-        
-        # TODO: Implement manual processing trigger
-        # This would involve getting the latest stream and creating a processing job
-        
-        logger.info(f"Manual processing triggered by admin {current_user.username}: streamer_id={streamer_id}")
-        return {"message": "Processing triggered successfully"}
-        
+
+        twitch_username = streamer_tuple[2]
+
+        # List archived VODs from Twitch (newest first).
+        try:
+            twitch_api = TwitchAPI()
+            await twitch_api.twitch_api_init()
+            twitch_api.set_streamer_nickname(twitch_username)
+            videos = await twitch_api.get_available_video_ids_async()
+        except Exception as e:
+            logger.error(f"Failed to list VODs for {twitch_username}: {e}")
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to list VODs from Twitch"
+            )
+
+        # Pick the newest VOD not already collected into the stream table.
+        target = next(
+            (v for v in videos if not select_stream_by_twitch_id_db(int(v.id))),
+            None
+        )
+        if target is None:
+            return {"message": "No un-collected VODs available for this streamer", "queued": False}
+
+        twitch_stream_id = int(target.id)
+        if job_exists_db(streamer_id, twitch_stream_id):
+            return {
+                "message": "A job for this VOD is already queued",
+                "queued": False,
+                "twitch_stream_id": twitch_stream_id,
+            }
+
+        job_id = insert_processing_job_db(streamer_id, twitch_stream_id)
+        if not job_id:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to create processing job"
+            )
+
+        logger.info(
+            f"Manual processing queued by admin {current_user.username}: "
+            f"streamer_id={streamer_id}, job_id={job_id}, vod={twitch_stream_id}"
+        )
+        return {
+            "message": "Processing queued",
+            "queued": True,
+            "job_id": job_id,
+            "twitch_stream_id": twitch_stream_id,
+            "vod_title": target.title,
+        }
+
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/stream_sniper/collector/twitch_collector_facade.py
+++ b/backend/stream_sniper/collector/twitch_collector_facade.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Optional
 
 from ..database.chatter_table_gateway import insert_new_chatters_db, select_all_chatters_db
 from ..database.creator_table_gateway import insert_new_creator_db, select_creator_id_db
@@ -42,11 +43,14 @@ class TwitchCollectorFacade:
         self.logger.info(f"Twitch collector initialized successfully for: {nickname}")
 
     @performance_timer("complete_stream_processing", slow_threshold=10.0)
-    def start_processing(self):
+    def start_processing(self, max_streams: Optional[int] = None):
         self.logger.info("Starting data collection process")
         processed_streams = 0
 
         while True:
+            if max_streams is not None and processed_streams >= max_streams:
+                self.logger.info(f"Reached max_streams={max_streams}; stopping data collection")
+                break
             try:
                 chat, twitch_stream_id, started_at, title, duration, thumbnail_url = (
                     self.chat_downloader.download_chat()

--- a/backend/stream_sniper/tracking/processing_queue.py
+++ b/backend/stream_sniper/tracking/processing_queue.py
@@ -134,11 +134,13 @@ class ProcessingQueue:
             # Create stream processor
             processor = StreamProcessor()
             
-            # Process the stream
+            # Process the stream. Bound each queued job to a single VOD so one
+            # job ingests one stream rather than the streamer's entire backlog.
             success = await processor.process_stream(
                 twitch_username=twitch_username,
                 twitch_stream_id=twitch_stream_id,
-                job_id=job_id
+                job_id=job_id,
+                max_streams=1
             )
             
             if success:

--- a/backend/stream_sniper/tracking/stream_processor.py
+++ b/backend/stream_sniper/tracking/stream_processor.py
@@ -24,33 +24,37 @@ class StreamProcessor:
         self,
         twitch_username: str,
         twitch_stream_id: int,
-        job_id: Optional[int] = None
+        job_id: Optional[int] = None,
+        max_streams: Optional[int] = None
     ) -> bool:
         """
         Process a stream's chat data.
-        
+
         Args:
             twitch_username: Twitch username of the streamer
             twitch_stream_id: Twitch stream ID to process
             job_id: Optional job ID for tracking
-            
+            max_streams: Optional cap on how many VODs the collector processes in
+                this run (None = all un-collected VODs). Queued jobs pass 1 so a
+                single job ingests one VOD rather than the whole backlog.
+
         Returns:
             True if processing was successful, False otherwise
         """
         try:
             self.logger.info(f"Starting stream processing for {twitch_username}, stream {twitch_stream_id}")
-            
+
             # Create collector facade
             collector = TwitchCollectorFacade(twitch_username)
-            
+
             # Run processing in a separate thread to avoid blocking
             # Since TwitchCollectorFacade is not async, we need to run it in an executor
             loop = asyncio.get_running_loop()
-            
+
             def run_collector():
                 try:
                     # Process the stream
-                    collector.start_processing()
+                    collector.start_processing(max_streams=max_streams)
                     return True
                 except Exception as e:
                     self.logger.error(f"Error in collector processing: {e}")


### PR DESCRIPTION
## Problem
`POST /admin/tracking/streamers/{id}/process` was a stub (`# TODO`) — returned success but did nothing. There was no way to collect chat data on demand; collection only happened when the monitor caught a live→offline transition.

## What this does
- **`trigger_processing` is now async and real**: lists the streamer's archived VODs from Twitch (newest first), picks the newest one **not already in the `stream` table**, and enqueues a pending processing job (deduped via `job_exists_db`). The tracking service's `ProcessingQueue` (polls every 10s) picks it up and runs the collector — so the **api enqueues, the tracking container collects**, and the request never blocks on a multi-hour download. Trigger repeatedly to walk back through older un-collected VODs.
- **Bounded to one VOD per job**: `TwitchCollectorFacade.start_processing` gains `max_streams`, threaded through `StreamProcessor.process_stream`; `ProcessingQueue` passes `max_streams=1`. Stops a single job from ingesting a streamer's whole backlog (xQc ≈ 57 × 9–10h VODs). CLI full-backfill unchanged (default `None`). Also guards the automatic monitor path from a giant first-run.

## Verification
- Ruff clean; 63 non-DB unit tests pass (DB-gateway tests need external Postgres, unreachable locally).
- `trigger_processing` confirmed to be a coroutine; `start_processing(self, max_streams: int | None = None)`.
- Async VOD listing verified against live Twitch earlier in this work.

Response shape: `{queued, job_id, twitch_stream_id, vod_title}` (or `queued:false` with a reason when nothing new / already queued).

https://claude.ai/code/session_01Xz11FdWuR4kVHWq9MdG56j