### PR TITLE
Construct TwitchCollectorFacade inside the executor thread

### DIFF
--- a/backend/stream_sniper/tracking/stream_processor.py
+++ b/backend/stream_sniper/tracking/stream_processor.py
@@ -44,16 +44,17 @@ class StreamProcessor:
         try:
             self.logger.info(f"Starting stream processing for {twitch_username}, stream {twitch_stream_id}")
 
-            # Create collector facade
-            collector = TwitchCollectorFacade(twitch_username)
-
-            # Run processing in a separate thread to avoid blocking
-            # Since TwitchCollectorFacade is not async, we need to run it in an executor
+            # Run processing in a separate thread to avoid blocking. The
+            # TwitchCollectorFacade is fully synchronous and calls asyncio.run()
+            # in its constructor, so it must be BOTH constructed and run inside
+            # the executor thread (which has no running loop). Building it here
+            # in the async context raises "asyncio.run() cannot be called from a
+            # running event loop".
             loop = asyncio.get_running_loop()
 
             def run_collector():
                 try:
-                    # Process the stream
+                    collector = TwitchCollectorFacade(twitch_username)
                     collector.start_processing(max_streams=max_streams)
                     return True
                 except Exception as e:


### PR DESCRIPTION
## Problem
Every queued processing job failed immediately with `asyncio.run() cannot be called from a running event loop`. `StreamProcessor.process_stream` constructed `TwitchCollectorFacade` in the async context (tracking service's running loop), and the facade's `__init__` calls `asyncio.run(twitch_api_init())`. Only `start_processing()` ran in the executor thread — construction didn't.

## Fix
Move facade construction **inside** `run_collector()` so both build and run happen in the executor thread (no running loop there). The facade is fully synchronous by design (the CLI path).

## Verification
Confirmed the sync collector Twitch path (`asyncio.run` init + sync `get_async_result` getters) works in a worker thread against live Twitch (Jynxzi, 57 VODs). Ruff clean.

Follow-up to #24; surfaced when job 1 fired on prod.

https://claude.ai/code/session_01Xz11FdWuR4kVHWq9MdG56j