### PR TITLE
Fix Twitch VOD chat download (PersistedQueryNotFound + thread retry)

### DIFF
--- a/backend/stream_sniper/collector/irc_chat_downloader.py
+++ b/backend/stream_sniper/collector/irc_chat_downloader.py
@@ -4,6 +4,7 @@ from chat_downloader import ChatDownloader
 
 from ..database.stream_table_gateway import select_stream_by_twitch_id_db
 from ..logging_config import get_logger
+from . import twitch_gql_patch  # noqa: F401  (import applies the VideoMetadata GQL patch)
 from .twitch_api import TwitchAPI
 
 
@@ -41,6 +42,11 @@ class IrcChatDownloader:
                     format="json",
                     message_receive_timeout=0.01,
                     buffer_size=16384,
+                    # The collector runs in a worker thread inside a container:
+                    # chat_downloader's default interactive retry prompt uses
+                    # signal-based timed stdin, which raises PermissionError off
+                    # the main thread. Fall back to plain back-off retries.
+                    interruptible_retry=False,
                 )
                 chat_iterated = [x for x in chat]
 

--- a/backend/stream_sniper/collector/twitch_gql_patch.py
+++ b/backend/stream_sniper/collector/twitch_gql_patch.py
@@ -1,0 +1,55 @@
+"""
+Runtime patch for chat_downloader's Twitch VOD chat download.
+
+chat_downloader 0.2.8 (unmaintained) fetches Twitch data via Automatic
+Persisted Queries, sending only a hardcoded ``sha256Hash`` per GraphQL
+operation. Twitch has since de-registered the ``VideoMetadata`` hash, so the
+first request of every VOD download now fails with ``PersistedQueryNotFound``
+(surfacing downstream as ``KeyError: 'data'``) and no chat is ever collected.
+
+Every other operation the VOD path uses (``VideoCommentsByOffsetOrCursor``,
+``ChatList_Badges``) still resolves, so we patch only ``VideoMetadata`` to send
+the full GraphQL query text instead of a persisted-query hash. Sending the query
+body is hash-independent and won't break again when Twitch rotates hashes.
+
+Importing this module applies the patch once (idempotent).
+"""
+
+from chat_downloader.sites.twitch import TwitchChatDownloader
+
+# chat_downloader only reads title, lengthSeconds and owner.login from the
+# VideoMetadata response (see TwitchChatDownloader.get_chat_by_vod_id).
+_VIDEO_METADATA_QUERY = (
+    "query VideoMetadata($videoID: ID!) { "
+    "video(id: $videoID) { title lengthSeconds owner { id login displayName } } }"
+)
+
+_PATCH_FLAG = "_stream_sniper_gql_patched"
+
+
+def _patched_download_gql(self, ops):
+    for op in ops:
+        if op.get("operationName") == "VideoMetadata":
+            # Full query instead of the de-registered persisted-query hash.
+            op["variables"] = {"videoID": op["variables"].get("videoID")}
+            op["query"] = _VIDEO_METADATA_QUERY
+            op.pop("extensions", None)
+        else:
+            op["extensions"] = {
+                "persistedQuery": {
+                    "version": 1,
+                    "sha256Hash": self._OPERATION_HASHES[op["operationName"]],
+                }
+            }
+    return self._download_base_gql(ops)
+
+
+def apply_patch():
+    """Idempotently replace TwitchChatDownloader._download_gql with the patched version."""
+    if getattr(TwitchChatDownloader, _PATCH_FLAG, False):
+        return
+    TwitchChatDownloader._download_gql = _patched_download_gql
+    setattr(TwitchChatDownloader, _PATCH_FLAG, True)
+
+
+apply_patch()


### PR DESCRIPTION
## Problem
VOD chat collection produced **zero messages** — two bugs:

1. **`PersistedQueryNotFound`**: `chat-downloader 0.2.8` (unmaintained) uses hardcoded persisted-query hashes. Twitch de-registered the **`VideoMetadata`** hash, so every VOD download fails on its first request (surfacing as `KeyError: 'data'`). The comments query (`VideoCommentsByOffsetOrCursor`) and `ChatList_Badges` still work.
2. **`PermissionError` in worker thread**: on any error, chat_downloader's default retry prompts via signal-based timed stdin, which fails off the main thread (the collector runs in an executor thread in a container).

## Fix
- `collector/twitch_gql_patch.py`: runtime monkeypatch sending the **full `VideoMetadata` GraphQL query** instead of a persisted hash — hash-independent, so it survives future Twitch rotations. Only `VideoMetadata` is rerouted; other ops keep the persisted path.
- Pass `interruptible_retry=False` to `get_chat` → plain back-off retries.

## Verification
End-to-end against a **live Twitch VOD**: title/duration resolve and real chat messages download (`OOOO`, `agahi`, …). Ruff clean. Surfaced when job 1 ran on prod.

https://claude.ai/code/session_01Xz11FdWuR4kVHWq9MdG56j