### PR TITLE
Night-ops visual redesign of the entire frontend

### DIFF
--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -2,9 +2,12 @@ import Link from 'next/link'
 
 export default function NotFound() {
   return (
-    <div className="container mt-5 text-center">
-      <h1 className="display-4">404</h1>
-      <p className="text-muted">This page could not be found.</p>
+    <div className="empty-state" style={{ minHeight: '100vh' }}>
+      <div className="empty-scope" aria-hidden="true" />
+      <h1 className="page-title mb-2">404 — Target not found</h1>
+      <p className="empty-hint mb-4">
+        The page you were tracking has gone dark. It may have been moved or never existed.
+      </p>
       <Link href="/" className="btn btn-primary">Back to streams</Link>
     </div>
   )

--- a/frontend/components/ChatterSmallInfo.jsx
+++ b/frontend/components/ChatterSmallInfo.jsx
@@ -1,52 +1,30 @@
 'use client'
-import React, {
-    useMemo,
-} from 'react'
-import {
-    OverlayTrigger,
-    Tooltip,
-} from 'react-bootstrap'
+import React from 'react'
 
+/** One row in a ranked chatter leaderboard. */
 const ChatterSmallInfo = ({
-    id,
+    rank,
     nick,
     count,
     noun,
-}) => {
-    // Memoize the chatter ID to prevent string concatenation on every render
-    const chatterId = useMemo(() => `chatter-${id}`, [
-        id,
-    ])
-
-    // Memoize the tooltip content
-    const tooltipContent = useMemo(() => `${noun}: ${count}`, [
-        noun,
-        count,
-    ])
-
-    return (
-        <OverlayTrigger
-            placement="left"
-            overlay={
-                <Tooltip
-                    id={chatterId}
-                    role="tooltip"
-                >
-                    {tooltipContent}
-                </Tooltip>
-            }
-        >
-            <li
-                tabIndex="0"
-                role="listitem"
-                aria-describedby={chatterId}
-                aria-label={`${nick}, ${tooltipContent}`}
-                style={{ cursor: 'pointer' }}
-            >
-                {nick}
-            </li>
-        </OverlayTrigger>
-    )
-}
+}) => (
+    <li
+        tabIndex="0"
+        role="listitem"
+        aria-label={`Rank ${rank}: ${nick}, ${count} ${noun}`}
+    >
+        <span
+            className="rank"
+            aria-hidden="true">
+            {String(rank).padStart(2, '0')}
+        </span>
+        <span className="nick">{nick}</span>
+        <span
+            className="count"
+            aria-hidden="true">
+            {count?.toLocaleString()}
+        </span>
+    </li>
+)
 
 export default React.memo(ChatterSmallInfo)

--- a/frontend/components/ErrorAlert.jsx
+++ b/frontend/components/ErrorAlert.jsx
@@ -13,23 +13,23 @@ import ErrorActions from './ErrorActions'
 import ErrorDetails from './ErrorDetails'
 
 /**
- * Helper function to get error icon based on error type
+ * Helper function to get error icon class based on error type
  */
 const getErrorIcon = type => {
     switch (type) {
         case 'network':
-            return '🌐'
+            return 'bi bi-wifi-off'
         case 'authentication':
         case 'authorization':
-            return '🔐'
+            return 'bi bi-shield-lock'
         case 'not_found':
-            return '🔍'
+            return 'bi bi-search'
         case 'server':
-            return '🚫'
+            return 'bi bi-x-octagon'
         case 'validation':
-            return '⚠️'
+            return 'bi bi-exclamation-triangle'
         default:
-            return '❌'
+            return 'bi bi-x-circle'
     }
 }
 
@@ -101,13 +101,11 @@ const ErrorAlert = ({
             {...props}
         >
             <div className="d-flex align-items-start">
-                <span
-                    className="me-2 fs-4"
+                <i
+                    className={`${getErrorIcon(errorInfo.type)} me-3 fs-4`}
                     role="img"
                     aria-label={`${errorInfo.type} error`}
-                >
-                    {getErrorIcon(errorInfo.type)}
-                </span>
+                ></i>
                 <div className="flex-grow-1">
                     <ErrorHeader
                         title={title}

--- a/frontend/components/Loader.jsx
+++ b/frontend/components/Loader.jsx
@@ -1,14 +1,41 @@
 'use client'
 
-import { Spinner } from 'react-bootstrap'
-
+/** Full-screen crosshair loader — "acquiring target". */
 const Loader = () => (
-    <div className="fallback-spinner">
-        <div className="loading">
-            <Spinner
-                animation="border"
-                variant="primary"
-            />
+    <div
+        className="fallback-spinner"
+        role="status"
+        aria-label="Loading"
+    >
+        <div className="scope-loader">
+            <svg
+                viewBox="0 0 64 64"
+                aria-hidden="true"
+            >
+                <circle
+                    className="scope-ring"
+                    cx="32"
+                    cy="32"
+                    r="22"
+                />
+                <circle
+                    className="scope-sweep"
+                    cx="32"
+                    cy="32"
+                    r="22"
+                />
+                <path
+                    className="scope-cross"
+                    d="M32 2v12M32 50v12M2 32h12M50 32h12"
+                />
+                <circle
+                    className="scope-dot"
+                    cx="32"
+                    cy="32"
+                    r="3"
+                />
+            </svg>
+            <span className="scope-text">Acquiring target…</span>
         </div>
     </div>
 )

--- a/frontend/components/LoadingSpinner.jsx
+++ b/frontend/components/LoadingSpinner.jsx
@@ -63,8 +63,12 @@ const SpinnerContent = ({
  */
 const OverlaySpinner = ({ children }) => (
     <div
-        className="position-absolute top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center bg-white bg-opacity-75"
-        style={{ zIndex: 1000 }}
+        className="position-absolute top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center"
+        style={{
+            zIndex: 1000,
+            background: 'rgba(11, 14, 19, 0.75)',
+            backdropFilter: 'blur(2px)',
+        }}
     >
         {children}
     </div>

--- a/frontend/components/StreamThumbnail.jsx
+++ b/frontend/components/StreamThumbnail.jsx
@@ -8,6 +8,7 @@ import {
 } from 'react-bootstrap'
 import { useRouter } from 'next/navigation'
 import { findThumbnailSrc } from '@/utils/utils'
+import ThumbImage from '@/components/streams/ThumbImage'
 import { THUMBNAIL } from '@/constants'
 import {
     formatTimeAgo, formatDurationBetween,
@@ -65,7 +66,7 @@ const StreamThumbnail = ({
     const isLive = !end
 
     return (
-        <Card className="mx-2 stream-card">
+        <Card className="stream-card">
             <div
                 onClick={handleNavigation}
                 onKeyDown={handleKeyDown}
@@ -74,7 +75,7 @@ const StreamThumbnail = ({
                 aria-label={`View details for ${name}'s stream with ${messageCount} messages`}
             >
                 <div className="thumb-wrap">
-                    <img
+                    <ThumbImage
                         src={thumbnailUrl}
                         alt={`Stream thumbnail for ${name}`}
                     />

--- a/frontend/components/TwitchChatLookalike.jsx
+++ b/frontend/components/TwitchChatLookalike.jsx
@@ -3,32 +3,40 @@ import React, {
     useMemo,
     useCallback,
 } from 'react'
+import { Virtuoso } from 'react-virtuoso'
 import { EMOTES } from '@/lib/bettertv_emotes'
+
+/* Twitch-style username palette (dark-theme readable). */
+const NICK_COLORS = [
+    '#ff7a7a',
+    '#f5b759',
+    '#9fef00',
+    '#2dd4a7',
+    '#58a6ff',
+    '#c58fff',
+    '#ff8fd0',
+    '#5edfff',
+    '#ffb86b',
+    '#a3e635',
+]
+
+/** Deterministic color per nick so it stays stable across renders. */
+const nickColor = nick => {
+    let hash = 0
+    for (let i = 0; i < nick.length; i++) {
+        hash = (hash * 31 + nick.charCodeAt(i)) | 0
+    }
+    return NICK_COLORS[Math.abs(hash) % NICK_COLORS.length]
+}
 
 const TwitchChatLookalike = ({
     nick,
     messages,
 }) => {
-    const generateRandomColor = () => {
-
-        while(true){
-            let randomHue = Math.random() * 360
-            if ((randomHue >= 45 && randomHue <= 90) || (randomHue >= 140 && randomHue <= 195)){
-                continue
-            }
-
-            const randomColor = `hsla(${randomHue}, 100%, 50%, 1)`
-            return randomColor
-        }
-    }
-
     /**
      * Applies BetterTV emotes to the message with memoization.
      * @param {string} message
      * @returns {JSX.Element}
-     * @example
-     * // returns <img src="https://cdn.betterttv.net/emote/5e1a9a9f6b77c70ebf4b3b7f/1x" alt="LUL" />
-     * applyBetterTvEmotes('LUL')
      */
     const applyBetterTvEmotes = useCallback(message => {
         if (!message) {
@@ -55,54 +63,67 @@ const TwitchChatLookalike = ({
     }, [
     ])
 
-    // Memoize the random color to prevent regeneration on every render
-    const randomColor = useMemo(() => generateRandomColor(), [
+    const color = useMemo(() => nickColor(nick || ''), [
+        nick,
     ])
 
-    // Memoize the processed messages to avoid re-processing on every render
-    const processedMessages = useMemo(() => {
-        if (!messages || messages.length === 0) {
-            return null
-        }
-
-        return messages.map((message, index) => (
-            <div
-                key={index}
-                className='my-2'
-                role="listitem"
-                aria-label={`Message ${index + 1} from ${nick}: ${message}`}
+    // Virtualized row renderer — only visible messages hit the DOM
+    const renderLine = useCallback((index, message) => (
+        <p
+            className="chat-line"
+            role="listitem"
+        >
+            <span
+                className="chat-nick"
+                style={{ color }}
             >
-                <span
-                    style={{ color: randomColor }}
-                    aria-label={`Message from ${nick}`}
-                >
-                    {nick}
-                </span>
-                <span aria-hidden="true">: </span>
-                <span role="text">
-                    {applyBetterTvEmotes(message)}
-                </span>
-            </div>
-        ))
-    }, [
-        messages,
-        randomColor,
+                {nick}
+            </span>
+            <span aria-hidden="true">: </span>
+            <span>
+                {applyBetterTvEmotes(message)}
+            </span>
+        </p>
+    ), [
+        color,
         nick,
         applyBetterTvEmotes,
     ])
 
+    const hasMessages = messages && messages.length > 0
+    // Keep short replays compact instead of forcing a tall empty panel
+    const panelHeight = useMemo(() => Math.min(480, Math.max(120, (messages?.length || 0) * 32)), [
+        messages?.length,
+    ])
+
     return (
         <div
-            className="my-3"
+            className="chat-panel"
             role="log"
             aria-live="polite"
             aria-label={`Chat messages from ${nick}`}
             tabIndex="0"
         >
             <div
+                className="chat-panel-head"
+                aria-hidden="true">
+                <i className="bi bi-chat-left-text"></i>
+                <span>Chat replay // {nick}</span>
+                <span className="chat-count">{(messages?.length || 0).toLocaleString()} msgs</span>
+            </div>
+            <div
+                className="chat-panel-body"
                 role="list"
                 aria-label={`${messages?.length || 0} messages from ${nick}`}>
-                {processedMessages}
+                {hasMessages ? (
+                    <Virtuoso
+                        data={messages}
+                        itemContent={renderLine}
+                        style={{ height: `${panelHeight}px` }}
+                    />
+                ) : (
+                    <p className="text-muted small mb-0 py-2">No messages recorded for this chatter.</p>
+                )}
             </div>
         </div>
     )

--- a/frontend/components/admin/ComponentsHealth.jsx
+++ b/frontend/components/admin/ComponentsHealth.jsx
@@ -12,11 +12,11 @@ const ComponentsHealth = ({
     <Row className="mb-4">
         <Col>
             <Card>
-                <Card.Header>
-                    <h5 className="mb-0">Components Health</h5>
-                </Card.Header>
                 <Card.Body>
-                    <Table responsive>
+                    <h3 className="section-label mb-3">Components</h3>
+                    <Table
+                        hover
+                        responsive>
                         <thead>
                             <tr>
                                 <th>Component</th>
@@ -33,12 +33,12 @@ const ComponentsHealth = ({
                                 <tr key={component}>
                                     <td className="text-capitalize">{component}</td>
                                     <td>{getStatusBadge(data.status)}</td>
-                                    <td>
+                                    <td className="mono">
                                         {data.response_time_ms ? `${data.response_time_ms.toFixed(2)}ms` : 'N/A'}
                                     </td>
                                     <td>
                                         {data.details && (
-                                            <small className="text-muted">
+                                            <small className="text-muted mono">
                                                 {typeof data.details === 'object'
                                                     ? JSON.stringify(data.details, null, 2)
                                                     : data.details}

--- a/frontend/components/admin/EditUserForm.jsx
+++ b/frontend/components/admin/EditUserForm.jsx
@@ -64,7 +64,7 @@ const EditUserForm = ({
             </Form.Group>
             <div className="d-flex justify-content-end">
                 <Button
-                    variant="secondary"
+                    variant="outline-primary"
                     onClick={onCancel}
                     className="me-2">
                     Cancel

--- a/frontend/components/admin/ProcessingJobsStatistics.jsx
+++ b/frontend/components/admin/ProcessingJobsStatistics.jsx
@@ -1,67 +1,39 @@
 'use client'
-import {
-    Row, Col, Card,
-} from 'react-bootstrap'
+import { Card } from 'react-bootstrap'
 
 /**
  * Processing Jobs Statistics Component
  */
 const ProcessingJobsStatistics = ({ stats }) => (
     <Card>
-        <Card.Header>
-            <Card.Title>Processing Jobs Statistics</Card.Title>
-        </Card.Header>
         <Card.Body>
-            <Row>
-                <Col md={2}>
-                    <Card className="text-center bg-light">
-                        <Card.Body>
-                            <Card.Title className="text-primary">Total</Card.Title>
-                            <Card.Text className="display-6">{stats.processing_jobs.total}</Card.Text>
-                        </Card.Body>
-                    </Card>
-                </Col>
-                <Col md={2}>
-                    <Card className="text-center bg-light">
-                        <Card.Body>
-                            <Card.Title className="text-secondary">Pending</Card.Title>
-                            <Card.Text className="display-6">{stats.processing_jobs.pending || 0}</Card.Text>
-                        </Card.Body>
-                    </Card>
-                </Col>
-                <Col md={2}>
-                    <Card className="text-center bg-light">
-                        <Card.Body>
-                            <Card.Title className="text-primary">In Progress</Card.Title>
-                            <Card.Text className="display-6">{stats.processing_jobs.in_progress || 0}</Card.Text>
-                        </Card.Body>
-                    </Card>
-                </Col>
-                <Col md={2}>
-                    <Card className="text-center bg-light">
-                        <Card.Body>
-                            <Card.Title className="text-success">Completed</Card.Title>
-                            <Card.Text className="display-6">{stats.processing_jobs.completed || 0}</Card.Text>
-                        </Card.Body>
-                    </Card>
-                </Col>
-                <Col md={2}>
-                    <Card className="text-center bg-light">
-                        <Card.Body>
-                            <Card.Title className="text-danger">Failed</Card.Title>
-                            <Card.Text className="display-6">{stats.processing_jobs.failed || 0}</Card.Text>
-                        </Card.Body>
-                    </Card>
-                </Col>
-                <Col md={2}>
-                    <Card className="text-center bg-light">
-                        <Card.Body>
-                            <Card.Title className="text-info">Recent 24h</Card.Title>
-                            <Card.Text className="display-6">{stats.processing_jobs.recent_24h || 0}</Card.Text>
-                        </Card.Body>
-                    </Card>
-                </Col>
-            </Row>
+            <h3 className="section-label mb-3">Processing jobs</h3>
+            <div className="stat-grid">
+                <div className="stat-tile">
+                    <div className="stat-label">Total</div>
+                    <div className="stat-value text-phosphor">{stats.processing_jobs.total}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">Pending</div>
+                    <div className="stat-value">{stats.processing_jobs.pending || 0}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">In progress</div>
+                    <div className="stat-value">{stats.processing_jobs.in_progress || 0}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">Completed</div>
+                    <div className="stat-value">{stats.processing_jobs.completed || 0}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">Failed</div>
+                    <div className="stat-value">{stats.processing_jobs.failed || 0}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">Recent 24h</div>
+                    <div className="stat-value">{stats.processing_jobs.recent_24h || 0}</div>
+                </div>
+            </div>
         </Card.Body>
     </Card>
 )

--- a/frontend/components/admin/ProcessingOverviewCard.jsx
+++ b/frontend/components/admin/ProcessingOverviewCard.jsx
@@ -1,6 +1,6 @@
 'use client'
 import {
-    Card, Badge, ProgressBar,
+    Card, ProgressBar,
 } from 'react-bootstrap'
 
 /**
@@ -12,13 +12,13 @@ const ProcessingOverviewCard = ({
     const successRate = calculateSuccessRate(stats.processing_jobs.completed, stats.processing_jobs.total)
 
     return (
-        <Card>
+        <Card className="h-100">
             <Card.Body>
-                <h5>Processing Overview</h5>
+                <h3 className="section-label mb-3">Processing overview</h3>
                 <div className="mb-3">
-                    <div className="d-flex justify-content-between">
+                    <div className="d-flex justify-content-between align-items-center">
                         <span>Success Rate</span>
-                        <Badge bg="success">{successRate}%</Badge>
+                        <span className="mono">{successRate}%</span>
                     </div>
                     <ProgressBar
                         now={successRate}
@@ -27,9 +27,9 @@ const ProcessingOverviewCard = ({
                     />
                 </div>
                 <div className="mb-3">
-                    <div className="d-flex justify-content-between">
+                    <div className="d-flex justify-content-between align-items-center">
                         <span>Recent Activity</span>
-                        <Badge bg="info">{stats.processing_jobs.recent_24h} jobs (24h)</Badge>
+                        <span className="mono">{stats.processing_jobs.recent_24h} jobs (24h)</span>
                     </div>
                 </div>
             </Card.Body>

--- a/frontend/components/admin/RateLimitingMetrics.jsx
+++ b/frontend/components/admin/RateLimitingMetrics.jsx
@@ -1,6 +1,6 @@
 'use client'
 import {
-    Row, Col, Card, Table,
+    Row, Col, Card,
 } from 'react-bootstrap'
 
 /**
@@ -10,28 +10,18 @@ const RateLimitingMetrics = ({ metricsData }) => (
     <Row className="mb-4">
         <Col>
             <Card>
-                <Card.Header>
-                    <h5 className="mb-0">Rate Limiting</h5>
-                </Card.Header>
                 <Card.Body>
-                    <Table responsive>
-                        <tbody>
-                            <tr>
-                                <td>Total Requests</td>
-                                <td>{metricsData.rate_limiting.total_requests}</td>
-                            </tr>
-                            <tr>
-                                <td>Rate Limited</td>
-                                <td>{metricsData.rate_limiting.rate_limited_requests}</td>
-                            </tr>
-                            <tr>
-                                <td>Rate Limit Percentage</td>
-                                <td>
-                                    {(metricsData.rate_limiting.rate_limit_percentage * 100).toFixed(2)}%
-                                </td>
-                            </tr>
-                        </tbody>
-                    </Table>
+                    <h3 className="section-label mb-3">Rate limiting</h3>
+                    <dl className="spec-list">
+                        <dt>Total requests</dt>
+                        <dd className="mono">{metricsData.rate_limiting.total_requests}</dd>
+                        <dt>Rate limited</dt>
+                        <dd className="mono">{metricsData.rate_limiting.rate_limited_requests}</dd>
+                        <dt>Rate limit percentage</dt>
+                        <dd className="mono">
+                            {(metricsData.rate_limiting.rate_limit_percentage * 100).toFixed(2)}%
+                        </dd>
+                    </dl>
                 </Card.Body>
             </Card>
         </Col>

--- a/frontend/components/admin/RedisCacheDetails.jsx
+++ b/frontend/components/admin/RedisCacheDetails.jsx
@@ -1,6 +1,6 @@
 'use client'
 import {
-    Row, Col, Card, Table,
+    Row, Col, Card,
 } from 'react-bootstrap'
 
 /**
@@ -12,34 +12,22 @@ const RedisCacheDetails = ({
     <Row className="mb-4">
         <Col>
             <Card>
-                <Card.Header>
-                    <h5 className="mb-0">Redis Cache Details</h5>
-                </Card.Header>
                 <Card.Body>
-                    <Table responsive>
-                        <tbody>
-                            <tr>
-                                <td>Connected Clients</td>
-                                <td>{cacheStats.redis_stats.connected_clients}</td>
-                            </tr>
-                            <tr>
-                                <td>Used Memory</td>
-                                <td>{cacheStats.redis_stats.used_memory_human}</td>
-                            </tr>
-                            <tr>
-                                <td>Total Keys</td>
-                                <td>{cacheStats.redis_stats.total_keys}</td>
-                            </tr>
-                            <tr>
-                                <td>Hit Ratio</td>
-                                <td>{(cacheStats.redis_stats.keyspace_hit_ratio * 100).toFixed(2)}%</td>
-                            </tr>
-                            <tr>
-                                <td>Uptime</td>
-                                <td>{formatUptime(cacheStats.redis_stats.uptime_in_seconds)}</td>
-                            </tr>
-                        </tbody>
-                    </Table>
+                    <h3 className="section-label mb-3">Redis cache</h3>
+                    <dl className="spec-list">
+                        <dt>Connected clients</dt>
+                        <dd className="mono">{cacheStats.redis_stats.connected_clients}</dd>
+                        <dt>Used memory</dt>
+                        <dd className="mono">{cacheStats.redis_stats.used_memory_human}</dd>
+                        <dt>Total keys</dt>
+                        <dd className="mono">{cacheStats.redis_stats.total_keys}</dd>
+                        <dt>Hit ratio</dt>
+                        <dd className="mono">
+                            {(cacheStats.redis_stats.keyspace_hit_ratio * 100).toFixed(2)}%
+                        </dd>
+                        <dt>Uptime</dt>
+                        <dd className="mono">{formatUptime(cacheStats.redis_stats.uptime_in_seconds)}</dd>
+                    </dl>
                 </Card.Body>
             </Card>
         </Col>

--- a/frontend/components/admin/RequestStatistics.jsx
+++ b/frontend/components/admin/RequestStatistics.jsx
@@ -1,6 +1,6 @@
 'use client'
 import {
-    Row, Col, Card, Table, Button, ProgressBar,
+    Row, Col, Card, Button,
 } from 'react-bootstrap'
 
 /**
@@ -11,76 +11,65 @@ const RequestStatistics = ({
 }) => (
     <Row className="mb-4">
         <Col md={6}>
-            <Card>
-                <Card.Header>
-                    <h5 className="mb-0">Request Statistics</h5>
-                </Card.Header>
+            <Card className="h-100">
                 <Card.Body>
-                    <Table responsive>
-                        <tbody>
-                            <tr>
-                                <td>Total Requests</td>
-                                <td>{metricsData.requests.total_requests}</td>
-                            </tr>
-                            <tr>
-                                <td>Successful Requests</td>
-                                <td>{metricsData.requests.successful_requests}</td>
-                            </tr>
-                            <tr>
-                                <td>Failed Requests</td>
-                                <td>{metricsData.requests.failed_requests}</td>
-                            </tr>
-                            <tr>
-                                <td>Average Response Time</td>
-                                <td>{metricsData.requests.average_response_time_ms?.toFixed(2)}ms</td>
-                            </tr>
-                        </tbody>
-                    </Table>
+                    <h3 className="section-label mb-3">Request statistics</h3>
+                    <div className="stat-grid">
+                        <div className="stat-tile">
+                            <div className="stat-label">Total requests</div>
+                            <div className="stat-value mono">{metricsData.requests.total_requests}</div>
+                        </div>
+                        <div className="stat-tile">
+                            <div className="stat-label">Successful</div>
+                            <div className="stat-value mono">{metricsData.requests.successful_requests}</div>
+                        </div>
+                        <div className="stat-tile">
+                            <div className="stat-label">Failed</div>
+                            <div className="stat-value mono">{metricsData.requests.failed_requests}</div>
+                        </div>
+                        <div className="stat-tile">
+                            <div className="stat-label">Avg response</div>
+                            <div className="stat-value mono">
+                                {metricsData.requests.average_response_time_ms?.toFixed(2)}ms
+                            </div>
+                        </div>
+                    </div>
                 </Card.Body>
             </Card>
         </Col>
         <Col md={6}>
-            <Card>
-                <Card.Header>
-                    <h5 className="mb-0">Cache Performance</h5>
-                </Card.Header>
+            <Card className="h-100">
                 <Card.Body>
+                    <h3 className="section-label mb-3">Cache performance</h3>
                     {metricsData.cache && (
-                        <Table responsive>
-                            <tbody>
-                                <tr>
-                                    <td>Hit Rate</td>
-                                    <td>
-                                        {(metricsData.cache.hit_rate * 100).toFixed(1)}%
-                                        <ProgressBar
-                                            now={metricsData.cache.hit_rate * 100}
-                                            variant="success"
-                                            className="mt-1"
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>Total Hits</td>
-                                    <td>{metricsData.cache.total_hits}</td>
-                                </tr>
-                                <tr>
-                                    <td>Total Misses</td>
-                                    <td>{metricsData.cache.total_misses}</td>
-                                </tr>
-                                <tr>
-                                    <td>Cache Operations</td>
-                                    <td>{metricsData.cache.total_operations}</td>
-                                </tr>
-                            </tbody>
-                        </Table>
+                        <div className="stat-grid">
+                            <div className="stat-tile">
+                                <div className="stat-label">Hit rate</div>
+                                <div className="stat-value text-phosphor mono">
+                                    {(metricsData.cache.hit_rate * 100).toFixed(1)}%
+                                </div>
+                            </div>
+                            <div className="stat-tile">
+                                <div className="stat-label">Total hits</div>
+                                <div className="stat-value mono">{metricsData.cache.total_hits}</div>
+                            </div>
+                            <div className="stat-tile">
+                                <div className="stat-label">Total misses</div>
+                                <div className="stat-value mono">{metricsData.cache.total_misses}</div>
+                            </div>
+                            <div className="stat-tile">
+                                <div className="stat-label">Operations</div>
+                                <div className="stat-value mono">{metricsData.cache.total_operations}</div>
+                            </div>
+                        </div>
                     )}
                     <div className="mt-3">
                         <Button
-                            variant="outline-warning"
+                            variant="outline-danger"
                             size="sm"
                             onClick={flushCache}
                         >
-                            <i className="bi bi-arrow-clockwise me-1"></i>
+                            <i className="bi bi-trash3 me-1"></i>
                             Flush Cache
                         </Button>
                     </div>

--- a/frontend/components/admin/SystemHealthOverview.jsx
+++ b/frontend/components/admin/SystemHealthOverview.jsx
@@ -1,57 +1,41 @@
 'use client'
-import {
-    Row, Col, Card,
-} from 'react-bootstrap'
 
 /**
- * System Health Overview Cards
+ * System Health Overview Stat Tiles
  */
 const SystemHealthOverview = ({
     healthData, formatUptime, getStatusBadge,
 }) => (
-    <Row className="mb-4">
-        <Col md={3}>
-            <Card className="text-center">
-                <Card.Body>
-                    <Card.Title>System Status</Card.Title>
-                    {getStatusBadge(healthData.status)}
-                    <div className="mt-2">
-                        <small className="text-muted">
-                            Last updated: {new Date(healthData.timestamp).toLocaleString()}
-                        </small>
-                    </div>
-                </Card.Body>
-            </Card>
-        </Col>
-        <Col md={3}>
-            <Card className="text-center">
-                <Card.Body>
-                    <Card.Title>Uptime</Card.Title>
-                    <Card.Text className="h4">
-                        {formatUptime(healthData.uptime_seconds)}
-                    </Card.Text>
-                </Card.Body>
-            </Card>
-        </Col>
-        <Col md={3}>
-            <Card className="text-center">
-                <Card.Body>
-                    <Card.Title>Version</Card.Title>
-                    <Card.Text className="h4">{healthData.version}</Card.Text>
-                </Card.Body>
-            </Card>
-        </Col>
-        <Col md={3}>
-            <Card className="text-center">
-                <Card.Body>
-                    <Card.Title>Memory Usage</Card.Title>
-                    <Card.Text className="h4">
-                        {healthData.system?.memory_usage_percent?.toFixed(1)}%
-                    </Card.Text>
-                </Card.Body>
-            </Card>
-        </Col>
-    </Row>
+    <div className="stat-grid mb-4">
+        <div className="stat-tile">
+            <div className="stat-label">System status</div>
+            <div className="stat-value">
+                {getStatusBadge(healthData.status)}
+            </div>
+            <div className="stat-hint mono">
+                Updated {new Date(healthData.timestamp).toLocaleString()}
+            </div>
+        </div>
+        <div className="stat-tile">
+            <div className="stat-label">Uptime</div>
+            <div className="stat-value text-phosphor mono">
+                {formatUptime(healthData.uptime_seconds)}
+            </div>
+            <div className="stat-hint">since last restart</div>
+        </div>
+        <div className="stat-tile">
+            <div className="stat-label">Version</div>
+            <div className="stat-value mono">{healthData.version}</div>
+            <div className="stat-hint">API build</div>
+        </div>
+        <div className="stat-tile">
+            <div className="stat-label">Memory usage</div>
+            <div className="stat-value mono">
+                {healthData.system?.memory_usage_percent?.toFixed(1)}%
+            </div>
+            <div className="stat-hint">of system memory</div>
+        </div>
+    </div>
 )
 
 export default SystemHealthOverview

--- a/frontend/components/admin/SystemStatusCard.jsx
+++ b/frontend/components/admin/SystemStatusCard.jsx
@@ -1,7 +1,5 @@
 'use client'
-import {
-    Card, Badge,
-} from 'react-bootstrap'
+import { Card } from 'react-bootstrap'
 
 /**
  * System Status Card Component
@@ -9,29 +7,29 @@ import {
 const SystemStatusCard = ({
     stats, getStatusBadge,
 }) => (
-    <Card>
+    <Card className="h-100">
         <Card.Body>
-            <h5>System Status</h5>
+            <h3 className="section-label mb-3">System status</h3>
             <div className="mb-3">
-                <div className="d-flex justify-content-between">
+                <div className="d-flex justify-content-between align-items-center">
                     <span>Stream Monitoring</span>
                     {getStatusBadge(stats.system_status.monitoring_active)}
                 </div>
             </div>
             <div className="mb-3">
-                <div className="d-flex justify-content-between">
+                <div className="d-flex justify-content-between align-items-center">
                     <span>Processing Queue</span>
-                    <Badge bg={stats.system_status.processing_queue_size > 0 ? 'warning' : 'success'}>
+                    <span className={`status-chip ${stats.system_status.processing_queue_size > 0 ? 'is-warn' : 'is-ok'}`}>
                         {stats.system_status.processing_queue_size} pending
-                    </Badge>
+                    </span>
                 </div>
             </div>
             <div className="mb-3">
-                <div className="d-flex justify-content-between">
+                <div className="d-flex justify-content-between align-items-center">
                     <span>Failed Jobs</span>
-                    <Badge bg={stats.system_status.failed_jobs > 0 ? 'danger' : 'success'}>
+                    <span className={`status-chip ${stats.system_status.failed_jobs > 0 ? 'is-err' : 'is-ok'}`}>
                         {stats.system_status.failed_jobs}
-                    </Badge>
+                    </span>
                 </div>
             </div>
         </Card.Body>

--- a/frontend/components/admin/TrackedStreamersCard.jsx
+++ b/frontend/components/admin/TrackedStreamersCard.jsx
@@ -1,37 +1,35 @@
 'use client'
-import {
-    Card, Badge,
-} from 'react-bootstrap'
+import { Card } from 'react-bootstrap'
 
 /**
  * Tracked Streamers Card Component
  */
 const TrackedStreamersCard = ({ stats }) => (
-    <Card>
+    <Card className="h-100">
         <Card.Body>
-            <h5>Tracked Streamers</h5>
+            <h3 className="section-label mb-3">Tracked streamers</h3>
             <div className="mb-3">
-                <div className="d-flex justify-content-between">
+                <div className="d-flex justify-content-between align-items-center">
                     <span>Total Streamers</span>
-                    <Badge bg="primary">{stats.tracked_streamers.total}</Badge>
+                    <span className="mono">{stats.tracked_streamers.total}</span>
                 </div>
             </div>
             <div className="mb-3">
-                <div className="d-flex justify-content-between">
+                <div className="d-flex justify-content-between align-items-center">
                     <span>Active</span>
-                    <Badge bg="success">{stats.tracked_streamers.active}</Badge>
+                    <span className="status-chip is-ok">{stats.tracked_streamers.active}</span>
                 </div>
             </div>
             <div className="mb-3">
-                <div className="d-flex justify-content-between">
+                <div className="d-flex justify-content-between align-items-center">
                     <span>Processing Enabled</span>
-                    <Badge bg="info">{stats.tracked_streamers.processing_enabled}</Badge>
+                    <span className="mono">{stats.tracked_streamers.processing_enabled}</span>
                 </div>
             </div>
             <div className="mb-3">
-                <div className="d-flex justify-content-between">
+                <div className="d-flex justify-content-between align-items-center">
                     <span>Inactive</span>
-                    <Badge bg="secondary">{stats.tracked_streamers.inactive}</Badge>
+                    <span className="status-chip">{stats.tracked_streamers.inactive}</span>
                 </div>
             </div>
         </Card.Body>

--- a/frontend/components/admin/TrackingDashboardActions.jsx
+++ b/frontend/components/admin/TrackingDashboardActions.jsx
@@ -2,6 +2,7 @@
 import {
     Row, Col, Card,
 } from 'react-bootstrap'
+import Link from 'next/link'
 
 /**
  * Tracking Dashboard Actions and System Health Component
@@ -11,30 +12,34 @@ const TrackingDashboardActions = ({
 }) => (
     <Row>
         <Col md={6}>
-            <Card>
-                <Card.Header>
-                    <Card.Title>Quick Actions</Card.Title>
-                </Card.Header>
+            <Card className="mb-4">
                 <Card.Body>
+                    <h3 className="section-label mb-3">Quick actions</h3>
                     <div className="d-grid gap-2">
-                        <a
+                        <Link
                             href="/admin/tracking/streamers"
                             className="btn btn-primary">
-                            <i className="bi bi-people me-2"></i>
+                            <i
+                                className="bi bi-people me-2"
+                                aria-hidden="true" />
                             Manage Tracked Streamers
-                        </a>
-                        <a
+                        </Link>
+                        <Link
                             href="/admin/tracking/jobs"
-                            className="btn btn-info">
-                            <i className="bi bi-list-check me-2"></i>
+                            className="btn btn-outline-primary">
+                            <i
+                                className="bi bi-list-check me-2"
+                                aria-hidden="true" />
                             View Processing Jobs
-                        </a>
+                        </Link>
                         <button
-                            className="btn btn-success"
+                            className="btn btn-outline-primary"
                             onClick={fetchStats}
                             disabled={loading}
                         >
-                            <i className="bi bi-arrow-clockwise me-2"></i>
+                            <i
+                                className="bi bi-arrow-clockwise me-2"
+                                aria-hidden="true" />
                             Refresh Statistics
                         </button>
                     </div>
@@ -42,13 +47,11 @@ const TrackingDashboardActions = ({
             </Card>
         </Col>
         <Col md={6}>
-            <Card>
-                <Card.Header>
-                    <Card.Title>System Health</Card.Title>
-                </Card.Header>
+            <Card className="mb-4">
                 <Card.Body>
+                    <h3 className="section-label mb-3">System health</h3>
                     <div className="mb-3">
-                        <div className="d-flex justify-content-between">
+                        <div className="d-flex justify-content-between align-items-center">
                             <span>Overall System</span>
                             {getHealthBadge(
                                 stats.system_status.monitoring_active &&
@@ -57,19 +60,19 @@ const TrackingDashboardActions = ({
                         </div>
                     </div>
                     <div className="mb-3">
-                        <div className="d-flex justify-content-between">
+                        <div className="d-flex justify-content-between align-items-center">
                             <span>Stream Monitoring</span>
                             {getHealthBadge(stats.system_status.monitoring_active)}
                         </div>
                     </div>
                     <div className="mb-3">
-                        <div className="d-flex justify-content-between">
+                        <div className="d-flex justify-content-between align-items-center">
                             <span>Processing Queue</span>
                             {getHealthBadge(stats.system_status.processing_queue_size < 100)}
                         </div>
                     </div>
                     <div className="mb-3">
-                        <div className="d-flex justify-content-between">
+                        <div className="d-flex justify-content-between align-items-center">
                             <span>Error Rate</span>
                             {getHealthBadge(stats.system_status.failed_jobs < 10)}
                         </div>

--- a/frontend/components/admin/UserManagementModals.jsx
+++ b/frontend/components/admin/UserManagementModals.jsx
@@ -44,14 +44,17 @@ const UserManagementModals = ({
             </Modal.Body>
             <Modal.Footer>
                 <Button
-                    variant="secondary"
+                    variant="outline-primary"
                     onClick={() => setShowDeleteModal(false)}>
                     Cancel
                 </Button>
                 <Button
-                    variant="danger"
+                    variant="outline-danger"
                     onClick={handleUserDelete}>
-                    Delete User
+                    <i
+                        className="bi bi-trash me-2"
+                        aria-hidden="true" />
+                    Delete user
                 </Button>
             </Modal.Footer>
         </Modal>

--- a/frontend/components/admin/UserManagementTable.jsx
+++ b/frontend/components/admin/UserManagementTable.jsx
@@ -1,6 +1,6 @@
 'use client'
 import {
-    Table, Badge, ButtonGroup, Button, Dropdown,
+    Table, ButtonGroup, Button, Dropdown,
 } from 'react-bootstrap'
 
 const UserManagementTable = ({
@@ -10,84 +10,108 @@ const UserManagementTable = ({
     handleUserAction,
     handleDeleteUser,
     handleRoleChange,
-}) => (
-    <Table
-        responsive
-        hover>
-        <thead>
-            <tr>
-                <th>ID</th>
-                <th>Username</th>
-                <th>Email</th>
-                <th>Role</th>
-                <th>Status</th>
-                <th>Created</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-            {users.map(userItem => (
-                <tr key={userItem.id}>
-                    <td>{userItem.id}</td>
-                    <td>{userItem.username}</td>
-                    <td>{userItem.email}</td>
-                    <td>
-                        <Dropdown>
-                            <Dropdown.Toggle
-                                variant={userItem.role === 'admin' ? 'warning' : 'secondary'}
-                                size="sm"
-                            >
-                                {userItem.role}
-                            </Dropdown.Toggle>
-                            <Dropdown.Menu>
-                                <Dropdown.Item
-                                    onClick={() => handleRoleChange(userItem.id, 'user')}
-                                    disabled={userItem.role === 'user'}
-                                >
-                                    User
-                                </Dropdown.Item>
-                                <Dropdown.Item
-                                    onClick={() => handleRoleChange(userItem.id, 'admin')}
-                                    disabled={userItem.role === 'admin'}
-                                >
-                                    Admin
-                                </Dropdown.Item>
-                            </Dropdown.Menu>
-                        </Dropdown>
-                    </td>
-                    <td>
-                        <Badge bg={userItem.is_active ? 'success' : 'secondary'}>
-                            {userItem.is_active ? 'Active' : 'Inactive'}
-                        </Badge>
-                    </td>
-                    <td>{new Date(userItem.created_at).toLocaleDateString()}</td>
-                    <td>
-                        <ButtonGroup size="sm">
-                            <Button
-                                variant="outline-primary"
-                                onClick={() => handleEditUser(userItem)}
-                            >
-                                <i className="bi bi-pencil"></i>
-                            </Button>
-                            <Button
-                                variant={userItem.is_active ? 'outline-warning' : 'outline-success'}
-                                onClick={() => handleUserAction(userItem.id, userItem.is_active ? 'deactivate' : 'activate')}
-                            >
-                                <i className={`bi bi-${userItem.is_active ? 'pause' : 'play'}`}></i>
-                            </Button>
-                            <Button
-                                variant="outline-danger"
-                                onClick={() => handleDeleteUser(userItem)}
-                                disabled={authenticatedUser.id === userItem.id} // Prevent admin from deleting themselves
-                            >
-                                <i className="bi bi-trash"></i>
-                            </Button>
-                        </ButtonGroup>
-                    </td>
+}) => {
+    if (users.length === 0) {
+        return (
+            <div className="empty-state">
+                <div
+                    className="empty-scope"
+                    aria-hidden="true" />
+                <p className="empty-title">No users</p>
+                <p className="empty-hint">No accounts match the current page — create one to get started.</p>
+            </div>
+        )
+    }
+
+    return (
+        <Table
+            responsive
+            hover>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Username</th>
+                    <th>Email</th>
+                    <th>Role</th>
+                    <th>Status</th>
+                    <th>Created</th>
+                    <th>Actions</th>
                 </tr>
-            ))}
-        </tbody>
-    </Table>
-)
+            </thead>
+            <tbody>
+                {users.map(userItem => (
+                    <tr key={userItem.id}>
+                        <td className="mono">{userItem.id}</td>
+                        <td>{userItem.username}</td>
+                        <td>{userItem.email}</td>
+                        <td>
+                            <Dropdown>
+                                <Dropdown.Toggle
+                                    variant="outline-primary"
+                                    size="sm"
+                                    aria-label={`Change role for ${userItem.username}`}
+                                >
+                                    {userItem.role}
+                                </Dropdown.Toggle>
+                                <Dropdown.Menu>
+                                    <Dropdown.Item
+                                        onClick={() => handleRoleChange(userItem.id, 'user')}
+                                        disabled={userItem.role === 'user'}
+                                    >
+                                        User
+                                    </Dropdown.Item>
+                                    <Dropdown.Item
+                                        onClick={() => handleRoleChange(userItem.id, 'admin')}
+                                        disabled={userItem.role === 'admin'}
+                                    >
+                                        Admin
+                                    </Dropdown.Item>
+                                </Dropdown.Menu>
+                            </Dropdown>
+                        </td>
+                        <td>
+                            <span className={userItem.is_active ? 'status-chip is-ok' : 'status-chip is-err'}>
+                                {userItem.is_active ? 'Active' : 'Inactive'}
+                            </span>
+                        </td>
+                        <td className="mono">{new Date(userItem.created_at).toLocaleDateString()}</td>
+                        <td>
+                            <ButtonGroup size="sm">
+                                <Button
+                                    variant="outline-primary"
+                                    onClick={() => handleEditUser(userItem)}
+                                    aria-label={`Edit ${userItem.username}`}
+                                >
+                                    <i
+                                        className="bi bi-pencil"
+                                        aria-hidden="true" />
+                                </Button>
+                                <Button
+                                    variant="outline-primary"
+                                    onClick={() => handleUserAction(userItem.id, userItem.is_active ? 'deactivate' : 'activate')}
+                                    aria-label={`${userItem.is_active ? 'Deactivate' : 'Activate'} ${userItem.username}`}
+                                >
+                                    <i
+                                        className={`bi bi-${userItem.is_active ? 'pause' : 'play'}`}
+                                        aria-hidden="true" />
+                                </Button>
+                                <Button
+                                    variant="outline-danger"
+                                    onClick={() => handleDeleteUser(userItem)}
+                                    disabled={authenticatedUser.id === userItem.id} // Prevent admin from deleting themselves
+                                    aria-label={`Delete ${userItem.username}`}
+                                >
+                                    <i
+                                        className="bi bi-trash"
+                                        aria-hidden="true" />
+                                </Button>
+                            </ButtonGroup>
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </Table>
+    )
+}
 
 export default UserManagementTable

--- a/frontend/components/auth/LoginForm.jsx
+++ b/frontend/components/auth/LoginForm.jsx
@@ -93,9 +93,9 @@ const LoginForm = ({
     const displayError = localError || error
 
     return (
-        <Card className="shadow-sm">
+        <Card className="auth-card">
             <Card.Header>
-                <h4 className="mb-0">Login</h4>
+                <h1 className="auth-mode">Sign in</h1>
             </Card.Header>
             <Card.Body>
                 {displayError && (

--- a/frontend/components/auth/PasswordChangeModal.jsx
+++ b/frontend/components/auth/PasswordChangeModal.jsx
@@ -147,7 +147,7 @@ const PasswordChangeModal = ({
                 </Modal.Body>
                 <Modal.Footer>
                     <Button
-                        variant="secondary"
+                        variant="outline-primary"
                         onClick={handleClose}
                         disabled={isSubmitting || loading}
                     >

--- a/frontend/components/auth/ProfileInfo.jsx
+++ b/frontend/components/auth/ProfileInfo.jsx
@@ -1,7 +1,7 @@
 'use client'
 
 import {
-    Form, Row, Col, Badge,
+    Form, Row, Col,
 } from 'react-bootstrap'
 
 /**
@@ -19,7 +19,6 @@ const ProfileInfo = ({
                         type="text"
                         value={user?.username || ''}
                         disabled
-                        className="bg-light"
                     />
                     <small className="text-muted">Username cannot be changed</small>
                 </Form.Group>
@@ -28,12 +27,9 @@ const ProfileInfo = ({
                 <Form.Group className="mb-3">
                     <Form.Label>Role</Form.Label>
                     <div>
-                        <Badge
-                            variant={user?.role === 'admin' ? 'danger' : 'primary'}
-                            className="fs-6"
-                        >
+                        <span className={user?.role === 'admin' ? 'status-chip is-warn' : 'status-chip is-ok'}>
                             {user?.role || 'user'}
-                        </Badge>
+                        </span>
                     </div>
                 </Form.Group>
             </Col>
@@ -53,21 +49,26 @@ const ProfileInfo = ({
             />
         </Form.Group>
 
-        <Form.Group className="mb-3">
-            <Form.Label>Account Status</Form.Label>
-            <div>
-                <Badge variant={user?.is_active ? 'success' : 'warning'}>
-                    {user?.is_active ? 'Active' : 'Inactive'}
-                </Badge>
-            </div>
-        </Form.Group>
-
-        <Form.Group className="mb-3">
-            <Form.Label>Member Since</Form.Label>
-            <div className="text-muted">
-                {user?.created_at ? new Date(user.created_at).toLocaleDateString() : 'N/A'}
-            </div>
-        </Form.Group>
+        <Row>
+            <Col md={6}>
+                <Form.Group className="mb-3">
+                    <Form.Label>Account Status</Form.Label>
+                    <div>
+                        <span className={user?.is_active ? 'status-chip is-ok' : 'status-chip is-err'}>
+                            {user?.is_active ? 'Active' : 'Inactive'}
+                        </span>
+                    </div>
+                </Form.Group>
+            </Col>
+            <Col md={6}>
+                <Form.Group className="mb-3">
+                    <Form.Label>Member Since</Form.Label>
+                    <div className="mono text-muted small pt-1">
+                        {user?.created_at ? new Date(user.created_at).toLocaleDateString() : 'N/A'}
+                    </div>
+                </Form.Group>
+            </Col>
+        </Row>
     </>
 )
 

--- a/frontend/components/auth/RegisterForm.jsx
+++ b/frontend/components/auth/RegisterForm.jsx
@@ -170,9 +170,9 @@ const RegisterForm = ({
     const displayError = localError || error
 
     return (
-        <Card className="shadow-sm">
+        <Card className="auth-card">
             <Card.Header>
-                <h4 className="mb-0">Register</h4>
+                <h1 className="auth-mode">Create account</h1>
             </Card.Header>
             <Card.Body>
                 {displayError && (

--- a/frontend/components/layout/FullLayout.jsx
+++ b/frontend/components/layout/FullLayout.jsx
@@ -6,6 +6,11 @@ import {
     Container,
 } from 'react-bootstrap'
 
+/** Closes the mobile sidebar when the dimmed backdrop is tapped. */
+const closeMobileSidebar = () => {
+    document.getElementById('sidebarArea')?.classList.remove('showSidebar')
+}
+
 const FullLayout = ({ children }) => (
     <>
         {/* Skip link for keyboard navigation */}
@@ -19,11 +24,17 @@ const FullLayout = ({ children }) => (
         <div className="pageWrapper d-lg-flex">
             {/********Sidebar**********/}
             <aside
-                className="sidebarArea shadow"
+                className="sidebarArea"
                 id="sidebarArea"
                 aria-label="Main navigation sidebar">
                 <Sidebar />
             </aside>
+            {/* mobile-only dimmed backdrop; visible while the sidebar is open */}
+            <div
+                className="sidebar-backdrop d-lg-none"
+                onClick={closeMobileSidebar}
+                aria-hidden="true"
+            />
             {/********Content Area**********/}
 
             <div className="contentArea">
@@ -35,7 +46,7 @@ const FullLayout = ({ children }) => (
                     aria-label="Main content area"
                 >
                     <Container
-                        className="p-4 wrapper"
+                        className="p-3 p-md-4 wrapper"
                         fluid>
                         {children}
                     </Container>

--- a/frontend/components/layout/Header.jsx
+++ b/frontend/components/layout/Header.jsx
@@ -4,12 +4,11 @@ import {
     useState,
 } from 'react'
 import {
-    useRouter,
+    useRouter, usePathname,
 } from 'next/navigation'
 import {
     Dropdown,
     Button,
-    Badge,
 } from 'react-bootstrap'
 import { useAuth } from '@/contexts/AuthContext'
 
@@ -24,7 +23,7 @@ const AdminMenuItems = ({ navigate }) => (
             tabIndex="0"
             onClick={() => navigate('/admin/dashboard')}
         >
-            <i className="bi bi-shield-check me-2"></i>
+            <i className="bi bi-speedometer2 me-2"></i>
             Admin Dashboard
         </Dropdown.Item>
         <Dropdown.Item
@@ -32,7 +31,7 @@ const AdminMenuItems = ({ navigate }) => (
             tabIndex="0"
             onClick={() => navigate('/admin/users')}
         >
-            <i className="bi bi-people me-2"></i>
+            <i className="bi bi-person-gear me-2"></i>
             User Management
         </Dropdown.Item>
         <Dropdown.Item
@@ -40,7 +39,7 @@ const AdminMenuItems = ({ navigate }) => (
             tabIndex="0"
             onClick={() => navigate('/admin/system')}
         >
-            <i className="bi bi-gear me-2"></i>
+            <i className="bi bi-cpu me-2"></i>
             System Information
         </Dropdown.Item>
     </>
@@ -54,30 +53,28 @@ const UserDropdown = ({
 }) => (
     <Dropdown
         show={dropdownOpen}
-        onToggle={toggle}>
+        onToggle={toggle}
+        align="end">
         <Dropdown.Toggle
-            variant="light"
+            variant="dark"
             size="sm"
             aria-label="User menu"
             aria-expanded={dropdownOpen}
             aria-haspopup="true"
-            className="d-flex align-items-center"
+            className="user-chip"
         >
-            <img
-                src="/images/user1.jpg"
-                alt="User profile picture"
-                className="rounded-circle me-2"
-                width="30"
-            />
+            <span
+                className="avatar-orb"
+                aria-hidden="true">
+                {user?.username?.charAt(0) || '?'}
+            </span>
             <span className="d-none d-md-inline">
                 {user?.username}
             </span>
             {user?.role === 'admin' && (
-                <Badge
-                    bg="warning"
-                    className="ms-2">
+                <span className="role-chip d-none d-md-inline">
                     Admin
-                </Badge>
+                </span>
             )}
         </Dropdown.Toggle>
         <Dropdown.Menu
@@ -115,7 +112,8 @@ const MobileSidebarToggle = ({
     showMobilemenu, handleKeyDown,
 }) => (
     <Button
-        variant="primary"
+        variant="outline-primary"
+        size="sm"
         className="d-lg-none"
         onClick={() => showMobilemenu()}
         onKeyDown={e => handleKeyDown(e, showMobilemenu)}
@@ -128,6 +126,31 @@ const MobileSidebarToggle = ({
     </Button>
 )
 
+/** Mono breadcrumb-style readout of the current route. */
+const HeaderPath = ({ pathname }) => {
+    const segments = pathname === '/'
+        ? [
+            'streams',
+        ]
+        : pathname.split('/').filter(Boolean)
+
+    return (
+        <span
+            className="header-path d-none d-sm-inline"
+            aria-hidden="true">
+            ~
+            {segments.map((segment, index) => (
+                <span key={index}>
+                    <span className="path-sep">/</span>
+                    <span className={index === segments.length - 1 ? 'path-current' : ''}>
+                        {segment}
+                    </span>
+                </span>
+            ))}
+        </span>
+    )
+}
+
 const Header = () => {
     const [
         dropdownOpen,
@@ -137,6 +160,7 @@ const Header = () => {
         isAuthenticated, user, logout,
     } = useAuth()
     const router = useRouter()
+    const pathname = usePathname()
 
     const toggle = () => setDropdownOpen(prevState => !prevState)
     const showMobilemenu = () => {
@@ -165,11 +189,12 @@ const Header = () => {
             role="navigation"
             aria-label="Main header navigation"
         >
-            <div className="d-flex align-items-center gap-2">
+            <div className="d-flex align-items-center gap-3">
                 <MobileSidebarToggle
                     showMobilemenu={showMobilemenu}
                     handleKeyDown={handleKeyDown}
                 />
+                <HeaderPath pathname={pathname} />
             </div>
 
             <div className="d-flex align-items-center gap-2">

--- a/frontend/components/layout/Sidebar.jsx
+++ b/frontend/components/layout/Sidebar.jsx
@@ -12,12 +12,12 @@ const navigation = [
     {
         title: 'All streams',
         href: '/',
-        icon: 'bi bi-person',
+        icon: 'bi bi-collection-play',
     },
     {
-        title: 'Get chatter messages',
+        title: 'Chatter messages',
         href: '/chatter-messages',
-        icon: 'bi bi-person',
+        icon: 'bi bi-chat-left-text',
     },
     {
         title: 'Streamer regulars',
@@ -27,27 +27,66 @@ const navigation = [
     {
         title: 'Chatter footprint',
         href: '/chatter-footprint',
-        icon: 'bi bi-graph-up',
+        icon: 'bi bi-fingerprint',
     },
 ]
 
 const adminNavigation = [
     {
-        title: 'Admin Dashboard',
+        title: 'Dashboard',
         href: '/admin/dashboard',
-        icon: 'bi bi-shield-check',
+        icon: 'bi bi-speedometer2',
     },
     {
-        title: 'User Management',
+        title: 'Users',
         href: '/admin/users',
-        icon: 'bi bi-people',
+        icon: 'bi bi-person-gear',
     },
     {
-        title: 'System Information',
+        title: 'Tracking',
+        href: '/admin/tracking',
+        icon: 'bi bi-broadcast',
+    },
+    {
+        title: 'System',
         href: '/admin/system',
-        icon: 'bi bi-gear',
+        icon: 'bi bi-cpu',
     },
 ]
+
+/** Active when the path matches exactly, or is nested under a non-root href. */
+const isActivePath = (pathname, href) => {
+    if (href === '/') {
+        return pathname === '/'
+    }
+    return pathname === href || pathname.startsWith(`${href}/`)
+}
+
+const NavLinks = ({
+    items, pathname, keyPrefix,
+}) => items.map((navi, index) => (
+    <Nav.Item
+        key={`${keyPrefix}${index}`}
+        role="none"
+    >
+        <Link
+            href={navi.href}
+            className={
+                isActivePath(pathname, navi.href)
+                    ? 'nav-link active'
+                    : 'nav-link'
+            }
+            aria-current={isActivePath(pathname, navi.href) ? 'page' : null}
+            aria-label={navi.title}
+        >
+            <i
+                className={navi.icon}
+                aria-hidden="true"
+            ></i>
+            <span className="ms-3 d-inline-block">{navi.title}</span>
+        </Link>
+    </Nav.Item>
+))
 
 const Sidebar = () => {
     const {
@@ -76,7 +115,7 @@ const Sidebar = () => {
     const pathname = usePathname()
 
     return (
-        <div className="p-3">
+        <div className="sidebar-inner p-3 pb-0">
             <div className="d-flex align-items-center">
                 <Logo />
                 <Button
@@ -90,72 +129,44 @@ const Sidebar = () => {
                 />
             </div>
             <nav
-                className="pt-4 mt-2"
+                className="pt-4 mt-2 flex-grow-1 d-flex flex-column"
                 aria-label="Main navigation">
                 <Nav
                     className="flex-column sidebarNav"
                     role="navigation"
                 >
-                    {navigation.map((navi, index) => (
-                        <Nav.Item
-                            key={index}
-                            className="sidenav-bg"
-                            role="none"
-                        >
-                            <Link
-                                href={navi.href}
-                                className={
-                                    pathname === navi.href
-                                        ? 'nav-link active'
-                                        : 'nav-link'
-                                }
-                                aria-current={pathname === navi.href ? 'page' : null}
-                                aria-label={navi.title}
-                            >
-                                <i
-                                    className={navi.icon}
-                                    aria-hidden="true"
-                                ></i>
-                                <span className="ms-3 d-inline-block">{navi.title}</span>
-                            </Link>
-                        </Nav.Item>
-                    ))}
+                    <div className="px-3 pb-1">
+                        <span className="sidebar-section">Intel</span>
+                    </div>
+                    <NavLinks
+                        items={navigation}
+                        pathname={pathname}
+                        keyPrefix=""
+                    />
 
                     {/* Admin Navigation */}
                     {isAuthenticated && isAdmin && (
                         <>
                             <hr className="my-3" />
                             <div className="px-3 pb-1">
-                                <span className="sidebar-section">{'// Administration'}</span>
+                                <span className="sidebar-section">Command</span>
                             </div>
-                            {adminNavigation.map((navi, index) => (
-                                <Nav.Item
-                                    key={`admin-${index}`}
-                                    className="sidenav-bg"
-                                    role="none"
-                                >
-                                    <Link
-                                        href={navi.href}
-                                        className={
-                                            pathname === navi.href
-                                                ? 'text-primary nav-link py-3'
-                                                : 'nav-link text-secondary py-3'
-                                        }
-                                        aria-current={pathname === navi.href ? 'page' : null}
-                                        aria-label={navi.title}
-                                    >
-                                        <i
-                                            className={navi.icon}
-                                            aria-hidden="true"
-                                        ></i>
-                                        <span className="ms-3 d-inline-block">{navi.title}</span>
-                                    </Link>
-                                </Nav.Item>
-                            ))}
+                            <NavLinks
+                                items={adminNavigation}
+                                pathname={pathname}
+                                keyPrefix="admin-"
+                            />
                         </>
                     )}
                 </Nav>
             </nav>
+            <div
+                className="sidebar-status"
+                aria-hidden="true"
+            >
+                <span className="status-dot"></span>
+                <span>Link active</span>
+            </div>
         </div>
     )
 }

--- a/frontend/components/streams/ChatSearchCard.jsx
+++ b/frontend/components/streams/ChatSearchCard.jsx
@@ -1,10 +1,20 @@
 'use client'
+import {
+    useState, useMemo, useCallback,
+} from 'react'
 import Select from 'react-select'
 import {
     Card,
 } from 'react-bootstrap'
 import LoadingSpinner from '../LoadingSpinner'
 import ErrorAlert from '../ErrorAlert'
+
+/**
+ * react-select renders every matching option into the DOM, which freezes the
+ * UI when a stream has thousands of chatters. We pre-filter + cap the visible
+ * options ourselves and disable react-select's own filtering.
+ */
+const MAX_RENDERED_OPTIONS = 100
 
 /**
  * Chat Search Card Component
@@ -16,57 +26,94 @@ const ChatSearchCard = ({
     isMessagesLoading,
     messagesError,
     renderTwitchChat,
-}) => (
-    <Card>
-        <Card.Body>
-            <Card.Title
-                as="h2"
-                id="chat-search-heading">
-                Searching for messages in this stream
-            </Card.Title>
-            <div
-                role="search"
-                aria-labelledby="chat-search-heading">
-                <label
-                    htmlFor="chatter-select"
-                    className="visually-hidden">
-                    Select a chatter to view their messages
-                </label>
-                <Select
-                    instanceId="chatter-select"
-                    inputId="chatter-select"
-                    options={chattersInStream}
-                    value={selectedChatterOption}
-                    onChange={handleChatterSelection}
-                    placeholder="Search for a chatter..."
-                    isClearable
-                    isSearchable
-                    aria-describedby="chatter-select-help"
-                />
+}) => {
+    const [
+        inputValue,
+        setInputValue,
+    ] = useState('')
+
+    const handleInputChange = useCallback(value => {
+        setInputValue(value)
+        return value
+    }, [
+    ])
+
+    const visibleOptions = useMemo(() => {
+        const query = inputValue.trim().toLowerCase()
+        const matches = query
+            ? chattersInStream.filter(option => option.label?.toLowerCase().includes(query))
+            : chattersInStream
+        return matches.slice(0, MAX_RENDERED_OPTIONS)
+    }, [
+        chattersInStream,
+        inputValue,
+    ])
+
+    const noOptionsMessage = useCallback(({ inputValue: query }) => (
+        query
+            ? `No chatters matching "${query}"`
+            : 'No chatters recorded in this stream'
+    ), [
+    ])
+
+    return (
+        <Card>
+            <Card.Body>
+                <h2
+                    className="section-label mb-1"
+                    id="chat-search-heading">
+                    Chat replay
+                </h2>
+                <p className="text-muted small mb-3">
+                    {chattersInStream.length.toLocaleString()} chatters recorded — pick one to replay their messages.
+                </p>
                 <div
-                    id="chatter-select-help"
-                    className="form-text">
-                    Select a chatter to see their messages from this stream
+                    role="search"
+                    aria-labelledby="chat-search-heading">
+                    <label
+                        htmlFor="chatter-select"
+                        className="visually-hidden">
+                        Select a chatter to view their messages
+                    </label>
+                    <Select
+                        instanceId="chatter-select"
+                        inputId="chatter-select"
+                        options={visibleOptions}
+                        value={selectedChatterOption}
+                        onChange={handleChatterSelection}
+                        onInputChange={handleInputChange}
+                        filterOption={() => true}
+                        noOptionsMessage={noOptionsMessage}
+                        placeholder="Search for a chatter..."
+                        isClearable
+                        isSearchable
+                        aria-describedby="chatter-select-help"
+                    />
+                    <div
+                        id="chatter-select-help"
+                        className="form-text">
+                        Type to search; the first {MAX_RENDERED_OPTIONS} matches are shown
+                    </div>
                 </div>
-            </div>
 
-            {isMessagesLoading && (
-                <LoadingSpinner
-                    text="Loading messages..."
-                    className="mt-3" />
-            )}
+                {isMessagesLoading && (
+                    <LoadingSpinner
+                        text="Loading messages..."
+                        className="mt-3" />
+                )}
 
-            {messagesError && (
-                <ErrorAlert
-                    error={messagesError}
-                    title="Failed to load messages"
-                    className="mt-3"
-                />
-            )}
+                {messagesError && (
+                    <ErrorAlert
+                        error={messagesError}
+                        title="Failed to load messages"
+                        className="mt-3"
+                    />
+                )}
 
-            {renderTwitchChat}
-        </Card.Body>
-    </Card>
-)
+                {renderTwitchChat}
+            </Card.Body>
+        </Card>
+    )
+}
 
 export default ChatSearchCard

--- a/frontend/components/streams/FiltersCard.jsx
+++ b/frontend/components/streams/FiltersCard.jsx
@@ -1,18 +1,17 @@
 'use client'
 import React from 'react'
 import Select from 'react-select'
-import {
-    Card, Container, Row, Col,
-} from 'react-bootstrap'
 import { AVAILABLE_ORDERING } from '@/constants'
 
 /**
- * Renders filters component
+ * Slim filter toolbar above the stream grid.
  * @param {Array} creators
  * @param {object} selectedCreator
  * @param {function} onCreatorChange
  * @param {object} selectedOrdering
  * @param {function} onOrderingChange
+ * @param {number} page
+ * @param {number} pagesCount
  * @returns {JSX.Element}
  */
 const FiltersCard = React.memo(({
@@ -21,67 +20,74 @@ const FiltersCard = React.memo(({
     onCreatorChange,
     selectedOrdering,
     onOrderingChange,
+    page,
+    pagesCount,
 }) => (
-    <Card>
-        <Card.Header>
-            <h2 id="filters-heading" className="page-title fs-6 mb-0">Filters</h2>
-        </Card.Header>
-        <Card.Body>
-            <Container>
-                <Row>
-                    <Col>
-                        <label
-                            htmlFor="creator-select"
-                            className="visually-hidden"
-                        >
-                            Filter by creator
-                        </label>
-                        <Select
-                            instanceId="creator-select"
-                            inputId="creator-select"
-                            options={creators}
-                            value={selectedCreator}
-                            onChange={onCreatorChange}
-                            placeholder="Select creator..."
-                            isClearable
-                            aria-label="Filter streams by creator"
-                            aria-describedby="creator-help"
-                        />
-                        <div
-                            id="creator-help"
-                            className="visually-hidden"
-                        >
-                            Choose a specific creator to filter streams, or leave empty to show all streams
-                        </div>
-                    </Col>
-                    <Col>
-                        <label
-                            htmlFor="ordering-select"
-                            className="visually-hidden"
-                        >
-                            Sort streams by
-                        </label>
-                        <Select
-                            instanceId="ordering-select"
-                            inputId="ordering-select"
-                            options={AVAILABLE_ORDERING}
-                            value={selectedOrdering}
-                            onChange={onOrderingChange}
-                            placeholder="Sort by..."
-                            aria-label="Sort streams by different criteria"
-                            aria-describedby="ordering-help"
-                        />
-                        <div
-                            id="ordering-help"
-                            className="visually-hidden"
-                        >
-                            Choose how to sort the streams list
-                        </div>
-                    </Col>
-                </Row>
-            </Container>
-        </Card.Body>
-    </Card>
+    <div
+        className="toolbar"
+        role="search"
+        aria-label="Stream filters"
+    >
+        <span
+            className="toolbar-label"
+            aria-hidden="true">
+            Filter
+        </span>
+        <div className="toolbar-field">
+            <label
+                htmlFor="creator-select"
+                className="visually-hidden"
+            >
+                Filter by creator
+            </label>
+            <Select
+                instanceId="creator-select"
+                inputId="creator-select"
+                options={creators}
+                value={selectedCreator}
+                onChange={onCreatorChange}
+                placeholder="All creators"
+                isClearable
+                aria-label="Filter streams by creator"
+                aria-describedby="creator-help"
+            />
+            <div
+                id="creator-help"
+                className="visually-hidden"
+            >
+                Choose a specific creator to filter streams, or leave empty to show all streams
+            </div>
+        </div>
+        <div className="toolbar-field">
+            <label
+                htmlFor="ordering-select"
+                className="visually-hidden"
+            >
+                Sort streams by
+            </label>
+            <Select
+                instanceId="ordering-select"
+                inputId="ordering-select"
+                options={AVAILABLE_ORDERING}
+                value={selectedOrdering}
+                onChange={onOrderingChange}
+                placeholder="Sort by..."
+                aria-label="Sort streams by different criteria"
+                aria-describedby="ordering-help"
+            />
+            <div
+                id="ordering-help"
+                className="visually-hidden"
+            >
+                Choose how to sort the streams list
+            </div>
+        </div>
+        {pagesCount > 0 && (
+            <span className="toolbar-readout">
+                Page <strong>{page}</strong> / {pagesCount}
+            </span>
+        )}
+    </div>
 ))
 
 FiltersCard.displayName = 'FiltersCard'

--- a/frontend/components/streams/PaginationComponent.jsx
+++ b/frontend/components/streams/PaginationComponent.jsx
@@ -2,6 +2,43 @@
 import React from 'react'
 import { Pagination } from 'react-bootstrap'
 
+/** Max numbered page buttons rendered around the current page. */
+const WINDOW = 2
+
+/**
+ * Builds the list of page indices to render, with `null` marking an ellipsis.
+ * Always includes first, last, and a window around the current page.
+ * @param {number} pagesCount
+ * @param {number} offset current page (0-based)
+ * @returns {Array<number|null>}
+ */
+const buildPageItems = (pagesCount, offset) => {
+    const pages = new Set([
+        0,
+        pagesCount - 1,
+    ])
+    for (let k = offset - WINDOW; k <= offset + WINDOW; k++) {
+        if (k >= 0 && k < pagesCount) {
+            pages.add(k)
+        }
+    }
+
+    const sorted = [
+        ...pages,
+    ].sort((a, b) => a - b)
+    const items = [
+    ]
+    let prev = null
+    for (const k of sorted) {
+        if (prev !== null && k - prev > 1) {
+            items.push(null) // ellipsis
+        }
+        items.push(k)
+        prev = k
+    }
+    return items
+}
+
 /**
  * Renders pagination component
  * @param {number} pagesCount
@@ -12,7 +49,7 @@ import { Pagination } from 'react-bootstrap'
 const PaginationComponent = React.memo(({
     pagesCount, offset, updateOffset,
 }) => {
-    if (pagesCount === 0) {
+    if (pagesCount <= 1) {
         return null
     }
 
@@ -26,15 +63,14 @@ const PaginationComponent = React.memo(({
 
     const isFirstPage = offset === 0
     const isLastPage = offset + 1 === pagesCount
+    const pageItems = buildPageItems(pagesCount, offset)
 
     return (
         <nav
             aria-label="Stream pagination navigation"
-            className="h-100 d-flex align-items-center justify-content-center p-1"
+            className="d-flex align-items-center justify-content-center p-1"
         >
-            <Pagination
-                size="lg"
-            >
+            <Pagination className="mb-0">
                 <Pagination.First
                     onClick={() => updateOffset(0)}
                     onKeyDown={e => handleKeyDown(e, () => updateOffset(0))}
@@ -49,18 +85,23 @@ const PaginationComponent = React.memo(({
                     aria-label="Go to previous page"
                     tabIndex={0}
                 />
-                {Array.from({ length: pagesCount }, (_, k) => (
-                    <Pagination.Item
-                        active={k === offset}
-                        key={k + 1}
-                        onClick={() => updateOffset(k)}
-                        onKeyDown={e => handleKeyDown(e, () => updateOffset(k))}
-                        aria-label={`Go to page ${k + 1}`}
-                        aria-current={k === offset ? 'page' : null}
-                        tabIndex={0}
-                    >
-                        {k + 1}
-                    </Pagination.Item>
+                {pageItems.map((k, index) => (
+                    k === null
+                        ? <Pagination.Ellipsis
+                            key={`ellipsis-${index}`}
+                            disabled
+                        />
+                        : <Pagination.Item
+                            active={k === offset}
+                            key={k}
+                            onClick={() => updateOffset(k)}
+                            onKeyDown={e => handleKeyDown(e, () => updateOffset(k))}
+                            aria-label={`Go to page ${k + 1}`}
+                            aria-current={k === offset ? 'page' : null}
+                            tabIndex={0}
+                        >
+                            {k + 1}
+                        </Pagination.Item>
                 ))}
                 <Pagination.Next
                     disabled={isLastPage}

--- a/frontend/components/streams/StreamGridSkeleton.jsx
+++ b/frontend/components/streams/StreamGridSkeleton.jsx
@@ -1,0 +1,30 @@
+'use client'
+import React from 'react'
+import { Card } from 'react-bootstrap'
+
+/** Shimmering placeholder grid shown while streams load. */
+const StreamGridSkeleton = ({ count = 8 }) => (
+    <div
+        className="stream-grid"
+        role="status"
+        aria-label="Loading streams"
+    >
+        {Array.from({ length: count }, (_, index) => (
+            <Card
+                key={index}
+                className="stream-card"
+                aria-hidden="true"
+            >
+                <div className="skeleton skeleton-thumb" />
+                <Card.Body className="py-3">
+                    <div className="skeleton skeleton-line w-75" />
+                    <div className="skeleton skeleton-line" />
+                    <div className="skeleton skeleton-line w-50 mb-0" />
+                </Card.Body>
+            </Card>
+        ))}
+        <span className="visually-hidden">Loading streams…</span>
+    </div>
+)
+
+export default React.memo(StreamGridSkeleton)

--- a/frontend/components/streams/StreamInfoCard.jsx
+++ b/frontend/components/streams/StreamInfoCard.jsx
@@ -1,52 +1,84 @@
 'use client'
+import { useMemo } from 'react'
 import {
-    Card,
+    Card, Row, Col,
 } from 'react-bootstrap'
+import { findThumbnailSrc } from '@/utils/utils'
+import ThumbImage from './ThumbImage'
 
 /**
- * Stream Information Card Component
+ * Stream hero: thumbnail + identity + key numbers.
  */
 const StreamInfoCard = ({
     streamInfoData, twitchLink, formattedStartTime, formattedEndTime, timeAgo, duration,
 }) => {
     const {
-        title, displayName, messageCount,
+        title, displayName, messageCount, thumbnailUrl,
     } = streamInfoData
 
+    const heroThumb = useMemo(() => findThumbnailSrc(thumbnailUrl, 640, 360), [
+        thumbnailUrl,
+    ])
+
     return (
-        <Card>
-            <Card.Body>
-                <Card.Title as="h1">{title}</Card.Title>
-                <Card.Subtitle
-                    className="mb-2 text-muted"
-                    as="h2">
-                    {displayName}
-                </Card.Subtitle>
-                <dl>
-                    <dt>Twitch link:</dt>
-                    <dd>
-                        <a
-                            href={twitchLink}
-                            target="_blank"
-                            rel="noreferrer"
-                            aria-label={`Visit ${displayName}'s Twitch channel (opens in new tab)`}
-                        >
-                            {twitchLink}
-                        </a>
-                    </dd>
-                    <dt>Message count:</dt>
-                    <dd><span className="fw-bold">{messageCount}</span></dd>
-                    <dt>Start time:</dt>
-                    <dd><span className="fw-bold">{formattedStartTime}</span></dd>
-                    <dt>End time:</dt>
-                    <dd><span className="fw-bold">{formattedEndTime}</span></dd>
-                    <dt>Time ago:</dt>
-                    <dd><span className="fw-bold">{timeAgo}</span></dd>
-                    <dt>Duration:</dt>
-                    <dd><span className="fw-bold">{duration}</span></dd>
-                </dl>
-            </Card.Body>
-        </Card>
+        <>
+            <div className="page-head">
+                <div>
+                    <h1 className="page-title">{displayName}</h1>
+                    <p className="page-sub">Stream intel report</p>
+                </div>
+                <div className="page-actions">
+                    <a
+                        href={twitchLink}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="btn btn-outline-primary btn-sm"
+                        aria-label={`Visit ${displayName}'s Twitch channel (opens in new tab)`}
+                    >
+                        <i
+                            className="bi bi-twitch me-2"
+                            aria-hidden="true"></i>
+                        Twitch channel
+                    </a>
+                </div>
+            </div>
+
+            <Card className="card-hud">
+                <Card.Body>
+                    <Row className="g-4 align-items-center">
+                        <Col
+                            md={4}
+                            lg={3}>
+                            <div
+                                className="thumb-wrap rounded overflow-hidden border"
+                                style={{ aspectRatio: '16 / 9' }}>
+                                <ThumbImage
+                                    src={heroThumb}
+                                    alt={`Stream thumbnail for ${displayName}`}
+                                />
+                            </div>
+                        </Col>
+                        <Col
+                            md={8}
+                            lg={9}>
+                            <h2 className="fs-5 mb-3">{title}</h2>
+                            <dl className="spec-list">
+                                <dt>Messages</dt>
+                                <dd className="mono">{messageCount?.toLocaleString()}</dd>
+                                <dt>Duration</dt>
+                                <dd className="mono">{duration}</dd>
+                                <dt>Aired</dt>
+                                <dd>{timeAgo}</dd>
+                                <dt>Start</dt>
+                                <dd className="mono">{formattedStartTime}</dd>
+                                <dt>End</dt>
+                                <dd className="mono">{formattedEndTime}</dd>
+                            </dl>
+                        </Col>
+                    </Row>
+                </Card.Body>
+            </Card>
+        </>
     )
 }
 

--- a/frontend/components/streams/StreamStatsCard.jsx
+++ b/frontend/components/streams/StreamStatsCard.jsx
@@ -1,8 +1,39 @@
 'use client'
 import {
-    Card,
+    Card, Row, Col,
 } from 'react-bootstrap'
 import ChatterSmallInfo from '../ChatterSmallInfo'
+
+/** Ranked leaderboard column. */
+const RankColumn = ({
+    headingId, label, chatters, noun,
+}) => (
+    <section aria-labelledby={headingId}>
+        <h3
+            id={headingId}
+            className="section-label mb-3">
+            {label}
+        </h3>
+        {chatters?.length ? (
+            <ul
+                className="rank-list"
+                role="list"
+                aria-label={label}>
+                {chatters.map((chatter, index) => (
+                    <ChatterSmallInfo
+                        key={chatter[0]}
+                        rank={index + 1}
+                        nick={chatter[1]}
+                        count={chatter[2]}
+                        noun={noun}
+                    />
+                ))}
+            </ul>
+        ) : (
+            <p className="text-muted small mb-0">No data recorded.</p>
+        )}
+    </section>
+)
 
 /**
  * Stream Statistics Card Component
@@ -12,38 +43,24 @@ const StreamStatsCard = ({
 }) => (
     <Card>
         <Card.Body>
-            <section aria-labelledby="most-active-heading">
-                <h3 id="most-active-heading">Most active chatters</h3>
-                <ul
-                    role="list"
-                    aria-label="Most active chatters in this stream">
-                    {mostActiveChatters?.map(chatter => (
-                        <ChatterSmallInfo
-                            key={chatter[0]}
-                            id={chatter[0]}
-                            nick={chatter[1]}
-                            count={chatter[2]}
-                            noun="Count"
-                        />
-                    ))}
-                </ul>
-            </section>
-            <section aria-labelledby="most-tagged-heading">
-                <h3 id="most-tagged-heading">Most tagged chatters</h3>
-                <ul
-                    role="list"
-                    aria-label="Most tagged chatters in this stream">
-                    {mostTaggedChatters?.map(chatter => (
-                        <ChatterSmallInfo
-                            key={chatter[0]}
-                            id={chatter[0]}
-                            nick={chatter[1]}
-                            count={chatter[2]}
-                            noun="Tagged"
-                        />
-                    ))}
-                </ul>
-            </section>
+            <Row className="g-4">
+                <Col md={6}>
+                    <RankColumn
+                        headingId="most-active-heading"
+                        label="Most active chatters"
+                        chatters={mostActiveChatters}
+                        noun="messages"
+                    />
+                </Col>
+                <Col md={6}>
+                    <RankColumn
+                        headingId="most-tagged-heading"
+                        label="Most tagged chatters"
+                        chatters={mostTaggedChatters}
+                        noun="tags"
+                    />
+                </Col>
+            </Row>
             {renderOtherCreators}
         </Card.Body>
     </Card>

--- a/frontend/components/streams/ThumbImage.jsx
+++ b/frontend/components/streams/ThumbImage.jsx
@@ -1,0 +1,40 @@
+'use client'
+import React, { useState } from 'react'
+
+/**
+ * Stream thumbnail image with a night-ops "no feed" fallback when the
+ * source 404s (Twitch VOD thumbnails are often missing/still processing).
+ */
+const ThumbImage = ({
+    src, alt,
+}) => {
+    const [
+        failed,
+        setFailed,
+    ] = useState(false)
+
+    if (failed || !src) {
+        return (
+            <div
+                className="thumb-fallback"
+                role="img"
+                aria-label={alt}
+            >
+                <i
+                    className="bi bi-camera-video-off"
+                    aria-hidden="true"></i>
+                <span>No feed</span>
+            </div>
+        )
+    }
+
+    return (
+        <img
+            src={src}
+            alt={alt}
+            onError={() => setFailed(true)}
+        />
+    )
+}
+
+export default React.memo(ThumbImage)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,8 @@
         "react": "^19.2.0",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.2.0",
-        "react-select": "^5.8.1"
+        "react-select": "^5.8.1",
+        "react-virtuoso": "^4.18.10"
       },
       "devDependencies": {
         "@eslint/js": "^9.31.0",
@@ -6124,6 +6125,16 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.10",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.10.tgz",
+      "integrity": "sha512-P6GIZ7kWAPOYB2H16yRQNgy+VF9pJOuTFw1EUc1EAtCj5WxVSAF1Sql3x3fbLwaLeBFsiPnu+3U9o6sIOyTdFw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
       }
     },
     "node_modules/readdirp": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,8 @@
     "react": "^19.2.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.0",
-    "react-select": "^5.8.1"
+    "react-select": "^5.8.1",
+    "react-virtuoso": "^4.18.10"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",

--- a/frontend/styles/_accessibility.scss
+++ b/frontend/styles/_accessibility.scss
@@ -1,33 +1,34 @@
-// Accessibility improvements for Stream Sniper
+// Accessibility layer — tuned for the night-ops dark theme.
+// (Focus rings use phosphor so they read against the dark surfaces.)
 
-// Enhanced focus indicators
-*:focus {
-  outline: 2px solid #0d6efd !important;
-  outline-offset: 2px !important;
-  box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.25) !important;
+// Visible focus for keyboard users only; pointer users keep clean chrome.
+:focus-visible {
+  outline: 2px solid rgba($phosphor, 0.85);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
-// High contrast focus for better visibility
-.btn:focus,
-.nav-link:focus,
-[role="button"]:focus {
-  outline: 3px solid #0d6efd !important;
-  outline-offset: 2px !important;
-  box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.5) !important;
+.btn:focus-visible,
+.nav-link:focus-visible,
+[role="button"]:focus-visible {
+  outline: 2px solid rgba($phosphor, 0.85);
+  outline-offset: 2px;
 }
 
-// Skip links for keyboard navigation
+// Skip link for keyboard navigation
 .skip-link {
   position: absolute;
-  top: -40px;
+  top: -48px;
   left: 6px;
-  background: #0d6efd;
-  color: white;
-  padding: 8px;
+  background: $phosphor;
+  color: $bg-base;
+  font-family: $font-family-monospace;
+  font-size: 0.78rem;
+  padding: 8px 12px;
   text-decoration: none;
-  z-index: 1000;
-  border-radius: 4px;
-  
+  z-index: 2000;
+  border-radius: 3px;
+
   &:focus {
     top: 6px;
   }
@@ -35,48 +36,22 @@
 
 // Ensure interactive elements have proper cursor
 [role="button"],
-.hover-zoom > div,
-.pagination-item {
+.pagination .page-link {
   cursor: pointer;
 }
 
-// Improve text contrast for better readability
-.text-muted {
-  color: #495057 !important; // Improved contrast from Bootstrap's default
-}
-
-// Ensure sufficient color contrast for links
+// Links: phosphor-tinted, readable on dark surfaces
 a {
-  color: #0056b3;
-  
+  color: #b9f34d;
+  text-decoration: none;
+
   &:hover {
-    color: #004085;
+    color: $phosphor;
+    text-decoration: underline;
   }
 }
 
-// Better focus for custom select components
-.react-select__control:focus-within {
-  outline: 2px solid #0d6efd !important;
-  outline-offset: 1px !important;
-  box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.25) !important;
-}
-
-// Improve pagination focus visibility
-.pagination .page-link:focus {
-  z-index: 3;
-  outline: 2px solid #0d6efd !important;
-  outline-offset: 1px !important;
-  box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.25) !important;
-}
-
-// Improve dropdown focus
-.dropdown-item:focus {
-  background-color: #e9ecef;
-  outline: 2px solid #0d6efd !important;
-  outline-offset: -2px !important;
-}
-
-// Screen reader only text (visually hidden but accessible to screen readers)
+// Screen reader only text
 .visually-hidden {
   position: absolute !important;
   width: 1px !important;
@@ -89,49 +64,7 @@ a {
   border: 0 !important;
 }
 
-// Ensure focus is visible on custom interactive elements
-.sidenav-bg .nav-link:focus {
-  background-color: rgba(13, 110, 253, 0.1);
-  outline: 2px solid #0d6efd !important;
-  outline-offset: -2px !important;
-}
-
-// Chat message focus improvements
-[role="log"] {
-  &:focus {
-    outline: 2px solid #0d6efd !important;
-    outline-offset: 2px !important;
-  }
-}
-
-// Improve card focus when used as interactive elements
-.card [role="button"]:focus {
-  .card {
-    box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.25) !important;
-  }
-}
-
-// Ensure error messages have proper contrast
-[role="alert"] {
-  color: #721c24;
-  background-color: #f8d7da;
-  border-color: #f5c6cb;
-  padding: 0.75rem 1.25rem;
-  border: 1px solid;
-  border-radius: 0.25rem;
-}
-
-// Loading state improvements
-[role="status"] {
-  color: #0f5132;
-  background-color: #d1e7dd;
-  border-color: #badbcc;
-  padding: 0.5rem 1rem;
-  border: 1px solid;
-  border-radius: 0.25rem;
-}
-
-// Responsive text scaling
+// Smooth scrolling for those who don't mind motion
 @media (prefers-reduced-motion: no-preference) {
   html {
     scroll-behavior: smooth;
@@ -155,21 +88,8 @@ a {
   .btn {
     border: 2px solid !important;
   }
-  
-  .card {
-    border: 2px solid #000 !important;
-  }
-  
-  .text-muted {
-    color: #000 !important;
-  }
-}
 
-// Dark mode considerations
-@media (prefers-color-scheme: dark) {
-  // Focus indicators should be more visible in dark mode
-  *:focus {
-    outline-color: #6ea8fe !important;
-    box-shadow: 0 0 0 2px rgba(110, 168, 254, 0.25) !important;
+  .card {
+    border: 2px solid $gray-300 !important;
   }
 }

--- a/frontend/styles/_loader.scss
+++ b/frontend/styles/_loader.scss
@@ -1,18 +1,65 @@
 .fallback-spinner {
-  position: relative;
   display: flex;
+  align-items: center;
+  justify-content: center;
   height: 100vh;
   width: 100%;
 }
 
-.loading {
-  position: absolute;
-  left: calc(50% - 35px);
-  top: 50%;
-  width: 55px;
-  height: 55px;
-  border-radius: 50%;
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-  border: 3px solid transparent;
+.scope-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+
+  svg {
+    width: 72px;
+    height: 72px;
+    overflow: visible;
+  }
+
+  .scope-ring {
+    fill: none;
+    stroke: $gray-600;
+    stroke-width: 1.5;
+  }
+
+  .scope-sweep {
+    fill: none;
+    stroke: $phosphor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-dasharray: 34 200;
+    transform-origin: center;
+    animation: scopeSpin 1.1s linear infinite;
+    filter: drop-shadow(0 0 4px rgba($phosphor, 0.6));
+  }
+
+  .scope-cross {
+    stroke: $gray-500;
+    stroke-width: 1.5;
+    stroke-linecap: round;
+  }
+
+  .scope-dot {
+    fill: $phosphor;
+    animation: scopeBlink 1.1s ease-in-out infinite;
+  }
+
+  .scope-text {
+    font-family: $font-family-monospace;
+    font-size: 0.68rem;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: $gray-400;
+  }
+}
+
+@keyframes scopeSpin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes scopeBlink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.25; }
 }

--- a/frontend/styles/_theme.scss
+++ b/frontend/styles/_theme.scss
@@ -1,6 +1,9 @@
 /*
  * Night-ops theme layer: atmosphere, chrome, and component skins that go
  * beyond what Bootstrap variables can express.
+ *
+ * Design language: signal-intelligence console. Phosphor green on deep
+ * navy-black, hairline borders, mono data readouts, HUD corner ticks.
  */
 
 /* ---------- Atmosphere ---------- */
@@ -58,6 +61,36 @@ body {
     background: transparent;
 }
 
+/* ---------- Motion ---------- */
+@keyframes rise {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    main .card,
+    main .stat-tile,
+    .auth-card {
+        animation: rise 0.45s cubic-bezier(0.16, 1, 0.3, 1) backwards;
+    }
+
+    /* stagger sibling cards / tiles on page load */
+    @for $i from 1 through 10 {
+        main .card:nth-child(#{$i}),
+        main .row > *:nth-child(#{$i}) .card,
+        main .row > *:nth-child(#{$i}) .stat-tile,
+        main .stat-grid > *:nth-child(#{$i}) {
+            animation-delay: #{0.04 * ($i - 1)}s;
+        }
+    }
+}
+
 /* ---------- Typography helpers ---------- */
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
@@ -69,6 +102,7 @@ h1, h2, h3, h4, h5, h6,
     font-variant-numeric: tabular-nums;
 }
 
+/* main page title with phosphor blade */
 .page-title {
     font-family: $headings-font-family;
     font-weight: 700;
@@ -78,6 +112,7 @@ h1, h2, h3, h4, h5, h6,
     display: flex;
     align-items: center;
     gap: 0.6rem;
+    margin-bottom: 0;
 
     &::before {
         content: "";
@@ -86,6 +121,47 @@ h1, h2, h3, h4, h5, h6,
         background: $phosphor;
         clip-path: polygon(0 0, 100% 0, 100% 65%, 0 100%);
         flex-shrink: 0;
+    }
+}
+
+/* page header block: title + mono subtitle + right-side actions */
+.page-head {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.85rem;
+    border-bottom: 1px solid $hairline;
+
+    .page-sub {
+        font-family: $font-family-monospace;
+        font-size: 0.72rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: $gray-400;
+        margin: 0.35rem 0 0 1.15rem;
+    }
+
+    .page-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+}
+
+/* small mono section label, e.g. table captions and card kickers */
+.section-label {
+    font-family: $font-family-monospace;
+    font-size: 0.68rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: $gray-400;
+
+    &::before {
+        content: "// ";
+        color: rgba($phosphor, 0.6);
     }
 }
 
@@ -110,12 +186,29 @@ h1, h2, h3, h4, h5, h6,
             color: $phosphor;
         }
     }
+
+    svg {
+        transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    &:hover svg {
+        transform: rotate(90deg);
+    }
 }
 
 /* ---------- Sidebar ---------- */
 .sidebarArea {
     background-color: $bg-surface;
     border-right: 1px solid $hairline;
+    display: flex;
+    flex-direction: column;
+
+    .sidebar-inner {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        min-height: 0;
+    }
 
     .sidebarNav .nav-link {
         display: flex;
@@ -123,24 +216,35 @@ h1, h2, h3, h4, h5, h6,
         color: $gray-300;
         border-left: 2px solid transparent;
         border-radius: 0;
-        padding: 0.7rem 1rem;
+        padding: 0.62rem 1rem;
         font-weight: 500;
+        font-size: 0.92rem;
         transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
 
         i {
-            font-size: 1.05rem;
+            font-size: 1.02rem;
             width: 1.4rem;
+            color: $gray-400;
+            transition: color 0.15s ease;
         }
 
         &:hover {
             color: $white;
             background: rgba($phosphor, 0.05);
+
+            i {
+                color: $gray-200;
+            }
         }
 
         &.active {
             color: $phosphor;
             border-left-color: $phosphor;
             background: linear-gradient(90deg, rgba($phosphor, 0.1), transparent 75%);
+
+            i {
+                color: $phosphor;
+            }
         }
     }
 
@@ -150,7 +254,42 @@ h1, h2, h3, h4, h5, h6,
         letter-spacing: 0.22em;
         text-transform: uppercase;
         color: $gray-400;
+
+        &::before {
+            content: "// ";
+            color: rgba($phosphor, 0.5);
+        }
     }
+
+    /* status line pinned to the bottom of the rail (negative margins
+       counter the .sidebar-inner padding so the top border spans full width) */
+    .sidebar-status {
+        margin: auto -1rem 0;
+        padding: 0.85rem 1rem;
+        border-top: 1px solid $hairline;
+        font-family: $font-family-monospace;
+        font-size: 0.66rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: $gray-400;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+
+        .status-dot {
+            width: 7px;
+            height: 7px;
+            border-radius: 50%;
+            background: $phosphor;
+            box-shadow: 0 0 6px rgba($phosphor, 0.8);
+            animation: statusPulse 2.4s ease-in-out infinite;
+        }
+    }
+}
+
+@keyframes statusPulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.35; }
 }
 
 /* ---------- Header ---------- */
@@ -159,23 +298,371 @@ h1, h2, h3, h4, h5, h6,
     backdrop-filter: blur(6px);
     border-bottom: 1px solid $hairline;
     padding: 0.55rem 1.25rem;
+    min-height: 56px;
+
+    .header-path {
+        font-family: $font-family-monospace;
+        font-size: 0.74rem;
+        letter-spacing: 0.08em;
+        color: $gray-400;
+
+        .path-sep {
+            color: $gray-600;
+            margin: 0 0.35rem;
+        }
+
+        .path-current {
+            color: $phosphor;
+        }
+    }
+}
+
+/* user chip in the header */
+.user-chip {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    background: $bg-surface !important;
+    border: 1px solid $hairline !important;
+    color: $gray-100 !important;
+    border-radius: 999px !important;
+    padding: 0.25rem 0.8rem 0.25rem 0.3rem !important;
+    font-family: $font-family-sans-serif;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0;
+
+    &:hover, &:focus, &:active {
+        border-color: rgba($phosphor, 0.5) !important;
+        background: $bg-raised !important;
+        color: $white !important;
+    }
+
+    &::after {
+        display: none !important; /* kill caret */
+    }
+
+    .avatar-orb {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: radial-gradient(circle at 30% 30%, rgba($phosphor, 0.35), rgba($phosphor, 0.1));
+        border: 1px solid rgba($phosphor, 0.45);
+        color: $phosphor;
+        font-family: $headings-font-family;
+        font-weight: 700;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+    }
+}
+
+.role-chip {
+    font-family: $font-family-monospace;
+    font-size: 0.6rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    padding: 0.14rem 0.45rem;
+    border-radius: 2px;
+    background: rgba($amber, 0.15);
+    color: $amber;
+    border: 1px solid rgba($amber, 0.35);
 }
 
 /* ---------- Cards ---------- */
 .card {
     border: 1px solid $hairline;
     background-color: $bg-surface;
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.03) inset;
 
     .card-title {
         font-family: $headings-font-family;
     }
+
+    .card-header {
+        border-bottom: 1px solid $hairline;
+        padding-top: 0.85rem;
+        padding-bottom: 0.85rem;
+    }
 }
 
-/* ---------- Stream cards ---------- */
+/* HUD corner ticks — opt-in via .card-hud */
+.card-hud {
+    position: relative;
+
+    &::before,
+    &::after {
+        content: "";
+        position: absolute;
+        width: 14px;
+        height: 14px;
+        pointer-events: none;
+        z-index: 1;
+    }
+
+    &::before {
+        top: -1px;
+        left: -1px;
+        border-top: 2px solid rgba($phosphor, 0.7);
+        border-left: 2px solid rgba($phosphor, 0.7);
+    }
+
+    &::after {
+        bottom: -1px;
+        right: -1px;
+        border-bottom: 2px solid rgba($phosphor, 0.7);
+        border-right: 2px solid rgba($phosphor, 0.7);
+    }
+}
+
+/* ---------- Stat tiles ---------- */
+.stat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.stat-tile {
+    position: relative;
+    background: $bg-surface;
+    border: 1px solid $hairline;
+    border-radius: $border-radius;
+    padding: 1rem 1.15rem 0.9rem;
+    overflow: hidden;
+    transition: border-color 0.18s ease, transform 0.18s ease;
+
+    /* corner notch */
+    &::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 22px;
+        height: 22px;
+        background: linear-gradient(225deg, rgba($phosphor, 0.28) 0%, transparent 50%);
+    }
+
+    .stat-label {
+        font-family: $font-family-monospace;
+        font-size: 0.64rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: $gray-400;
+        margin-bottom: 0.4rem;
+        white-space: nowrap;
+    }
+
+    .stat-value {
+        font-family: $headings-font-family;
+        font-weight: 700;
+        font-size: 2rem;
+        line-height: 1.1;
+        color: $white;
+        font-variant-numeric: tabular-nums;
+
+        &.text-phosphor { color: $phosphor; }
+    }
+
+    .stat-hint {
+        font-family: $font-family-monospace;
+        font-size: 0.66rem;
+        color: $gray-500;
+        margin-top: 0.3rem;
+    }
+
+    &:hover {
+        border-color: rgba($phosphor, 0.4);
+        transform: translateY(-2px);
+    }
+}
+
+/* ---------- Tables ---------- */
+.table {
+    margin-bottom: 0;
+
+    thead th {
+        font-family: $font-family-monospace;
+        font-size: 0.66rem;
+        font-weight: 600;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: $gray-400;
+        border-bottom: 1px solid $gray-600;
+        padding: 0.55rem 0.75rem;
+        white-space: nowrap;
+    }
+
+    tbody td {
+        padding: 0.6rem 0.75rem;
+        vertical-align: middle;
+        border-color: rgba($hairline, 0.6);
+    }
+
+    tbody tr {
+        transition: background-color 0.12s ease;
+    }
+}
+
+/* rank digits for leaderboards */
+.rank-num {
+    font-family: $font-family-monospace;
+    font-size: 0.78rem;
+    color: $gray-500;
+    width: 2.5rem;
+
+    tr:nth-child(-n+3) & {
+        color: $phosphor;
+        font-weight: 600;
+    }
+}
+
+/* relative magnitude bar behind counts */
+.data-bar {
+    position: relative;
+    display: block;
+    height: 3px;
+    margin-top: 0.3rem;
+    background: rgba($phosphor, 0.12);
+    border-radius: 1px;
+    overflow: hidden;
+
+    .data-bar-fill {
+        position: absolute;
+        inset: 0 auto 0 0;
+        background: linear-gradient(90deg, $phosphor-dim, $phosphor);
+        border-radius: 1px;
+    }
+}
+
+/* ---------- Chips & badges ---------- */
+.badge {
+    font-family: $font-family-monospace;
+    font-size: 0.62rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    border-radius: 2px;
+    padding: 0.3em 0.55em;
+}
+
+/* status chip with signal dot: .status-chip.is-ok / .is-warn / .is-err / .is-idle */
+.status-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-family: $font-family-monospace;
+    font-size: 0.66rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 0.22rem 0.6rem;
+    border-radius: 2px;
+    border: 1px solid $hairline;
+    background: $bg-raised;
+    color: $gray-300;
+
+    &::before {
+        content: "";
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: $gray-500;
+        flex-shrink: 0;
+    }
+
+    &.is-ok {
+        color: $teal;
+        border-color: rgba($teal, 0.35);
+        &::before { background: $teal; box-shadow: 0 0 5px rgba($teal, 0.7); }
+    }
+
+    &.is-warn {
+        color: $amber;
+        border-color: rgba($amber, 0.35);
+        &::before { background: $amber; box-shadow: 0 0 5px rgba($amber, 0.7); }
+    }
+
+    &.is-err {
+        color: $signal-red;
+        border-color: rgba($signal-red, 0.35);
+        &::before { background: $signal-red; box-shadow: 0 0 5px rgba($signal-red, 0.7); }
+    }
+}
+
+/* ---------- Empty states ---------- */
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 3rem 1.5rem;
+    color: $gray-400;
+
+    .empty-scope {
+        position: relative;
+        width: 54px;
+        height: 54px;
+        border: 1px solid $gray-600;
+        border-radius: 50%;
+        margin-bottom: 1rem;
+        opacity: 0.8;
+
+        &::before,
+        &::after {
+            content: "";
+            position: absolute;
+            background: $gray-600;
+        }
+
+        &::before {
+            left: 50%;
+            top: -7px;
+            bottom: -7px;
+            width: 1px;
+            transform: translateX(-50%);
+        }
+
+        &::after {
+            top: 50%;
+            left: -7px;
+            right: -7px;
+            height: 1px;
+            transform: translateY(-50%);
+        }
+    }
+
+    .empty-title {
+        font-family: $font-family-monospace;
+        font-size: 0.74rem;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: $gray-300;
+        margin-bottom: 0.35rem;
+    }
+
+    .empty-hint {
+        font-size: 0.86rem;
+        color: $gray-400;
+        max-width: 34rem;
+        margin: 0;
+    }
+}
+
+/* ---------- Stream grid & cards ---------- */
+.stream-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+    gap: 1.15rem;
+    margin-bottom: 1.5rem;
+}
+
 .stream-card {
     overflow: hidden;
     transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
     cursor: pointer;
+    margin-bottom: 0;
 
     .thumb-wrap {
         position: relative;
@@ -191,10 +678,21 @@ h1, h2, h3, h4, h5, h6,
             filter: saturate(0.85) contrast(1.02);
         }
 
+        /* bottom info gradient so chips always read */
+        &::after {
+            content: "";
+            position: absolute;
+            inset: auto 0 0 0;
+            height: 40%;
+            background: linear-gradient(to top, rgba($black, 0.55), transparent);
+            pointer-events: none;
+        }
+
         .duration-chip {
             position: absolute;
             right: 0.5rem;
             bottom: 0.5rem;
+            z-index: 1;
             font-family: $font-family-monospace;
             font-size: 0.72rem;
             padding: 0.1rem 0.45rem;
@@ -208,6 +706,7 @@ h1, h2, h3, h4, h5, h6,
             position: absolute;
             left: 0.5rem;
             top: 0.5rem;
+            z-index: 1;
             font-family: $headings-font-family;
             font-weight: 700;
             font-size: 0.68rem;
@@ -264,6 +763,137 @@ h1, h2, h3, h4, h5, h6,
     100% { box-shadow: 0 0 0 6px rgba(255, 255, 255, 0); }
 }
 
+/* ---------- Skeleton loaders ---------- */
+@keyframes skeletonSheen {
+    from { background-position: 200% 0; }
+    to { background-position: -200% 0; }
+}
+
+.skeleton {
+    position: relative;
+    background: $bg-raised;
+    border-radius: 3px;
+    overflow: hidden;
+
+    &::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+            100deg,
+            transparent 30%,
+            rgba(255, 255, 255, 0.045) 50%,
+            transparent 70%
+        );
+        background-size: 200% 100%;
+        animation: skeletonSheen 1.6s linear infinite;
+    }
+}
+
+.skeleton-thumb {
+    aspect-ratio: 16 / 9;
+    border-radius: 0;
+}
+
+.skeleton-line {
+    height: 0.8rem;
+    margin-bottom: 0.55rem;
+
+    &.w-75 { width: 75%; }
+    &.w-50 { width: 50%; }
+}
+
+/* ---------- Toolbar (filters row) ---------- */
+.toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1.5rem;
+    background: $bg-surface;
+    border: 1px solid $hairline;
+    border-radius: $border-radius;
+
+    .toolbar-label {
+        font-family: $font-family-monospace;
+        font-size: 0.66rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: $gray-400;
+        white-space: nowrap;
+    }
+
+    .toolbar-field {
+        min-width: 220px;
+        flex: 1 1 220px;
+    }
+
+    .toolbar-readout {
+        margin-left: auto;
+        font-family: $font-family-monospace;
+        font-size: 0.72rem;
+        color: $gray-400;
+        white-space: nowrap;
+
+        strong {
+            color: $phosphor;
+            font-weight: 600;
+        }
+    }
+}
+
+/* ---------- Ranked lists (chatter leaderboards) ---------- */
+.rank-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    li {
+        display: flex;
+        align-items: center;
+        gap: 0.7rem;
+        padding: 0.42rem 0.5rem;
+        border-radius: 3px;
+        transition: background-color 0.12s ease;
+
+        &:hover {
+            background: rgba($phosphor, 0.06);
+        }
+
+        .rank {
+            font-family: $font-family-monospace;
+            font-size: 0.72rem;
+            color: $gray-500;
+            width: 1.6rem;
+            text-align: right;
+            flex-shrink: 0;
+        }
+
+        &:nth-child(-n+3) .rank {
+            color: $phosphor;
+            font-weight: 600;
+        }
+
+        .nick {
+            font-weight: 500;
+            color: $gray-100;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .count {
+            margin-left: auto;
+            font-family: $font-family-monospace;
+            font-size: 0.74rem;
+            color: $gray-300;
+            font-variant-numeric: tabular-nums;
+            flex-shrink: 0;
+        }
+    }
+}
+
 /* ---------- Buttons ---------- */
 .btn-primary {
     --bs-btn-color: #{$bg-base};
@@ -271,14 +901,35 @@ h1, h2, h3, h4, h5, h6,
     --bs-btn-active-color: #{$bg-base};
     text-transform: uppercase;
     letter-spacing: 0.05em;
+
+    &:hover {
+        box-shadow: 0 0 14px rgba($phosphor, 0.35);
+    }
+}
+
+.btn-outline-primary,
+.btn-outline-secondary,
+.btn-outline-danger,
+.btn-success,
+.btn-danger {
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
 }
 
 .btn-outline-primary {
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-
     &:hover, &:active {
         color: $bg-base !important;
+    }
+}
+
+/* ---------- Pagination ---------- */
+.pagination {
+    --bs-pagination-font-size: 0.82rem;
+    font-family: $font-family-monospace;
+
+    .page-link {
+        min-width: 2.35rem;
+        text-align: center;
     }
 }
 
@@ -287,12 +938,18 @@ h1, h2, h3, h4, h5, h6,
     background-color: $bg-raised !important;
     border-color: $hairline !important;
     color: $body-color;
+    min-height: 38px;
+
+    &:hover {
+        border-color: rgba($phosphor, 0.4) !important;
+    }
 }
 
 [class*="-menu"] {
     background-color: $bg-raised !important;
     border: 1px solid $hairline;
     color: $body-color;
+    z-index: 10 !important;
 }
 
 [class*="-option"] {
@@ -307,6 +964,10 @@ h1, h2, h3, h4, h5, h6,
     color: $body-color !important;
 }
 
+[class*="-placeholder"] {
+    color: $gray-400 !important;
+}
+
 /* ---------- Login screen ---------- */
 .auth-screen {
     min-height: 100vh;
@@ -314,23 +975,308 @@ h1, h2, h3, h4, h5, h6,
     align-items: center;
     justify-content: center;
     padding: 1.5rem;
+    position: relative;
     background:
         radial-gradient(800px 400px at 50% -10%, rgba($phosphor, 0.07), transparent 65%),
         $bg-base;
 
-    .auth-card {
+    /* faint blueprint grid */
+    &::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background:
+            linear-gradient(rgba($phosphor, 0.025) 1px, transparent 1px),
+            linear-gradient(90deg, rgba($phosphor, 0.025) 1px, transparent 1px);
+        background-size: 44px 44px;
+        mask-image: radial-gradient(ellipse 70% 60% at 50% 40%, #000 30%, transparent 75%);
+    }
+
+    .auth-panel {
+        position: relative;
         width: 100%;
-        max-width: 400px;
+        max-width: 420px;
+    }
+
+    .auth-brand {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.8rem;
+        margin-bottom: 1.75rem;
+
+        .auth-tagline {
+            font-family: $font-family-monospace;
+            font-size: 0.68rem;
+            letter-spacing: 0.28em;
+            text-transform: uppercase;
+            color: $gray-400;
+        }
+    }
+
+    .auth-card {
+        position: relative;
         border: 1px solid $hairline;
-        background: $bg-surface;
+        background: rgba($bg-surface, 0.92);
+        backdrop-filter: blur(4px);
         box-shadow: 0 20px 60px rgba($black, 0.6);
+        border-radius: $border-radius;
+
+        /* HUD corner brackets */
+        &::before,
+        &::after {
+            content: "";
+            position: absolute;
+            width: 18px;
+            height: 18px;
+            pointer-events: none;
+        }
+
+        &::before {
+            top: -1px;
+            left: -1px;
+            border-top: 2px solid rgba($phosphor, 0.8);
+            border-left: 2px solid rgba($phosphor, 0.8);
+        }
+
+        &::after {
+            bottom: -1px;
+            right: -1px;
+            border-bottom: 2px solid rgba($phosphor, 0.8);
+            border-right: 2px solid rgba($phosphor, 0.8);
+        }
+
+        .card-header {
+            background: transparent;
+            border-bottom: 1px solid $hairline;
+
+            .auth-mode {
+                font-family: $headings-font-family;
+                font-weight: 700;
+                font-size: 0.92rem;
+                letter-spacing: 0.14em;
+                text-transform: uppercase;
+                color: $white;
+                margin: 0;
+
+                &::before {
+                    content: "> ";
+                    color: $phosphor;
+                }
+            }
+        }
     }
 }
 
 /* ---------- Chat replay ---------- */
+.chat-panel {
+    margin-top: 1.25rem;
+    background: $bg-base;
+    border: 1px solid $hairline;
+    border-radius: $border-radius;
+    overflow: hidden;
+
+    .chat-panel-head {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 0.9rem;
+        border-bottom: 1px solid $hairline;
+        background: $bg-surface;
+        font-family: $font-family-monospace;
+        font-size: 0.68rem;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: $gray-400;
+
+        .chat-count {
+            margin-left: auto;
+            color: $phosphor;
+        }
+    }
+
+    .chat-panel-body {
+        max-height: 520px;
+        overflow-y: auto;
+        padding: 0.6rem 0.9rem;
+        font-size: 0.88rem;
+        line-height: 1.45;
+    }
+
+    .chat-line {
+        padding: 0.22rem 0.4rem;
+        border-radius: 3px;
+        margin: 0;
+
+        &:hover {
+            background: rgba(255, 255, 255, 0.03);
+        }
+
+        .chat-nick {
+            font-weight: 700;
+        }
+
+        img {
+            vertical-align: middle;
+            margin: -0.2rem 0.1rem 0;
+        }
+    }
+}
+
+/* legacy hooks kept for safety */
 .chat-lookalike, .twitch-chat {
     font-family: $font-family-sans-serif;
     background: $bg-raised;
     border: 1px solid $hairline;
     border-radius: $border-radius;
+}
+
+/* ---------- Definition lists (stream info) ---------- */
+.spec-list {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.35rem 1.5rem;
+    margin: 0;
+
+    dt {
+        font-family: $font-family-monospace;
+        font-size: 0.68rem;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: $gray-400;
+        font-weight: 400;
+        align-self: center;
+    }
+
+    dd {
+        margin: 0;
+        color: $gray-100;
+        font-variant-numeric: tabular-nums;
+    }
+}
+
+/* ---------- Modals ---------- */
+.modal-content {
+    border: 1px solid $hairline;
+    box-shadow: 0 24px 80px rgba($black, 0.7);
+}
+
+.modal-header {
+    border-bottom-color: $hairline;
+
+    .modal-title {
+        font-family: $headings-font-family;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+    }
+}
+
+.modal-footer {
+    border-top-color: $hairline;
+}
+
+/* ---------- Alerts ---------- */
+.alert {
+    border-width: 1px;
+    border-left-width: 3px;
+}
+
+/* ---------- Dropdowns ---------- */
+.dropdown-menu {
+    box-shadow: 0 14px 40px rgba($black, 0.55);
+
+    .dropdown-header {
+        font-family: $font-family-monospace;
+        font-size: 0.72rem;
+    }
+}
+
+/* ---------- Forms ---------- */
+.form-label {
+    font-family: $font-family-monospace;
+    font-size: 0.7rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: $gray-300;
+}
+
+.form-text, small.text-muted {
+    font-size: 0.74rem;
+}
+
+/* ---------- Responsive refinements ---------- */
+@include media-breakpoint-down(md) {
+    .page-title {
+        font-size: 1.15rem;
+    }
+
+    .page-head {
+        margin-bottom: 1.1rem;
+    }
+
+    .stat-tile .stat-value {
+        font-size: 1.6rem;
+    }
+
+    .toolbar {
+        .toolbar-readout {
+            margin-left: 0;
+            flex-basis: 100%;
+        }
+    }
+
+    .spec-list {
+        grid-template-columns: 1fr;
+        gap: 0.15rem;
+
+        dt {
+            margin-top: 0.5rem;
+        }
+    }
+
+    .chat-panel .chat-panel-body {
+        max-height: 380px;
+    }
+}
+
+/* "no feed" placeholder when a thumbnail 404s */
+.thumb-fallback {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    background:
+        repeating-linear-gradient(
+            -45deg,
+            rgba(255, 255, 255, 0.015) 0 8px,
+            transparent 8px 16px
+        ),
+        $bg-raised;
+    color: $gray-500;
+
+    i {
+        font-size: 1.5rem;
+    }
+
+    span {
+        font-family: $font-family-monospace;
+        font-size: 0.62rem;
+        letter-spacing: 0.24em;
+        text-transform: uppercase;
+    }
+}
+
+/* generic thumb container (also used outside .stream-card, e.g. stream hero) */
+.thumb-wrap {
+    position: relative;
+
+    img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
 }

--- a/frontend/styles/_variables.scss
+++ b/frontend/styles/_variables.scss
@@ -20,6 +20,7 @@ $bg-base: #0b0e13; // page background
 $bg-surface: #12161e; // cards / sidebar
 $bg-raised: #1a2029; // hover / inputs
 $hairline: #232c3a; // borders
+$phosphor-dim: #4d7a0a; // muted accent for bars / secondary marks
 
 $primary: $phosphor;
 $info: $sky;
@@ -70,7 +71,9 @@ $text-muted: #8b97a8;
 /*******************/
 // Components
 /********************/
-$border-radius: 0.375rem !default;
+$border-radius: 0.25rem !default; // sharper corners — instrument-panel look
+$border-radius-sm: 0.125rem !default;
+$border-radius-lg: 0.375rem !default;
 $border-color: $hairline;
 $box-shadow: 0 0.75rem 2rem rgba($black, 0.55);
 $headings-font-weight: 600 !default;

--- a/frontend/styles/layout/_container.scss
+++ b/frontend/styles/layout/_container.scss
@@ -4,15 +4,16 @@
 
 .contentArea {
     flex-grow: 1;
+    min-width: 0;
 }
 
 .wrapper {
-    max-width: 1300px;
+    max-width: 1360px;
     margin: 0 auto;
 }
 
 .card {
-    margin-bottom: 30px;
+    margin-bottom: 1.5rem;
 }
 
 .circle-box {

--- a/frontend/styles/layout/_sidebar.scss
+++ b/frontend/styles/layout/_sidebar.scss
@@ -4,16 +4,33 @@
   background-color: $sidebarColor;
 }
 
+.sidebar-backdrop {
+  display: none;
+}
+
 @include media-breakpoint-down(lg) {
   .sidebarArea {
     position: fixed;
     height: 100%;
     overflow: auto;
-    z-index: 1;
+    z-index: 1045;
     margin-left: -$sidebarWidth;
     transition: 0.2s ease-in;
+    box-shadow: none;
+
     &.showSidebar {
       margin-left: 0px;
+      box-shadow: 24px 0 60px rgba(0, 0, 0, 0.5);
     }
+  }
+
+  /* dimmed backdrop, activated by the sibling sidebar's open state */
+  .sidebarArea.showSidebar + .sidebar-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 1040;
+    background: rgba(5, 7, 10, 0.6);
+    backdrop-filter: blur(1px);
   }
 }

--- a/frontend/views/AllStreams.jsx
+++ b/frontend/views/AllStreams.jsx
@@ -3,18 +3,13 @@ import {
     useState, useCallback, useMemo,
 } from 'react'
 import {
-    Card,
-    CardGroup,
-} from 'react-bootstrap'
-import {
     useStreams, useCreators,
 } from '@/hooks/useApiQuery'
-import LoadingSpinner from '@/components/LoadingSpinner'
 import StreamThumbnail from '@/components/StreamThumbnail'
+import StreamGridSkeleton from '@/components/streams/StreamGridSkeleton'
 import ErrorDisplay from '@/components/streams/ErrorDisplay'
 import FiltersCard from '@/components/streams/FiltersCard'
 import PaginationComponent from '@/components/streams/PaginationComponent'
-import { chunks } from '@/utils/utils'
 
 
 const AllStreams = () => {
@@ -106,13 +101,12 @@ const AllStreams = () => {
 
     return (
         <>
-            {isLoading && (
-                <LoadingSpinner
-                    size="lg"
-                    text="Loading streams and creators..."
-                    card
-                />
-            )}
+            <div className="page-head">
+                <div>
+                    <h1 id="streams-heading" className="page-title">All streams</h1>
+                    <p className="page-sub">Captured VODs · chat intelligence</p>
+                </div>
+            </div>
 
             <ErrorDisplay
                 streamsError={streamsError}
@@ -127,59 +121,63 @@ const AllStreams = () => {
                 onCreatorChange={handleCreatorChange}
                 selectedOrdering={selectedOrdering}
                 onOrderingChange={handleOrderingChange}
+                page={offset + 1}
+                pagesCount={pagesCount}
             />
 
-            <Card>
-                <Card.Header>
-                    <h1 id="streams-heading" className="page-title mb-0">All streams</h1>
-                </Card.Header>
-                <Card.Body>
+            {isLoading && <StreamGridSkeleton />}
+
+            {!isLoading && (
+                <div
+                    role="region"
+                    aria-labelledby="streams-heading"
+                    aria-live="polite"
+                    aria-describedby="streams-description"
+                >
                     <div
-                        role="region"
-                        aria-labelledby="streams-heading"
-                        aria-live="polite"
-                        aria-describedby="streams-description"
-                    >
-                        <div
-                            id="streams-description"
-                            className="visually-hidden">
-                            {streams.length > 0
-                                ? `Showing ${streams.length} streams on page ${offset + 1} of ${pagesCount}`
-                                : 'No streams found'
-                            }
-                        </div>
-                        {useMemo(() =>
-                            chunks(streams, 4).map((chunk, chunkIndex) =>
-                                <CardGroup
-                                    key={chunkIndex}
-                                    className="mb-4"
-                                    role="group"
-                                    aria-label={`Stream row ${chunkIndex + 1}`}
-                                >
-                                    {chunk.map((stream, streamIndex) =>
-                                        <StreamThumbnail
-                                            key={`${stream[0]}-${streamIndex}`}
-                                            id={stream[0]}
-                                            name={stream[1]}
-                                            start={stream[2]}
-                                            end={stream[3]}
-                                            thumbnailSrc={stream[4]}
-                                            messageCount={stream[5]}
-                                        />,
-                                    )}
-                                </CardGroup>,
-                            ), [
-                            streams,
-                        ],
-                        )}
-                        <PaginationComponent
-                            pagesCount={pagesCount}
-                            offset={offset}
-                            updateOffset={updateOffset}
-                        />
+                        id="streams-description"
+                        className="visually-hidden">
+                        {streams.length > 0
+                            ? `Showing ${streams.length} streams on page ${offset + 1} of ${pagesCount}`
+                            : 'No streams found'
+                        }
                     </div>
-                </Card.Body>
-            </Card>
+
+                    {streams.length === 0 ? (
+                        <div className="card">
+                            <div className="empty-state">
+                                <div
+                                    className="empty-scope"
+                                    aria-hidden="true" />
+                                <p className="empty-title">No streams in scope</p>
+                                <p className="empty-hint">
+                                    No captured streams match this filter yet. Streams appear here once the collector has processed a VOD.
+                                </p>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="stream-grid">
+                            {streams.map((stream, streamIndex) => (
+                                <StreamThumbnail
+                                    key={`${stream[0]}-${streamIndex}`}
+                                    id={stream[0]}
+                                    name={stream[1]}
+                                    start={stream[2]}
+                                    end={stream[3]}
+                                    thumbnailSrc={stream[4]}
+                                    messageCount={stream[5]}
+                                />
+                            ))}
+                        </div>
+                    )}
+
+                    <PaginationComponent
+                        pagesCount={pagesCount}
+                        offset={offset}
+                        updateOffset={updateOffset}
+                    />
+                </div>
+            )}
         </>
     )
 }

--- a/frontend/views/ChatterFootprint.jsx
+++ b/frontend/views/ChatterFootprint.jsx
@@ -50,6 +50,11 @@ const ChatterFootprint = () => {
         activityData,
     ])
 
+    // Max message count across rows, for the relative magnitude bars
+    const maxMessages = useMemo(() => Math.max(1, ...activity.map(row => row[5] || 0)), [
+        activity,
+    ])
+
     /**
      * Handles the nick lookup form submission
      * @param {object} event
@@ -66,57 +71,87 @@ const ChatterFootprint = () => {
 
     return (
         <>
-            <Card className="mb-4">
-                <Card.Header>
-                    <h1 id="footprint-heading" className="page-title mb-0">Chatter footprint</h1>
-                </Card.Header>
-                <Card.Body>
-                    <Form
-                        onSubmit={handleSubmit}
-                        className="d-flex gap-2"
-                        role="search"
+            <div className="page-head">
+                <div>
+                    <h1 id="footprint-heading" className="page-title">Chatter footprint</h1>
+                    <p className="page-sub">Cross-stream presence trace</p>
+                </div>
+            </div>
+
+            <Form
+                onSubmit={handleSubmit}
+                className="toolbar"
+                role="search"
+            >
+                <span
+                    className="toolbar-label"
+                    aria-hidden="true">
+                    Trace
+                </span>
+                <div className="toolbar-field">
+                    <label
+                        htmlFor="footprint-nick-input"
+                        className="visually-hidden"
                     >
-                        <label
-                            htmlFor="footprint-nick-input"
-                            className="visually-hidden"
-                        >
-                            Chatter nickname
-                        </label>
-                        <Form.Control
-                            id="footprint-nick-input"
-                            type="text"
-                            value={nickInput}
-                            onChange={event => setNickInput(event.target.value)}
-                            placeholder="Enter chatter nickname..."
-                            aria-label="Chatter nickname"
-                        />
-                        <Button
-                            type="submit"
-                            variant="primary"
-                            disabled={!nickInput.trim()}
-                        >
-                            Search
-                        </Button>
-                    </Form>
-                </Card.Body>
-            </Card>
+                        Chatter nickname
+                    </label>
+                    <Form.Control
+                        id="footprint-nick-input"
+                        type="text"
+                        value={nickInput}
+                        onChange={event => setNickInput(event.target.value)}
+                        placeholder="Enter chatter nickname..."
+                        aria-label="Chatter nickname"
+                    />
+                </div>
+                <Button
+                    type="submit"
+                    variant="primary"
+                    disabled={!nickInput.trim()}
+                >
+                    <i
+                        className="bi bi-crosshair me-2"
+                        aria-hidden="true"></i>
+                    Trace
+                </Button>
+                {submittedNick && activity.length > 0 && !isLoading && (
+                    <span className="toolbar-readout">
+                        <strong>{activity.length}</strong> streams · target <strong>{submittedNick}</strong>
+                    </span>
+                )}
+            </Form>
 
             <Card>
-                <Card.Body>
+                <Card.Body className={!submittedNick || isNotFound || (chatterId && activity.length === 0 && !isLoading) ? 'p-0' : ''}>
                     {!submittedNick && (
-                        <p className="mb-0">Enter a chatter nickname to see every stream they appear in.</p>
+                        <div className="empty-state">
+                            <div
+                                className="empty-scope"
+                                aria-hidden="true" />
+                            <p className="empty-title">Awaiting target</p>
+                            <p className="empty-hint">
+                                Enter a chatter nickname to see every captured stream they appear in.
+                            </p>
+                        </div>
                     )}
 
                     {isLoading && (
                         <LoadingSpinner
                             size="lg"
-                            text="Loading chatter footprint..."
-                            card
+                            text="Tracing chatter footprint..."
                         />
                     )}
 
                     {isNotFound && !isLoading && (
-                        <p className="mb-0">No chatter found with the nickname <strong>{submittedNick}</strong>.</p>
+                        <div className="empty-state">
+                            <div
+                                className="empty-scope"
+                                aria-hidden="true" />
+                            <p className="empty-title">No signal</p>
+                            <p className="empty-hint">
+                                No chatter found with the nickname <strong>{submittedNick}</strong>.
+                            </p>
+                        </div>
                     )}
 
                     {chatterIdError && !isNotFound && !isLoading && (
@@ -144,10 +179,17 @@ const ChatterFootprint = () => {
                             aria-live="polite"
                         >
                             {activity.length === 0
-                                ? <p className="mb-0">This chatter has no recorded stream activity.</p>
+                                ? (
+                                    <div className="empty-state">
+                                        <div
+                                            className="empty-scope"
+                                            aria-hidden="true" />
+                                        <p className="empty-title">No activity</p>
+                                        <p className="empty-hint">This chatter has no recorded stream activity.</p>
+                                    </div>
+                                )
                                 : (
                                     <Table
-                                        striped
                                         hover
                                         responsive
                                     >
@@ -156,7 +198,9 @@ const ChatterFootprint = () => {
                                                 <th scope="col">Stream</th>
                                                 <th scope="col">Streamer</th>
                                                 <th scope="col">Started</th>
-                                                <th scope="col">Messages</th>
+                                                <th
+                                                    scope="col"
+                                                    className="text-end">Messages</th>
                                             </tr>
                                         </thead>
                                         <tbody>
@@ -168,8 +212,20 @@ const ChatterFootprint = () => {
                                                         </Link>
                                                     </td>
                                                     <td>{row[4]}</td>
-                                                    <td>{formatStreamTimestamp(row[2])}</td>
-                                                    <td>{row[5]?.toLocaleString()}</td>
+                                                    <td className="mono small">{formatStreamTimestamp(row[2])}</td>
+                                                    <td
+                                                        className="mono text-end"
+                                                        style={{ minWidth: '110px' }}>
+                                                        {row[5]?.toLocaleString()}
+                                                        <span
+                                                            className="data-bar"
+                                                            aria-hidden="true">
+                                                            <span
+                                                                className="data-bar-fill"
+                                                                style={{ width: `${Math.max(2, Math.round(((row[5] || 0) / maxMessages) * 100))}%` }}
+                                                            />
+                                                        </span>
+                                                    </td>
                                                 </tr>
                                             ))}
                                         </tbody>

--- a/frontend/views/Stream.jsx
+++ b/frontend/views/Stream.jsx
@@ -145,13 +145,27 @@ const Stream = ({ streamId }) => {
         }
 
         return(
-            <section aria-labelledby="other-creators-heading">
-                <h3 id="other-creators-heading">Other creators that wrote</h3>
-                <ul
+            <section
+                aria-labelledby="other-creators-heading"
+                className="mt-4">
+                <h3
+                    id="other-creators-heading"
+                    className="section-label mb-3">
+                    Other creators in chat
+                </h3>
+                <div
+                    className="d-flex flex-wrap gap-2"
                     role="list"
                     aria-label="Other creators who participated in this stream">
-                    {otherCreatorsThatWrote?.map(creator => <li key={creator[0]}>{creator[1]}</li>)}
-                </ul>
+                    {otherCreatorsThatWrote?.map(creator => (
+                        <span
+                            key={creator[0]}
+                            role="listitem"
+                            className="status-chip">
+                            {creator[1]}
+                        </span>
+                    ))}
+                </div>
             </section>
         )
     }, [

--- a/frontend/views/StreamerRegulars.jsx
+++ b/frontend/views/StreamerRegulars.jsx
@@ -4,7 +4,7 @@ import {
 } from 'react'
 import Select from 'react-select'
 import {
-    Card, Container, Row, Col, Table,
+    Card, Table,
 } from 'react-bootstrap'
 import {
     useCreators, useCreatorTopChatters,
@@ -49,6 +49,11 @@ const StreamerRegulars = () => {
         topChattersData,
     ])
 
+    // Max message count for relative magnitude bars
+    const maxMessages = useMemo(() => Math.max(1, ...topChatters.map(chatter => chatter[2] || 0)), [
+        topChatters,
+    ])
+
     /**
      * Handles creator selection change
      * @param {object} selectedOption
@@ -60,6 +65,13 @@ const StreamerRegulars = () => {
 
     return (
         <>
+            <div className="page-head">
+                <div>
+                    <h1 id="regulars-heading" className="page-title">Streamer regulars</h1>
+                    <p className="page-sub">Top {TOP_CHATTERS_LIMIT} chatters across all captured streams</p>
+                </div>
+            </div>
+
             {creatorsError && (
                 <ErrorAlert
                     error={creatorsError}
@@ -69,50 +81,58 @@ const StreamerRegulars = () => {
                 />
             )}
 
-            <Card className="mb-4">
-                <Card.Header>
-                    <h2 id="regulars-filter-heading" className="page-title fs-6 mb-0">Select creator</h2>
-                </Card.Header>
-                <Card.Body>
-                    <Container>
-                        <Row>
-                            <Col>
-                                <label
-                                    htmlFor="regulars-creator-select"
-                                    className="visually-hidden"
-                                >
-                                    Select a creator
-                                </label>
-                                <Select
-                                    instanceId="regulars-creator-select"
-                                    inputId="regulars-creator-select"
-                                    options={creators}
-                                    value={selectedCreator}
-                                    onChange={handleCreatorChange}
-                                    placeholder="Select creator..."
-                                    isClearable
-                                    aria-label="Select a creator to view their regulars"
-                                />
-                            </Col>
-                        </Row>
-                    </Container>
-                </Card.Body>
-            </Card>
+            <div
+                className="toolbar"
+                role="search"
+                aria-label="Creator selection">
+                <span
+                    className="toolbar-label"
+                    aria-hidden="true">
+                    Creator
+                </span>
+                <div className="toolbar-field">
+                    <label
+                        htmlFor="regulars-creator-select"
+                        className="visually-hidden"
+                    >
+                        Select a creator
+                    </label>
+                    <Select
+                        instanceId="regulars-creator-select"
+                        inputId="regulars-creator-select"
+                        options={creators}
+                        value={selectedCreator}
+                        onChange={handleCreatorChange}
+                        placeholder="Select creator..."
+                        isClearable
+                        aria-label="Select a creator to view their regulars"
+                    />
+                </div>
+                {selectedCreatorId && topChatters.length > 0 && !isLoading && (
+                    <span className="toolbar-readout">
+                        <strong>{topChatters.length}</strong> regulars
+                    </span>
+                )}
+            </div>
 
             <Card>
-                <Card.Header>
-                    <h1 id="regulars-heading" className="page-title mb-0">Streamer regulars</h1>
-                </Card.Header>
-                <Card.Body>
+                <Card.Body className={!selectedCreatorId || (selectedCreatorId && !isLoading && !error && topChatters.length === 0) ? 'p-0' : ''}>
                     {!selectedCreatorId && (
-                        <p className="mb-0">Select a creator to see their most active chatters across all streams.</p>
+                        <div className="empty-state">
+                            <div
+                                className="empty-scope"
+                                aria-hidden="true" />
+                            <p className="empty-title">No creator selected</p>
+                            <p className="empty-hint">
+                                Select a creator to see their most loyal chatters across all captured streams.
+                            </p>
+                        </div>
                     )}
 
                     {isLoading && (
                         <LoadingSpinner
                             size="lg"
                             text="Loading regulars..."
-                            card
                         />
                     )}
 
@@ -132,10 +152,17 @@ const StreamerRegulars = () => {
                             aria-live="polite"
                         >
                             {topChatters.length === 0
-                                ? <p className="mb-0">No chatters found for this creator.</p>
+                                ? (
+                                    <div className="empty-state">
+                                        <div
+                                            className="empty-scope"
+                                            aria-hidden="true" />
+                                        <p className="empty-title">No regulars found</p>
+                                        <p className="empty-hint">No chatters recorded for this creator yet.</p>
+                                    </div>
+                                )
                                 : (
                                     <Table
-                                        striped
                                         hover
                                         responsive
                                     >
@@ -143,15 +170,29 @@ const StreamerRegulars = () => {
                                             <tr>
                                                 <th scope="col">#</th>
                                                 <th scope="col">Chatter</th>
-                                                <th scope="col">Messages</th>
+                                                <th
+                                                    scope="col"
+                                                    className="text-end">Messages</th>
                                             </tr>
                                         </thead>
                                         <tbody>
                                             {topChatters.map((chatter, index) => (
                                                 <tr key={chatter[0]}>
-                                                    <td>{index + 1}</td>
+                                                    <td className="rank-num">{String(index + 1).padStart(2, '0')}</td>
                                                     <td>{chatter[1]}</td>
-                                                    <td>{chatter[2]?.toLocaleString()}</td>
+                                                    <td
+                                                        className="mono text-end"
+                                                        style={{ minWidth: '140px' }}>
+                                                        {chatter[2]?.toLocaleString()}
+                                                        <span
+                                                            className="data-bar"
+                                                            aria-hidden="true">
+                                                            <span
+                                                                className="data-bar-fill"
+                                                                style={{ width: `${Math.max(2, Math.round(((chatter[2] || 0) / maxMessages) * 100))}%` }}
+                                                            />
+                                                        </span>
+                                                    </td>
                                                 </tr>
                                             ))}
                                         </tbody>

--- a/frontend/views/UserMessages.jsx
+++ b/frontend/views/UserMessages.jsx
@@ -24,11 +24,6 @@ const UserMessages = () => {
         streamsData?.streams,
     ])
 
-    // Memoize streams count calculation
-    const streamsCount = useMemo(() => streams.length, [
-        streams.length,
-    ])
-
     if (isLoading) {
         return (
             <LoadingSpinner
@@ -51,21 +46,35 @@ const UserMessages = () => {
     }
 
     return (
-        <Card>
-            <Card.Header>
-                <h1 id="chatter-messages-heading">Chatter messages</h1>
-            </Card.Header>
-            <Card.Body>
-                <div
-                    role="status"
-                    aria-live="polite"
-                    aria-labelledby="chatter-messages-heading"
-                >
-                    <p>Found <strong>{streamsCount}</strong> streams</p>
-                    <p>TODO: Implement chatter message analysis functionality</p>
+        <>
+            <div className="page-head">
+                <div>
+                    <h1 id="chatter-messages-heading" className="page-title">Chatter messages</h1>
+                    <p className="page-sub">Cross-stream message analysis</p>
                 </div>
-            </Card.Body>
-        </Card>
+            </div>
+
+            <Card>
+                <Card.Body className="p-0">
+                    <div
+                        className="empty-state"
+                        role="status"
+                        aria-live="polite"
+                        aria-labelledby="chatter-messages-heading"
+                    >
+                        <div
+                            className="empty-scope"
+                            aria-hidden="true" />
+                        <p className="empty-title">Module under construction</p>
+                        <p className="empty-hint">
+                            Chatter message analysis is not wired up yet.
+                            {' '}{streams.length.toLocaleString()} streams are already captured and waiting —
+                            in the meantime, open a stream and use its chat replay.
+                        </p>
+                    </div>
+                </Card.Body>
+            </Card>
+        </>
     )
 }
 

--- a/frontend/views/admin/AdminDashboard.jsx
+++ b/frontend/views/admin/AdminDashboard.jsx
@@ -3,8 +3,9 @@ import {
     useState, useEffect, useCallback,
 } from 'react'
 import {
-    Container, Row, Col, Card, Alert, Spinner,
+    Row, Col, Card, Alert, Spinner,
 } from 'react-bootstrap'
+import Link from 'next/link'
 import { useAuth } from '@/contexts/AuthContext'
 import { api } from '@/lib/api'
 
@@ -47,24 +48,24 @@ const AdminDashboard = () => {
 
     if (loading) {
         return (
-            <Container
+            <div
                 className="d-flex justify-content-center align-items-center"
                 style={{ minHeight: '300px' }}>
                 <Spinner
                     animation="border"
                     variant="primary" />
-            </Container>
+            </div>
         )
     }
 
     return (
-        <Container>
-            <Row className="mb-4">
-                <Col>
-                    <h2>Admin Dashboard</h2>
-                    <p className="text-muted">Welcome back, {user?.username}!</p>
-                </Col>
-            </Row>
+        <>
+            <div className="page-head">
+                <div>
+                    <h1 className="page-title">Admin dashboard</h1>
+                    <p className="page-sub">Welcome back, {user?.username}</p>
+                </div>
+            </div>
 
             {error && (
                 <Alert
@@ -75,114 +76,102 @@ const AdminDashboard = () => {
             )}
 
             {stats && (
-                <Row className="mb-4">
-                    <Col md={3}>
-                        <Card className="text-center">
-                            <Card.Body>
-                                <Card.Title className="mono text-secondary fs-6 text-uppercase">Total Users</Card.Title>
-                                <Card.Text className="display-4">{stats.total_users}</Card.Text>
-                            </Card.Body>
-                        </Card>
-                    </Col>
-                    <Col md={3}>
-                        <Card className="text-center">
-                            <Card.Body>
-                                <Card.Title className="mono text-secondary fs-6 text-uppercase">Active Users</Card.Title>
-                                <Card.Text className="display-4">{stats.active_users}</Card.Text>
-                            </Card.Body>
-                        </Card>
-                    </Col>
-                    <Col md={3}>
-                        <Card className="text-center">
-                            <Card.Body>
-                                <Card.Title className="mono text-secondary fs-6 text-uppercase">Admin Users</Card.Title>
-                                <Card.Text className="display-4">{stats.admin_users}</Card.Text>
-                            </Card.Body>
-                        </Card>
-                    </Col>
-                    <Col md={3}>
-                        <Card className="text-center">
-                            <Card.Body>
-                                <Card.Title className="mono text-secondary fs-6 text-uppercase">Recent Registrations</Card.Title>
-                                <Card.Text className="display-4">{stats.recent_registrations}</Card.Text>
-                                <small className="text-muted">Last 24 hours</small>
-                            </Card.Body>
-                        </Card>
-                    </Col>
-                </Row>
+                <div className="stat-grid mb-4">
+                    <div className="stat-tile">
+                        <div className="stat-label">Total users</div>
+                        <div className="stat-value text-phosphor">{stats.total_users}</div>
+                    </div>
+                    <div className="stat-tile">
+                        <div className="stat-label">Active users</div>
+                        <div className="stat-value">{stats.active_users}</div>
+                    </div>
+                    <div className="stat-tile">
+                        <div className="stat-label">Admin users</div>
+                        <div className="stat-value">{stats.admin_users}</div>
+                    </div>
+                    <div className="stat-tile">
+                        <div className="stat-label">Recent registrations</div>
+                        <div className="stat-value">{stats.recent_registrations}</div>
+                        <div className="stat-hint">Last 24 hours</div>
+                    </div>
+                </div>
             )}
 
             <Row>
                 <Col md={6}>
-                    <Card>
-                        <Card.Header>
-                            <Card.Title>Quick Actions</Card.Title>
-                        </Card.Header>
+                    <Card className="mb-4">
                         <Card.Body>
+                            <h3 className="section-label mb-3">Quick actions</h3>
                             <div className="d-grid gap-2">
-                                <a
+                                <Link
                                     href="/admin/users"
                                     className="btn btn-primary">
-                                    <i className="bi bi-people me-2"></i>
+                                    <i
+                                        className="bi bi-people me-2"
+                                        aria-hidden="true" />
                                     Manage Users
-                                </a>
-                                <a
+                                </Link>
+                                <Link
                                     href="/admin/users/create"
                                     className="btn btn-outline-primary">
-                                    <i className="bi bi-person-plus me-2"></i>
+                                    <i
+                                        className="bi bi-person-plus me-2"
+                                        aria-hidden="true" />
                                     Create New User
-                                </a>
-                                <a
+                                </Link>
+                                <Link
                                     href="/admin/tracking"
                                     className="btn btn-outline-primary">
-                                    <i className="bi bi-broadcast me-2"></i>
+                                    <i
+                                        className="bi bi-broadcast me-2"
+                                        aria-hidden="true" />
                                     Stream Tracking
-                                </a>
-                                <a
+                                </Link>
+                                <Link
                                     href="/admin/system"
                                     className="btn btn-outline-primary">
-                                    <i className="bi bi-gear me-2"></i>
+                                    <i
+                                        className="bi bi-gear me-2"
+                                        aria-hidden="true" />
                                     System Information
-                                </a>
+                                </Link>
                             </div>
                         </Card.Body>
                     </Card>
                 </Col>
                 <Col md={6}>
-                    <Card>
-                        <Card.Header>
-                            <Card.Title>System Status</Card.Title>
-                        </Card.Header>
+                    <Card className="mb-4">
                         <Card.Body>
+                            <h3 className="section-label mb-3">System status</h3>
                             <div className="mb-3">
-                                <div className="d-flex justify-content-between">
+                                <div className="d-flex justify-content-between align-items-center">
                                     <span>Database</span>
-                                    <span className="badge bg-success">Online</span>
+                                    <span className="status-chip is-ok">Online</span>
                                 </div>
                             </div>
                             <div className="mb-3">
-                                <div className="d-flex justify-content-between">
+                                <div className="d-flex justify-content-between align-items-center">
                                     <span>API</span>
-                                    <span className="badge bg-success">Healthy</span>
+                                    <span className="status-chip is-ok">Healthy</span>
                                 </div>
                             </div>
                             <div className="mb-3">
-                                <div className="d-flex justify-content-between">
+                                <div className="d-flex justify-content-between align-items-center">
                                     <span>Cache</span>
-                                    <span className="badge bg-success">Active</span>
+                                    <span className="status-chip is-ok">Active</span>
                                 </div>
                             </div>
                             <div className="mb-3">
-                                <div className="d-flex justify-content-between">
+                                <div className="d-flex justify-content-between align-items-center">
                                     <span>User Activity</span>
-                                    <span className="badge bg-success">Normal</span>
+                                    <span className="status-chip is-ok">Normal</span>
                                 </div>
                             </div>
                         </Card.Body>
                     </Card>
                 </Col>
             </Row>
-        </Container>
+        </>
     )
 }
 

--- a/frontend/views/admin/CreateUser.jsx
+++ b/frontend/views/admin/CreateUser.jsx
@@ -126,15 +126,19 @@ const CreateUser = () => {
 
     return (
         <Container>
-            <Row className="justify-content-center">
+            <div className="page-head">
+                <div>
+                    <h1 className="page-title">Create user</h1>
+                    <p className="page-sub">Provision a new account</p>
+                </div>
+            </div>
+            <Row>
                 <Col
-                    md={8}
-                    lg={6}>
+                    lg={8}
+                    className="mx-auto">
                     <Card>
-                        <Card.Header>
-                            <h3 className="mb-0">Create New User</h3>
-                        </Card.Header>
                         <Card.Body>
+                            <h3 className="section-label mb-3">Account details</h3>
                             {error && (
                                 <Alert
                                     variant="danger"
@@ -251,11 +255,16 @@ const CreateUser = () => {
                                                 Creating User...
                                             </>
                                         ) : (
-                                            'Create User'
+                                            <>
+                                                <i
+                                                    className="bi bi-person-plus me-2"
+                                                    aria-hidden="true" />
+                                                Create user
+                                            </>
                                         )}
                                     </Button>
                                     <Button
-                                        variant="secondary"
+                                        variant="outline-primary"
                                         onClick={() => router.push('/admin/users')}
                                         disabled={loading}
                                     >

--- a/frontend/views/admin/ProcessingJobs.jsx
+++ b/frontend/views/admin/ProcessingJobs.jsx
@@ -3,107 +3,98 @@ import {
     useState, useEffect, useCallback,
 } from 'react'
 import {
-    Container, Row, Col, Card, Table, Alert, Spinner, Badge, Form, Pagination,
+    Card, Table, Alert, Spinner, Form, Pagination,
 } from 'react-bootstrap'
 import { api } from '@/lib/api'
 
 /**
- * Statistics Cards Component
+ * Statistics Tiles Component
  */
 const StatisticsCards = ({ stats }) => (
-    <Row className="mb-4">
-        <Col md={2}>
-            <Card className="text-center">
-                <Card.Body>
-                    <Card.Title className="text-primary">Total</Card.Title>
-                    <Card.Text className="display-6">{stats.total || 0}</Card.Text>
-                </Card.Body>
-            </Card>
-        </Col>
-        <Col md={2}>
-            <Card className="text-center">
-                <Card.Body>
-                    <Card.Title className="text-secondary">Pending</Card.Title>
-                    <Card.Text className="display-6">{stats.pending || 0}</Card.Text>
-                </Card.Body>
-            </Card>
-        </Col>
-        <Col md={2}>
-            <Card className="text-center">
-                <Card.Body>
-                    <Card.Title className="text-primary">In Progress</Card.Title>
-                    <Card.Text className="display-6">{stats.in_progress || 0}</Card.Text>
-                </Card.Body>
-            </Card>
-        </Col>
-        <Col md={2}>
-            <Card className="text-center">
-                <Card.Body>
-                    <Card.Title className="text-success">Completed</Card.Title>
-                    <Card.Text className="display-6">{stats.completed || 0}</Card.Text>
-                </Card.Body>
-            </Card>
-        </Col>
-        <Col md={2}>
-            <Card className="text-center">
-                <Card.Body>
-                    <Card.Title className="text-danger">Failed</Card.Title>
-                    <Card.Text className="display-6">{stats.failed || 0}</Card.Text>
-                </Card.Body>
-            </Card>
-        </Col>
-        <Col md={2}>
-            <Card className="text-center">
-                <Card.Body>
-                    <Card.Title className="text-info">Recent 24h</Card.Title>
-                    <Card.Text className="display-6">{stats.recent_24h || 0}</Card.Text>
-                </Card.Body>
-            </Card>
-        </Col>
-    </Row>
+    <div className="stat-grid">
+        <div className="stat-tile">
+            <div className="stat-label">Total</div>
+            <div className="stat-value">{stats.total || 0}</div>
+        </div>
+        <div className="stat-tile">
+            <div className="stat-label">Pending</div>
+            <div className="stat-value">{stats.pending || 0}</div>
+        </div>
+        <div className="stat-tile">
+            <div className="stat-label">In Progress</div>
+            <div className="stat-value">{stats.in_progress || 0}</div>
+        </div>
+        <div className="stat-tile">
+            <div className="stat-label">Completed</div>
+            <div className="stat-value">{stats.completed || 0}</div>
+        </div>
+        <div className="stat-tile">
+            <div className="stat-label">Failed</div>
+            <div className="stat-value">{stats.failed || 0}</div>
+        </div>
+        <div className="stat-tile">
+            <div className="stat-label">Recent 24h</div>
+            <div className="stat-value">{stats.recent_24h || 0}</div>
+        </div>
+    </div>
 )
 
 /**
- * Filters Component
+ * Filters Toolbar Component
  */
 const JobFilters = ({
-    filters, setFilters,
+    filters, setFilters, total,
 }) => (
-    <Card>
-        <Card.Body>
-            <h5>Filters</h5>
-            <Form>
-                <Form.Group className="mb-3">
-                    <Form.Label>Status</Form.Label>
-                    <Form.Select
-                        value={filters.status}
-                        onChange={e => setFilters(prev => ({
-                            ...prev,
-                            status: e.target.value,
-                        }))}
-                    >
-                        <option value="">All</option>
-                        <option value="pending">Pending</option>
-                        <option value="in_progress">In Progress</option>
-                        <option value="completed">Completed</option>
-                        <option value="failed">Failed</option>
-                    </Form.Select>
-                </Form.Group>
-                <Form.Group className="mb-3">
-                    <Form.Label>Streamer ID</Form.Label>
-                    <Form.Control
-                        type="number"
-                        value={filters.tracked_streamer_id}
-                        onChange={e => setFilters(prev => ({
-                            ...prev,
-                            tracked_streamer_id: e.target.value,
-                        }))}
-                        placeholder="Filter by streamer ID"
-                    />
-                </Form.Group>
-            </Form>
-        </Card.Body>
-    </Card>
+    <div className="toolbar">
+        <span
+            className="toolbar-label"
+            aria-hidden="true">
+            Filter
+        </span>
+        <div className="toolbar-field">
+            <label
+                htmlFor="jobs-status-filter"
+                className="visually-hidden"
+            >
+                Filter by status
+            </label>
+            <Form.Select
+                id="jobs-status-filter"
+                value={filters.status}
+                onChange={e => setFilters(prev => ({
+                    ...prev,
+                    status: e.target.value,
+                }))}
+            >
+                <option value="">All statuses</option>
+                <option value="pending">Pending</option>
+                <option value="in_progress">In Progress</option>
+                <option value="completed">Completed</option>
+                <option value="failed">Failed</option>
+            </Form.Select>
+        </div>
+        <div className="toolbar-field">
+            <label
+                htmlFor="jobs-streamer-filter"
+                className="visually-hidden"
+            >
+                Filter by streamer ID
+            </label>
+            <Form.Control
+                id="jobs-streamer-filter"
+                type="number"
+                value={filters.tracked_streamer_id}
+                onChange={e => setFilters(prev => ({
+                    ...prev,
+                    tracked_streamer_id: e.target.value,
+                }))}
+                placeholder="Filter by streamer ID"
+            />
+        </div>
+        <span className="toolbar-readout">
+            {total} jobs
+        </span>
+    </div>
 )
 
 const ProcessingJobs = () => {
@@ -220,26 +211,30 @@ const ProcessingJobs = () => {
         return `${duration}s`
     }
 
-    const getStatusBadge = status => {
-        const variants = {
-            'pending': 'secondary',
-            'in_progress': 'primary',
-            'completed': 'success',
-            'failed': 'danger',
+    const getStatusChip = status => {
+        const modifiers = {
+            'pending': ' is-warn',
+            'in_progress': ' is-warn',
+            'completed': ' is-ok',
+            'failed': ' is-err',
         }
-        return <Badge bg={variants[status] || 'secondary'}>{status}</Badge>
+        return (
+            <span className={`status-chip${modifiers[status] || ''}`}>
+                {status === 'in_progress' ? 'in progress' : status}
+            </span>
+        )
     }
 
     const totalPages = Math.ceil(pagination.total / pagination.limit)
 
     return (
-        <Container fluid>
-            <Row className="mb-4">
-                <Col>
-                    <h2>Processing Jobs</h2>
-                    <p className="text-muted">Monitor stream processing jobs and their status</p>
-                </Col>
-            </Row>
+        <>
+            <div className="page-head">
+                <div>
+                    <h1 className="page-title">Processing jobs</h1>
+                    <p className="page-sub">Stream processing queue and outcomes</p>
+                </div>
+            </div>
 
             {error && (
                 <Alert
@@ -253,118 +248,122 @@ const ProcessingJobs = () => {
 
             <StatisticsCards stats={stats} />
 
-            <Row>
-                <Col md={3}>
-                    <JobFilters
-                        filters={filters}
-                        setFilters={setFilters} />
-                </Col>
-                <Col md={9}>
-                    <Card>
-                        <Card.Header>
-                            <Card.Title>Processing Jobs ({pagination.total})</Card.Title>
-                        </Card.Header>
-                        <Card.Body>
-                            {loading ? (
-                                <div className="text-center">
-                                    <Spinner
-                                        animation="border"
-                                        variant="primary" />
-                                </div>
-                            ) : jobs.length === 0 ? (
-                                <Alert variant="info">No processing jobs found</Alert>
-                            ) : (
-                                <>
-                                    <Table
-                                        striped
-                                        bordered
-                                        hover
-                                        responsive>
-                                        <thead>
-                                            <tr>
-                                                <th>ID</th>
-                                                <th>Streamer</th>
-                                                <th>Stream ID</th>
-                                                <th>Status</th>
-                                                <th>Created</th>
-                                                <th>Started</th>
-                                                <th>Completed</th>
-                                                <th>Duration</th>
-                                                <th>Retries</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {jobs.map(job => (
-                                                <tr key={job.id}>
-                                                    <td>{job.id}</td>
-                                                    <td>
-                                                        <strong>{job.twitch_username}</strong>
-                                                        {job.streamer_display_name && (
-                                                            <small className="text-muted d-block">
-                                                                {job.streamer_display_name}
-                                                            </small>
-                                                        )}
-                                                    </td>
-                                                    <td>{job.twitch_stream_id}</td>
-                                                    <td>{getStatusBadge(job.status)}</td>
-                                                    <td>{formatDateTime(job.created_at)}</td>
-                                                    <td>{formatDateTime(job.started_at)}</td>
-                                                    <td>{formatDateTime(job.completed_at)}</td>
-                                                    <td>{getDuration(job.started_at, job.completed_at)}</td>
-                                                    <td>
-                                                        {job.retry_count > 0 && (
-                                                            <Badge bg="warning">{job.retry_count}</Badge>
-                                                        )}
-                                                    </td>
-                                                </tr>
-                                            ))}
-                                        </tbody>
-                                    </Table>
+            <JobFilters
+                filters={filters}
+                setFilters={setFilters}
+                total={pagination.total} />
 
-                                    {totalPages > 1 && (
-                                        <Pagination className="justify-content-center">
-                                            <Pagination.First
-                                                onClick={() => handlePageChange(1)}
-                                                disabled={pagination.currentPage === 1}
-                                            />
-                                            <Pagination.Prev
-                                                onClick={() => handlePageChange(pagination.currentPage - 1)}
-                                                disabled={pagination.currentPage === 1}
-                                            />
-                                            {[
-                                                ...Array(Math.min(5, totalPages)),
-                                            ].map((_, i) => {
-                                                const page = Math.max(1, pagination.currentPage - 2) + i
-                                                if (page <= totalPages) {
-                                                    return (
-                                                        <Pagination.Item
-                                                            key={page}
-                                                            active={page === pagination.currentPage}
-                                                            onClick={() => handlePageChange(page)}
-                                                        >
-                                                            {page}
-                                                        </Pagination.Item>
-                                                    )
-                                                }
-                                                return null
-                                            })}
-                                            <Pagination.Next
-                                                onClick={() => handlePageChange(pagination.currentPage + 1)}
-                                                disabled={pagination.currentPage === totalPages}
-                                            />
-                                            <Pagination.Last
-                                                onClick={() => handlePageChange(totalPages)}
-                                                disabled={pagination.currentPage === totalPages}
-                                            />
-                                        </Pagination>
-                                    )}
-                                </>
-                            )}
-                        </Card.Body>
-                    </Card>
-                </Col>
-            </Row>
-        </Container>
+            <Card>
+                <Card.Body className={!loading && jobs.length === 0 ? 'p-0' : ''}>
+                    {loading ? (
+                        <div className="text-center py-5">
+                            <Spinner
+                                animation="border"
+                                variant="primary" />
+                        </div>
+                    ) : jobs.length === 0 ? (
+                        <div className="empty-state">
+                            <div
+                                className="empty-scope"
+                                aria-hidden="true" />
+                            <p className="empty-title">No processing jobs</p>
+                            <p className="empty-hint">
+                                No jobs match this filter. Jobs appear here once tracked streamers have streams queued for processing.
+                            </p>
+                        </div>
+                    ) : (
+                        <>
+                            <Table
+                                hover
+                                responsive>
+                                <thead>
+                                    <tr>
+                                        <th>ID</th>
+                                        <th>Streamer</th>
+                                        <th>Stream ID</th>
+                                        <th>Status</th>
+                                        <th>Created</th>
+                                        <th>Started</th>
+                                        <th>Completed</th>
+                                        <th>Duration</th>
+                                        <th>Retries</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {jobs.map(job => (
+                                        <tr key={job.id}>
+                                            <td className="mono">{job.id}</td>
+                                            <td>
+                                                <strong>{job.twitch_username}</strong>
+                                                {job.streamer_display_name && (
+                                                    <small className="text-muted d-block">
+                                                        {job.streamer_display_name}
+                                                    </small>
+                                                )}
+                                            </td>
+                                            <td className="mono">{job.twitch_stream_id}</td>
+                                            <td>{getStatusChip(job.status)}</td>
+                                            <td className="mono">{formatDateTime(job.created_at)}</td>
+                                            <td className="mono">{formatDateTime(job.started_at)}</td>
+                                            <td className="mono">{formatDateTime(job.completed_at)}</td>
+                                            <td className="mono">{getDuration(job.started_at, job.completed_at)}</td>
+                                            <td className="mono">
+                                                {job.retry_count > 0 && (
+                                                    <span className="status-chip is-warn">{job.retry_count}</span>
+                                                )}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+
+                            <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mt-3">
+                                <span className="mono small text-muted">
+                                    Showing {jobs.length} of {pagination.total}
+                                </span>
+                                {totalPages > 1 && (
+                                    <Pagination className="mb-0">
+                                        <Pagination.First
+                                            onClick={() => handlePageChange(1)}
+                                            disabled={pagination.currentPage === 1}
+                                        />
+                                        <Pagination.Prev
+                                            onClick={() => handlePageChange(pagination.currentPage - 1)}
+                                            disabled={pagination.currentPage === 1}
+                                        />
+                                        {[
+                                            ...Array(Math.min(5, totalPages)),
+                                        ].map((_, i) => {
+                                            const page = Math.max(1, pagination.currentPage - 2) + i
+                                            if (page <= totalPages) {
+                                                return (
+                                                    <Pagination.Item
+                                                        key={page}
+                                                        active={page === pagination.currentPage}
+                                                        onClick={() => handlePageChange(page)}
+                                                    >
+                                                        {page}
+                                                    </Pagination.Item>
+                                                )
+                                            }
+                                            return null
+                                        })}
+                                        <Pagination.Next
+                                            onClick={() => handlePageChange(pagination.currentPage + 1)}
+                                            disabled={pagination.currentPage === totalPages}
+                                        />
+                                        <Pagination.Last
+                                            onClick={() => handlePageChange(totalPages)}
+                                            disabled={pagination.currentPage === totalPages}
+                                        />
+                                    </Pagination>
+                                )}
+                            </div>
+                        </>
+                    )}
+                </Card.Body>
+            </Card>
+        </>
     )
 }
 

--- a/frontend/views/admin/StreamerTracking.jsx
+++ b/frontend/views/admin/StreamerTracking.jsx
@@ -3,7 +3,7 @@ import {
     useState, useEffect, useCallback,
 } from 'react'
 import {
-    Container, Row, Col, Card, Table, Button, Alert, Spinner, Badge, Modal, Form, Pagination,
+    Card, Table, Button, Alert, Spinner, Modal, Form, Pagination,
 } from 'react-bootstrap'
 import { api } from '@/lib/api'
 
@@ -29,6 +29,10 @@ const StreamerTracking = () => {
         showAddModal,
         setShowAddModal,
     ] = useState(false)
+    const [
+        removeTarget,
+        setRemoveTarget,
+    ] = useState(null)
     const [
         pagination,
         setPagination,
@@ -151,11 +155,7 @@ const StreamerTracking = () => {
         }
     }
 
-    const handleRemoveStreamer = async (streamerId, username) => {
-        if (!window.confirm(`Are you sure you want to remove ${username} from tracking?`)) {
-            return
-        }
-
+    const handleRemoveStreamer = async streamerId => {
         try {
             await api.delete(`/admin/tracking/streamers/${streamerId}`)
             setSuccess('Streamer removed successfully')
@@ -163,6 +163,8 @@ const StreamerTracking = () => {
         } catch (removeError) {
             console.error('Error removing streamer:', removeError)
             setError(removeError.response?.data?.detail || removeError.message || 'Failed to remove streamer')
+        } finally {
+            setRemoveTarget(null)
         }
     }
 
@@ -181,34 +183,36 @@ const StreamerTracking = () => {
         return new Date(dateString).toLocaleString()
     }
 
-    const getStatusBadge = isActive => isActive ?
-        <Badge bg="success">Active</Badge> :
-        <Badge bg="secondary">Inactive</Badge>
+    const getStatusChip = isActive => isActive ?
+        <span className="status-chip is-ok">Active</span> :
+        <span className="status-chip is-err">Inactive</span>
 
-    const getProcessingBadge = isEnabled => isEnabled ?
-        <Badge bg="primary">Enabled</Badge> :
-        <Badge bg="warning">Disabled</Badge>
+    const getProcessingChip = isEnabled => isEnabled ?
+        <span className="status-chip is-ok">Enabled</span> :
+        <span className="status-chip is-warn">Disabled</span>
 
     const totalPages = Math.ceil(pagination.total / pagination.limit)
 
     return (
-        <Container fluid>
-            <Row className="mb-4">
-                <Col>
-                    <h2>Streamer Tracking</h2>
-                    <p className="text-muted">Manage automated tracking of Twitch streamers</p>
-                </Col>
-                <Col xs="auto">
+        <>
+            <div className="page-head">
+                <div>
+                    <h1 className="page-title">Streamer tracking</h1>
+                    <p className="page-sub">Automated VOD collection targets</p>
+                </div>
+                <div className="page-actions">
                     <Button
                         variant="primary"
                         onClick={() => setShowAddModal(true)}
                         disabled={loading}
                     >
-                        <i className="bi bi-plus-circle me-2"></i>
-                        Add Streamer
+                        <i
+                            className="bi bi-plus-circle me-2"
+                            aria-hidden="true" />
+                        Add streamer
                     </Button>
-                </Col>
-            </Row>
+                </div>
+            </div>
 
             {error && (
                 <Alert
@@ -230,160 +234,178 @@ const StreamerTracking = () => {
                 </Alert>
             )}
 
-            <Row className="mb-4">
-                <Col md={4}>
-                    <Card>
-                        <Card.Body>
-                            <h5>Filters</h5>
-                            <Form>
-                                <Form.Group className="mb-3">
-                                    <Form.Label>Status</Form.Label>
-                                    <Form.Select
-                                        value={filters.is_active === null ? '' : filters.is_active.toString()}
-                                        onChange={e => setFilters(prev => ({
-                                            ...prev,
-                                            is_active: e.target.value === '' ? null : e.target.value === 'true',
-                                        }))}
-                                    >
-                                        <option value="">All</option>
-                                        <option value="true">Active</option>
-                                        <option value="false">Inactive</option>
-                                    </Form.Select>
-                                </Form.Group>
-                                <Form.Group className="mb-3">
-                                    <Form.Label>Processing</Form.Label>
-                                    <Form.Select
-                                        value={filters.processing_enabled === null ? '' : filters.processing_enabled.toString()}
-                                        onChange={e => setFilters(prev => ({
-                                            ...prev,
-                                            processing_enabled: e.target.value === '' ? null : e.target.value === 'true',
-                                        }))}
-                                    >
-                                        <option value="">All</option>
-                                        <option value="true">Enabled</option>
-                                        <option value="false">Disabled</option>
-                                    </Form.Select>
-                                </Form.Group>
-                            </Form>
-                        </Card.Body>
-                    </Card>
-                </Col>
-                <Col md={8}>
-                    <Card>
-                        <Card.Header>
-                            <Card.Title>Tracked Streamers ({pagination.total})</Card.Title>
-                        </Card.Header>
-                        <Card.Body>
-                            {loading ? (
-                                <div className="text-center">
-                                    <Spinner
-                                        animation="border"
-                                        variant="primary" />
-                                </div>
-                            ) : streamers.length === 0 ? (
-                                <Alert variant="info">No streamers found</Alert>
-                            ) : (
-                                <>
-                                    <Table
-                                        striped
-                                        bordered
-                                        hover
-                                        responsive>
-                                        <thead>
-                                            <tr>
-                                                <th>Username</th>
-                                                <th>Display Name</th>
-                                                <th>Status</th>
-                                                <th>Processing</th>
-                                                <th>Last Check</th>
-                                                <th>Created</th>
-                                                <th>Actions</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {streamers.map(streamer => (
-                                                <tr key={streamer.id}>
-                                                    <td>
-                                                        <strong>{streamer.twitch_username}</strong>
-                                                    </td>
-                                                    <td>{streamer.display_name}</td>
-                                                    <td>{getStatusBadge(streamer.is_active)}</td>
-                                                    <td>{getProcessingBadge(streamer.processing_enabled)}</td>
-                                                    <td>{formatDateTime(streamer.last_stream_check)}</td>
-                                                    <td>{formatDateTime(streamer.created_at)}</td>
-                                                    <td>
-                                                        <Button
-                                                            variant={streamer.is_active ? 'warning' : 'success'}
-                                                            size="sm"
-                                                            className="me-2"
-                                                            onClick={() => handleToggleActive(streamer.id, streamer.is_active)}
-                                                        >
-                                                            {streamer.is_active ? 'Deactivate' : 'Activate'}
-                                                        </Button>
-                                                        <Button
-                                                            variant={streamer.processing_enabled ? 'secondary' : 'primary'}
-                                                            size="sm"
-                                                            className="me-2"
-                                                            onClick={() => handleToggleProcessing(streamer.id, streamer.processing_enabled)}
-                                                        >
-                                                            {streamer.processing_enabled ? 'Disable' : 'Enable'}
-                                                        </Button>
-                                                        <Button
-                                                            variant="danger"
-                                                            size="sm"
-                                                            onClick={() => handleRemoveStreamer(streamer.id, streamer.twitch_username)}
-                                                        >
-                                                            Remove
-                                                        </Button>
-                                                    </td>
-                                                </tr>
-                                            ))}
-                                        </tbody>
-                                    </Table>
+            <div className="toolbar">
+                <span
+                    className="toolbar-label"
+                    aria-hidden="true">
+                    Filter
+                </span>
+                <div className="toolbar-field">
+                    <label
+                        htmlFor="tracking-status-filter"
+                        className="visually-hidden"
+                    >
+                        Filter by status
+                    </label>
+                    <Form.Select
+                        id="tracking-status-filter"
+                        value={filters.is_active === null ? '' : filters.is_active.toString()}
+                        onChange={e => setFilters(prev => ({
+                            ...prev,
+                            is_active: e.target.value === '' ? null : e.target.value === 'true',
+                        }))}
+                    >
+                        <option value="">All statuses</option>
+                        <option value="true">Active</option>
+                        <option value="false">Inactive</option>
+                    </Form.Select>
+                </div>
+                <div className="toolbar-field">
+                    <label
+                        htmlFor="tracking-processing-filter"
+                        className="visually-hidden"
+                    >
+                        Filter by processing
+                    </label>
+                    <Form.Select
+                        id="tracking-processing-filter"
+                        value={filters.processing_enabled === null ? '' : filters.processing_enabled.toString()}
+                        onChange={e => setFilters(prev => ({
+                            ...prev,
+                            processing_enabled: e.target.value === '' ? null : e.target.value === 'true',
+                        }))}
+                    >
+                        <option value="">All processing</option>
+                        <option value="true">Processing enabled</option>
+                        <option value="false">Processing disabled</option>
+                    </Form.Select>
+                </div>
+                <span className="toolbar-readout">
+                    {pagination.total} tracked
+                </span>
+            </div>
 
-                                    {totalPages > 1 && (
-                                        <Pagination className="justify-content-center">
-                                            <Pagination.First
-                                                onClick={() => handlePageChange(1)}
-                                                disabled={pagination.currentPage === 1}
-                                            />
-                                            <Pagination.Prev
-                                                onClick={() => handlePageChange(pagination.currentPage - 1)}
-                                                disabled={pagination.currentPage === 1}
-                                            />
-                                            {[
-                                                ...Array(Math.min(5, totalPages)),
-                                            ].map((_, i) => {
-                                                const page = Math.max(1, pagination.currentPage - 2) + i
-                                                if (page <= totalPages) {
-                                                    return (
-                                                        <Pagination.Item
-                                                            key={page}
-                                                            active={page === pagination.currentPage}
-                                                            onClick={() => handlePageChange(page)}
-                                                        >
-                                                            {page}
-                                                        </Pagination.Item>
-                                                    )
-                                                }
-                                                return null
-                                            })}
-                                            <Pagination.Next
-                                                onClick={() => handlePageChange(pagination.currentPage + 1)}
-                                                disabled={pagination.currentPage === totalPages}
-                                            />
-                                            <Pagination.Last
-                                                onClick={() => handlePageChange(totalPages)}
-                                                disabled={pagination.currentPage === totalPages}
-                                            />
-                                        </Pagination>
-                                    )}
-                                </>
-                            )}
-                        </Card.Body>
-                    </Card>
-                </Col>
-            </Row>
+            <Card>
+                <Card.Body className={!loading && streamers.length === 0 ? 'p-0' : ''}>
+                    {loading ? (
+                        <div className="text-center py-5">
+                            <Spinner
+                                animation="border"
+                                variant="primary" />
+                        </div>
+                    ) : streamers.length === 0 ? (
+                        <div className="empty-state">
+                            <div
+                                className="empty-scope"
+                                aria-hidden="true" />
+                            <p className="empty-title">No tracked streamers</p>
+                            <p className="empty-hint">
+                                No streamers match this filter. Add a streamer to start automated VOD collection.
+                            </p>
+                        </div>
+                    ) : (
+                        <>
+                            <Table
+                                hover
+                                responsive>
+                                <thead>
+                                    <tr>
+                                        <th>Username</th>
+                                        <th>Display Name</th>
+                                        <th>Status</th>
+                                        <th>Processing</th>
+                                        <th>Last Check</th>
+                                        <th>Created</th>
+                                        <th>Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {streamers.map(streamer => (
+                                        <tr key={streamer.id}>
+                                            <td>
+                                                <strong>{streamer.twitch_username}</strong>
+                                            </td>
+                                            <td>{streamer.display_name}</td>
+                                            <td>{getStatusChip(streamer.is_active)}</td>
+                                            <td>{getProcessingChip(streamer.processing_enabled)}</td>
+                                            <td className="mono">{formatDateTime(streamer.last_stream_check)}</td>
+                                            <td className="mono">{formatDateTime(streamer.created_at)}</td>
+                                            <td>
+                                                <Button
+                                                    variant="outline-primary"
+                                                    size="sm"
+                                                    className="me-2"
+                                                    onClick={() => handleToggleActive(streamer.id, streamer.is_active)}
+                                                >
+                                                    {streamer.is_active ? 'Deactivate' : 'Activate'}
+                                                </Button>
+                                                <Button
+                                                    variant="outline-primary"
+                                                    size="sm"
+                                                    className="me-2"
+                                                    onClick={() => handleToggleProcessing(streamer.id, streamer.processing_enabled)}
+                                                >
+                                                    {streamer.processing_enabled ? 'Disable' : 'Enable'}
+                                                </Button>
+                                                <Button
+                                                    variant="outline-danger"
+                                                    size="sm"
+                                                    onClick={() => setRemoveTarget(streamer)}
+                                                >
+                                                    Remove
+                                                </Button>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+
+                            <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mt-3">
+                                <span className="mono small text-muted">
+                                    Showing {streamers.length} of {pagination.total}
+                                </span>
+                                {totalPages > 1 && (
+                                    <Pagination className="mb-0">
+                                        <Pagination.First
+                                            onClick={() => handlePageChange(1)}
+                                            disabled={pagination.currentPage === 1}
+                                        />
+                                        <Pagination.Prev
+                                            onClick={() => handlePageChange(pagination.currentPage - 1)}
+                                            disabled={pagination.currentPage === 1}
+                                        />
+                                        {[
+                                            ...Array(Math.min(5, totalPages)),
+                                        ].map((_, i) => {
+                                            const page = Math.max(1, pagination.currentPage - 2) + i
+                                            if (page <= totalPages) {
+                                                return (
+                                                    <Pagination.Item
+                                                        key={page}
+                                                        active={page === pagination.currentPage}
+                                                        onClick={() => handlePageChange(page)}
+                                                    >
+                                                        {page}
+                                                    </Pagination.Item>
+                                                )
+                                            }
+                                            return null
+                                        })}
+                                        <Pagination.Next
+                                            onClick={() => handlePageChange(pagination.currentPage + 1)}
+                                            disabled={pagination.currentPage === totalPages}
+                                        />
+                                        <Pagination.Last
+                                            onClick={() => handlePageChange(totalPages)}
+                                            disabled={pagination.currentPage === totalPages}
+                                        />
+                                    </Pagination>
+                                )}
+                            </div>
+                        </>
+                    )}
+                </Card.Body>
+            </Card>
 
             {/* Add Streamer Modal */}
             <Modal
@@ -445,7 +467,7 @@ const StreamerTracking = () => {
                     </Modal.Body>
                     <Modal.Footer>
                         <Button
-                            variant="secondary"
+                            variant="outline-primary"
                             onClick={() => setShowAddModal(false)}>
                             Cancel
                         </Button>
@@ -468,7 +490,33 @@ const StreamerTracking = () => {
                     </Modal.Footer>
                 </Form>
             </Modal>
-        </Container>
+
+            {/* Remove Streamer Confirmation Modal */}
+            <Modal
+                show={removeTarget !== null}
+                onHide={() => setRemoveTarget(null)}>
+                <Modal.Header closeButton>
+                    <Modal.Title>Remove streamer</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    Are you sure you want to remove{' '}
+                    <strong>{removeTarget?.twitch_username}</strong>{' '}
+                    from tracking?
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button
+                        variant="outline-primary"
+                        onClick={() => setRemoveTarget(null)}>
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="outline-danger"
+                        onClick={() => handleRemoveStreamer(removeTarget?.id)}>
+                        Remove
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        </>
     )
 }
 

--- a/frontend/views/admin/SystemInfo.jsx
+++ b/frontend/views/admin/SystemInfo.jsx
@@ -4,11 +4,8 @@ import {
 } from 'react'
 import {
     Container,
-    Row,
-    Col,
     Alert,
     Spinner,
-    Badge,
     Button,
 } from 'react-bootstrap'
 import SystemHealthOverview from '@/components/admin/SystemHealthOverview'
@@ -39,6 +36,10 @@ const SystemInfo = () => {
     const [
         error,
         setError,
+    ] = useState(null)
+    const [
+        success,
+        setSuccess,
     ] = useState(null)
 
     const fetchSystemInfo = useCallback(async () => {
@@ -93,23 +94,29 @@ const SystemInfo = () => {
 
     const getStatusBadge = status => {
         const statusMap = {
-            'healthy': 'success',
-            'degraded': 'warning',
-            'unhealthy': 'danger',
-            'critical': 'danger',
+            'healthy': 'is-ok',
+            'degraded': 'is-warn',
+            'unhealthy': 'is-err',
+            'critical': 'is-err',
         }
-        return <Badge bg={statusMap[status] || 'secondary'}>{status}</Badge>
+        const modifier = statusMap[status]
+        return (
+            <span className={modifier ? `status-chip ${modifier}` : 'status-chip'}>
+                {status}
+            </span>
+        )
     }
 
     const flushCache = async () => {
+        setError(null)
+        setSuccess(null)
         try {
             await api.post('/cache/flush')
-            alert('Cache flushed successfully')
+            setSuccess('Cache flushed successfully')
             fetchSystemInfo()
         } catch (flushError) {
             console.error('Error flushing cache:', flushError)
             setError(flushError.response?.data?.detail || flushError.message || 'Error flushing cache')
-            alert('Error flushing cache: ' + (flushError.response?.data?.detail || flushError.message))
         }
     }
 
@@ -127,27 +134,55 @@ const SystemInfo = () => {
 
     return (
         <Container>
-            <Row className="mb-4">
-                <Col>
-                    <h2>System Information</h2>
-                    <p className="text-muted">System health, performance metrics, and monitoring data</p>
-                </Col>
-                <Col xs="auto">
+            <div className="page-head">
+                <div>
+                    <h1 className="page-title">System information</h1>
+                    <p className="page-sub">Health · metrics · monitoring</p>
+                </div>
+                <div className="page-actions">
                     <Button
                         variant="outline-primary"
                         onClick={fetchSystemInfo}>
                         <i className="bi bi-arrow-clockwise me-2"></i>
                         Refresh
                     </Button>
-                </Col>
-            </Row>
+                </div>
+            </div>
 
             {error && (
                 <Alert
                     variant="danger"
-                    className="mb-4">
+                    className="mb-4"
+                    dismissible
+                    onClose={() => setError(null)}>
                     {error}
                 </Alert>
+            )}
+
+            {success && (
+                <Alert
+                    variant="success"
+                    className="mb-4"
+                    dismissible
+                    onClose={() => setSuccess(null)}>
+                    {success}
+                </Alert>
+            )}
+
+            {!healthData && !metricsData && !cacheStats && (
+                <div className="card">
+                    <div className="empty-state">
+                        <div
+                            className="empty-scope"
+                            aria-hidden="true" />
+                        <p className="empty-title">Telemetry offline</p>
+                        <p className="empty-hint">
+                            None of the monitoring endpoints responded (health, metrics, cache).
+                            The API may be up while its metrics backend is down — try Refresh, and
+                            check the api container logs if this persists.
+                        </p>
+                    </div>
+                </div>
             )}
 
             {healthData && (

--- a/frontend/views/admin/TrackingDashboard.jsx
+++ b/frontend/views/admin/TrackingDashboard.jsx
@@ -3,7 +3,7 @@ import {
     useState, useEffect, useCallback,
 } from 'react'
 import {
-    Container, Row, Col, Alert, Spinner, Badge,
+    Container, Row, Col, Alert, Spinner,
 } from 'react-bootstrap'
 import SystemStatusCard from '@/components/admin/SystemStatusCard'
 import TrackedStreamersCard from '@/components/admin/TrackedStreamersCard'
@@ -51,12 +51,12 @@ const TrackingDashboard = () => {
     ])
 
     const getHealthBadge = isHealthy => isHealthy ?
-        <Badge bg="success">Healthy</Badge> :
-        <Badge bg="danger">Unhealthy</Badge>
+        <span className="status-chip is-ok">Healthy</span> :
+        <span className="status-chip is-err">Unhealthy</span>
 
     const getStatusBadge = isActive => isActive ?
-        <Badge bg="success">Active</Badge> :
-        <Badge bg="secondary">Inactive</Badge>
+        <span className="status-chip is-ok">Active</span> :
+        <span className="status-chip">Inactive</span>
 
     const calculateSuccessRate = (completed, total) => {
         if (total === 0) {
@@ -79,15 +79,17 @@ const TrackingDashboard = () => {
 
     return (
         <Container fluid>
-            <Row className="mb-4">
-                <Col>
-                    <h2>Tracking Dashboard</h2>
-                    <p className="text-muted">
-                        Overview of automated stream tracking and processing system
-                        {stats && <small className="ms-2">Last updated: {new Date().toLocaleTimeString()}</small>}
-                    </p>
-                </Col>
-            </Row>
+            <div className="page-head">
+                <div>
+                    <h1 className="page-title">Tracking dashboard</h1>
+                    <p className="page-sub">Automated stream tracking · processing system</p>
+                </div>
+                {stats && (
+                    <div className="page-actions">
+                        <span className="mono small text-muted">Last updated: {new Date().toLocaleTimeString()}</span>
+                    </div>
+                )}
+            </div>
 
             {error && (
                 <Alert

--- a/frontend/views/admin/UserManagement.jsx
+++ b/frontend/views/admin/UserManagement.jsx
@@ -4,8 +4,6 @@ import {
 } from 'react'
 import {
     Container,
-    Row,
-    Col,
     Card,
     Button,
     Alert,
@@ -164,20 +162,22 @@ const UserManagement = () => {
 
     return (
         <Container>
-            <Row className="mb-4">
-                <Col>
-                    <h2>User Management</h2>
-                    <p className="text-muted">Manage user accounts and permissions</p>
-                </Col>
-                <Col xs="auto">
+            <div className="page-head">
+                <div>
+                    <h1 className="page-title">User management</h1>
+                    <p className="page-sub">Accounts &amp; permissions</p>
+                </div>
+                <div className="page-actions">
                     <Button
-                        variant="success"
+                        variant="primary"
                         href="/admin/users/create">
-                        <i className="bi bi-person-plus me-2"></i>
-                        Create New User
+                        <i
+                            className="bi bi-person-plus me-2"
+                            aria-hidden="true" />
+                        Create user
                     </Button>
-                </Col>
-            </Row>
+                </div>
+            </div>
 
             {error && (
                 <Alert
@@ -198,16 +198,21 @@ const UserManagement = () => {
             )}
 
             <Card>
-                <Card.Header className="d-flex justify-content-between align-items-center">
-                    <h5 className="mb-0">Users ({totalUsers})</h5>
-                    <Button
-                        variant="outline-primary"
-                        size="sm"
-                        onClick={fetchUsers}>
-                        <i className="bi bi-arrow-clockwise"></i> Refresh
-                    </Button>
-                </Card.Header>
                 <Card.Body>
+                    <div className="d-flex justify-content-between align-items-center mb-3">
+                        <h3 className="section-label mb-0">
+                            Users <span className="mono">({totalUsers})</span>
+                        </h3>
+                        <Button
+                            variant="outline-primary"
+                            size="sm"
+                            onClick={fetchUsers}>
+                            <i
+                                className="bi bi-arrow-clockwise me-2"
+                                aria-hidden="true" />
+                            Refresh
+                        </Button>
+                    </div>
                     <UserManagementTable
                         users={users}
                         authenticatedUser={authenticatedUser}
@@ -219,7 +224,7 @@ const UserManagement = () => {
                 </Card.Body>
                 <Card.Footer>
                     <div className="d-flex justify-content-between align-items-center">
-                        <span>
+                        <span className="mono small text-muted">
                             Showing {((currentPage - 1) * usersPerPage) + 1} to {Math.min(currentPage * usersPerPage, totalUsers)} of {totalUsers} users
                         </span>
                         {renderPagination(currentPage, totalPages, setCurrentPage)}

--- a/frontend/views/auth/Login.jsx
+++ b/frontend/views/auth/Login.jsx
@@ -4,12 +4,13 @@ import {
     useState, useEffect,
 } from 'react'
 import {
-    Container, Row, Col, Alert,
+    Alert,
 } from 'react-bootstrap'
 import {
     useRouter, useSearchParams,
 } from 'next/navigation'
 import { useAuth } from '@/contexts/AuthContext'
+import Logo from '@/components/layout/Logo'
 import LoginForm from '@/components/auth/LoginForm'
 import RegisterForm from '@/components/auth/RegisterForm'
 
@@ -69,40 +70,34 @@ const Login = () => {
     }
 
     return (
-        <Container className="mt-5">
-            <Row className="justify-content-center">
-                <Col
-                    md={6}
-                    lg={5}>
-                    <div className="text-center mb-4">
-                        <h2 className="text-primary">Stream Sniper</h2>
-                        <p className="text-muted">
-                            {showRegister ? 'Create your account' : 'Sign in to your account'}
-                        </p>
-                    </div>
+        <div className="auth-screen">
+            <div className="auth-panel">
+                <div className="auth-brand">
+                    <Logo />
+                    <span className="auth-tagline">Twitch chat intelligence</span>
+                </div>
 
-                    {successMessage && (
-                        <Alert
-                            variant="success"
-                            className="mb-3">
-                            {successMessage}
-                        </Alert>
-                    )}
+                {successMessage && (
+                    <Alert
+                        variant="success"
+                        className="mb-3">
+                        {successMessage}
+                    </Alert>
+                )}
 
-                    {showRegister ? (
-                        <RegisterForm
-                            onSwitchToLogin={handleSwitchToLogin}
-                            onSuccess={handleSuccess}
-                        />
-                    ) : (
-                        <LoginForm
-                            onSwitchToRegister={handleSwitchToRegister}
-                            onSuccess={handleSuccess}
-                        />
-                    )}
-                </Col>
-            </Row>
-        </Container>
+                {showRegister ? (
+                    <RegisterForm
+                        onSwitchToLogin={handleSwitchToLogin}
+                        onSuccess={handleSuccess}
+                    />
+                ) : (
+                    <LoginForm
+                        onSwitchToRegister={handleSwitchToRegister}
+                        onSuccess={handleSuccess}
+                    />
+                )}
+            </div>
+        </div>
     )
 }
 

--- a/frontend/views/auth/Profile.jsx
+++ b/frontend/views/auth/Profile.jsx
@@ -6,7 +6,13 @@ import {
 import UserProfile from '@/components/auth/UserProfile'
 
 const Profile = () => (
-    <Container className="mt-4">
+    <Container className="p-0">
+        <div className="page-head">
+            <div>
+                <h1 className="page-title">Operator profile</h1>
+                <p className="page-sub">Account &amp; credentials</p>
+            </div>
+        </div>
         <Row>
             <Col
                 lg={8}


### PR DESCRIPTION
## Summary
- Executes the night-ops (phosphor-on-dark, signal-intelligence console) design language across every page — the theme previously existed only in CSS variables while markup stayed vanilla Bootstrap
- New design system primitives: page headers, stat tiles, status chips, mono tables, ranked leaderboards with magnitude bars, empty states, skeleton loaders, HUD corner brackets, chat replay panel, staggered reveals
- Rewrites the legacy light-theme `_accessibility.scss` that was actively breaking the dark theme (blue focus rings, dark-blue links, light alert boxes)
- Perf: chatter search caps rendered react-select options at 100 (was ~10k DOM nodes → now filters in ~22ms), chat replay virtualized with react-virtuoso, NO FEED fallback for broken VOD thumbnails
- Mobile: overlay sidebar with tap-to-close backdrop, responsive toolbars/tables/titles
- Admin: all seven views re-skinned; `window.alert`/`confirm` replaced with alert state + confirm modal; telemetry-offline empty state on System page

## Test plan
- [x] `next build`, `tsc --noEmit`, `eslint .` — 0 errors
- [x] Verified in browser (next-browser) against prod data: login/auth flow, streams grid, stream detail + chat replay (711 msgs, 9.7k chatter select), regulars, footprint trace, chatter-messages, all admin pages
- [x] Mobile viewport (390×844): home, sidebar overlay, tables

https://claude.ai/code/session_01VRpQqskpuLYdt185y6XrE1