### PR TITLE
Widen message_text.text to unbounded text

### DIFF
--- a/backend/stream_sniper/database/create_table.sql
+++ b/backend/stream_sniper/database/create_table.sql
@@ -36,7 +36,7 @@ create table stream_sniper.stream
 create table stream_sniper.message_text
 (
     id   serial primary key,
-    text varchar(255) not null,
+    text text not null,
     constraint text_uq
         unique (text)
 );


### PR DESCRIPTION
## Problem
`message_text.text` was `varchar(255)`, but Twitch messages go up to 500 chars. `insert_message_texts_db` batches a whole VOD's unique messages into one `execute_values`, so one over-length message raised `StringDataRightTruncation` and aborted the entire stream — **zero messages stored**.

## Fix
Change the column to `text` (unbounded). The `text_uq` unique btree index stays within limits for real (≤500-char) Twitch messages, and `text` gives far more headroom than a tight varchar cap that would re-break on one long line.

Prod already patched via `ALTER COLUMN ... TYPE text`; this aligns the schema source of truth. Schema-only, no rebuild.

https://claude.ai/code/session_01Xz11FdWuR4kVHWq9MdG56j