### PR TITLE
Fix collector downloading the wrong streamer's VODs (TwitchAPI singleton race)

### DIFF
--- a/backend/stream_sniper/collector/irc_chat_downloader.py
+++ b/backend/stream_sniper/collector/irc_chat_downloader.py
@@ -9,10 +9,15 @@ from .twitch_api import TwitchAPI
 
 
 class IrcChatDownloader:
-    def __init__(self, nickname: str):
+    def __init__(self, nickname: str, twitch_api: TwitchAPI):
         self.nickname = nickname
         self.logger = get_logger(__name__)
-        self.available_video_ids = TwitchAPI.instance().get_available_video_ids()
+        # Use the caller's TwitchAPI instance, NOT TwitchAPI.instance(). The
+        # singleton is the first instance ever created; in the tracking service
+        # that's the stream monitor's, whose streamer_nickname it rewrites on
+        # every poll — so instance().get_available_video_ids() would return a
+        # different streamer's VODs than the one this collector is processing.
+        self.available_video_ids = twitch_api.get_available_video_ids()
         self.downloader = ChatDownloader()
         self.logger.info(
             f"IRC chat downloader initialized for {nickname} with {len(self.available_video_ids)} available videos"

--- a/backend/stream_sniper/collector/twitch_collector_facade.py
+++ b/backend/stream_sniper/collector/twitch_collector_facade.py
@@ -38,7 +38,7 @@ class TwitchCollectorFacade:
         self.db_buffer_insert_message = DatabaseBuffer(insert_message_db, 5000)
         self.message_handler = MessageHandler(nickname, self.db_buffer_insert_message.add_item)
         self.chat_processor = ChatProcessor(self.creator_id, self.message_handler.handle_message)
-        self.chat_downloader = IrcChatDownloader(nickname)
+        self.chat_downloader = IrcChatDownloader(nickname, self.twitch_api)
 
         self.logger.info(f"Twitch collector initialized successfully for: {nickname}")
 


### PR DESCRIPTION
## Problem
`IrcChatDownloader` fetched its VOD list via `TwitchAPI.instance()` — the global singleton (first `TwitchAPI` ever created). In the tracking service that's the **stream monitor's** instance, and the monitor rewrites `streamer_nickname` on every poll. So a collector job for streamer A got whatever streamer the monitor last checked: **a job for jynxzi downloaded xQc's VOD** (observed live — 40 VODs = xQc's count, owner login `xqc`), which would attribute the wrong streamer's chat to the job's `creator_id`.

The standalone CLI is unaffected (there the collector's own `TwitchAPI` *is* the first one created, so singleton == facade instance).

## Fix
Inject the facade's `TwitchAPI` into `IrcChatDownloader` instead of using the singleton — the collector always uses its own correctly-set nickname, no shared state raced against the monitor.

## Verification
Signature/call confirmed; ruff clean. Caught this on prod: a jynxzi job began downloading an xQc VOD; halted before any DB writes (no corruption).

https://claude.ai/code/session_01Xz11FdWuR4kVHWq9MdG56j