### PR TITLE
Fix collector truncation/OOM, chatter-messages endpoint, and red CI workflows

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -10,14 +10,17 @@ queries:
     uses: security-extended
 
 paths-ignore:
-  - "venv/**"
+  - "**/venv/**"
   - "**/__pycache__/**"
-  - "logs/**"
+  - "**/logs/**"
   - "*.log"
-  - "tests/fixtures/**"
+  - "backend/tests/fixtures/**"
 
+# The Python package lives under backend/, not the repo root — a bare
+# "stream_sniper/**" filter matches nothing and CodeQL fails with
+# "could not process any of it".
 paths:
-  - "stream_sniper/**"
+  - "backend/stream_sniper/**"
 
 packs:
   python:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,12 +77,14 @@ jobs:
     - name: Test Docker image
       if: github.event_name != 'pull_request'
       run: |
+        # Docker references must be lowercase; github.repository is "SlanyCukr/…"
+        image="${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}-${{ matrix.image }}:latest"
         if [ "${{ matrix.image }}" = "api" ]; then
           # server entry point starts uvicorn; smoke-test via an import with a
           # dummy JWT secret (the app fail-fasts without one) instead of --help
-          docker run --rm -e JWT_SECRET_KEY=ci-test-secret ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.image }}:latest python -c "import stream_sniper.api.api; print('API image import OK')"
+          docker run --rm -e JWT_SECRET_KEY=ci-test-secret "$image" python -c "import stream_sniper.api.api; print('API image import OK')"
         else
-          docker run --rm ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.image }}:latest --help
+          docker run --rm "$image" --help
         fi
 
   security-scan:
@@ -95,10 +97,15 @@ jobs:
         image: [api, collector]
 
     steps:
+    - name: Compute lowercase image reference
+      id: image
+      # Docker references must be lowercase; github.repository is "SlanyCukr/…"
+      run: echo "ref=${{ env.REGISTRY }}/${GITHUB_REPOSITORY,,}-${{ matrix.image }}:latest" >> "$GITHUB_OUTPUT"
+
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
       with:
-        image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.image }}:latest
+        image-ref: ${{ steps.image.outputs.ref }}
         format: 'sarif'
         output: 'trivy-results-${{ matrix.image }}.sarif'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -83,11 +83,13 @@ jobs:
         pip install bandit[toml] semgrep
 
     - name: Run Bandit
+      working-directory: backend
       run: |
         bandit -r stream_sniper/ -f json -o bandit-report.json || true
         bandit -r stream_sniper/ || true
 
     - name: Run Semgrep
+      working-directory: backend
       run: |
         python -m semgrep --config=auto stream_sniper/ --json --output=semgrep-report.json || true
         python -m semgrep --config=auto stream_sniper/ || true
@@ -97,7 +99,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: bandit-report
-        path: bandit-report.json
+        path: backend/bandit-report.json
         retention-days: 30
 
     - name: Upload Semgrep report
@@ -105,7 +107,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: semgrep-report
-        path: semgrep-report.json
+        path: backend/semgrep-report.json
         retention-days: 30
 
   codeql:
@@ -155,13 +157,30 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Run TruffleHog OSS
+    # base/head must differ per event: hardcoding base=main head=HEAD makes
+    # them identical on pushes to main and TruffleHog hard-fails.
+    - name: Run TruffleHog OSS (push — scan pushed commits)
+      if: github.event_name == 'push'
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
-        base: main
-        head: HEAD
-        extra_args: --debug --only-verified
+        base: ${{ github.event.before }}
+        head: ${{ github.sha }}
+        extra_args: --only-verified
+
+    - name: Run TruffleHog OSS (PR — scan branch diff)
+      if: github.event_name == 'pull_request'
+      uses: trufflesecurity/trufflehog@main
+      with:
+        path: ./
+        extra_args: --only-verified
+
+    - name: Run TruffleHog OSS (scheduled — full history scan)
+      if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      uses: trufflesecurity/trufflehog@main
+      with:
+        path: ./
+        extra_args: --only-verified
 
   docker-security:
     name: Docker Security Scan

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ pyvenv.cfg
 pip-selfcheck.json
 
 testing.py
+# Backend runtime logs (logger fallback during local runs)
+backend/logs/

--- a/backend/stream_sniper/collector/irc_chat_downloader.py
+++ b/backend/stream_sniper/collector/irc_chat_downloader.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Tuple, Union
+from typing import Any, Iterator, Optional, Tuple
 
 from chat_downloader import ChatDownloader
 
@@ -25,7 +25,14 @@ class IrcChatDownloader:
 
     def download_chat(
         self,
-    ) -> Union[Tuple[None, None, None, None, None, None], Tuple[List[dict], str, str, str, str, str]]:
+    ) -> Tuple[Optional[Iterator[dict]], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]]:
+        """Return a lazy chat iterator + VOD metadata for the next unprocessed video.
+
+        The chat is NOT materialized here — a full VOD from a large streamer can
+        be millions of messages, which OOMs the RPI. The caller iterates (and
+        batches) the messages instead. Returns an all-None tuple when no
+        unprocessed videos remain.
+        """
         while True:
             # no available videos
             if len(self.available_video_ids) == 0:
@@ -42,10 +49,14 @@ class IrcChatDownloader:
             self.logger.info(f"Downloading chat for video with ID {video_id}")
 
             try:
+                # Note: message_receive_timeout is deliberately NOT set — it
+                # only applies to live IRC sockets, never the VOD GQL path
+                # this collector uses (an earlier 0.01 value here was a red
+                # herring while chasing truncated captures; the real fix is
+                # the null-comments retry in twitch_gql_patch).
                 chat = self.downloader.get_chat(
                     f"https://www.twitch.tv/videos/{video_id}",
                     format="json",
-                    message_receive_timeout=0.01,
                     buffer_size=16384,
                     # The collector runs in a worker thread inside a container:
                     # chat_downloader's default interactive retry prompt uses
@@ -53,15 +64,12 @@ class IrcChatDownloader:
                     # the main thread. Fall back to plain back-off retries.
                     interruptible_retry=False,
                 )
-                chat_iterated = [x for x in chat]
-
-                self.logger.info(f"Chat downloaded successfully. Found {len(chat_iterated)} messages")
             except Exception as e:
-                self.logger.error(f"Failed to download chat for video {video_id}: {e}", exc_info=True)
+                self.logger.error(f"Failed to start chat download for video {video_id}: {e}", exc_info=True)
                 continue
 
             returned_tuple = (
-                chat_iterated,
+                iter(chat),
                 currently_processed_video.id,
                 currently_processed_video.created_at,
                 currently_processed_video.title,

--- a/backend/stream_sniper/collector/twitch_collector_facade.py
+++ b/backend/stream_sniper/collector/twitch_collector_facade.py
@@ -1,4 +1,5 @@
 import asyncio
+from itertools import batched
 from typing import Optional
 
 from ..database.chatter_table_gateway import insert_new_chatters_db, select_all_chatters_db
@@ -17,6 +18,13 @@ from .twitch_api import TwitchAPI
 
 class CreatorCreationError(Exception):
     """Raised when a creator cannot be created in the database."""
+
+
+# Messages processed per batch. A full VOD from a large streamer can be
+# millions of messages; materializing them all OOMs the RPI, so the chat
+# iterator is consumed in chunks (~1-2 KB per parsed message → tens of MB
+# peak per batch).
+CHAT_BATCH_SIZE = 20_000
 
 
 class TwitchCollectorFacade:
@@ -56,7 +64,7 @@ class TwitchCollectorFacade:
                     self.chat_downloader.download_chat()
                 )
 
-                if not chat:
+                if chat is None:
                     self.logger.debug("No more videos to process. Exiting...")
                     break
 
@@ -67,23 +75,34 @@ class TwitchCollectorFacade:
                     twitch_stream_id, started_at, self.creator_id, title, duration, thumbnail_url
                 )
 
-                # process nicks
-                nicks = self.chat_processor.get_nicks(chat)
-                insert_new_chatters_db(nicks)
-                known_chatters = select_all_chatters_db()
-                self.message_handler.set_known_chatters(known_chatters)
-                self.logger.debug(f"Processed {len(nicks)} unique nicknames")
+                # Consume the chat iterator in batches instead of materializing
+                # the whole VOD (OOM risk on the RPI for multi-hour streams).
+                num_of_messages = 0
+                for batch in batched(chat, CHAT_BATCH_SIZE, strict=False):
+                    chat_batch = list(batch)
 
-                # process messages
-                messages = self.chat_processor.get_messages(chat)
-                insert_message_texts_db(messages)
-                known_messages = select_all_message_texts_db()
-                self.message_handler.set_known_messages(known_messages)
-                self.logger.debug(f"Processed {len(messages)} unique messages")
+                    # process nicks
+                    nicks = self.chat_processor.get_nicks(chat_batch)
+                    insert_new_chatters_db(nicks)
+                    known_chatters = select_all_chatters_db()
+                    self.message_handler.set_known_chatters(known_chatters)
+                    self.logger.debug(f"Processed {len(nicks)} unique nicknames")
 
-                # process the messages in fetched chat
-                self.chat_processor.process_chat(chat, stream_id)
-                num_of_messages = len(chat)
+                    # process messages
+                    messages = self.chat_processor.get_messages(chat_batch)
+                    insert_message_texts_db(messages)
+                    known_messages = select_all_message_texts_db()
+                    self.message_handler.set_known_messages(known_messages)
+                    self.logger.debug(f"Processed {len(messages)} unique messages")
+
+                    # process the messages in fetched chat
+                    self.chat_processor.process_chat(chat_batch, stream_id)
+                    num_of_messages += len(chat_batch)
+                    self.logger.info(
+                        f"Processed batch of {len(chat_batch)} messages for stream {twitch_stream_id} "
+                        f"({num_of_messages} total so far)"
+                    )
+
                 self.logger.info(f"Processed {num_of_messages} chat messages for stream {twitch_stream_id}")
 
                 # add number of messages to stream

--- a/backend/stream_sniper/collector/twitch_gql_patch.py
+++ b/backend/stream_sniper/collector/twitch_gql_patch.py
@@ -1,6 +1,7 @@
 """
-Runtime patch for chat_downloader's Twitch VOD chat download.
+Runtime patches for chat_downloader's Twitch VOD chat download.
 
+Patch 1 — de-registered persisted query:
 chat_downloader 0.2.8 (unmaintained) fetches Twitch data via Automatic
 Persisted Queries, sending only a hardcoded ``sha256Hash`` per GraphQL
 operation. Twitch has since de-registered the ``VideoMetadata`` hash, so the
@@ -12,10 +13,26 @@ Every other operation the VOD path uses (``VideoCommentsByOffsetOrCursor``,
 the full GraphQL query text instead of a persisted-query hash. Sending the query
 body is hash-independent and won't break again when Twitch rotates hashes.
 
-Importing this module applies the patch once (idempotent).
+Patch 2 — silent mid-VOD truncation:
+``_get_chat_messages_by_vod_id`` paginates comments and does
+``if not comments: break`` — so a single transient GQL response with
+``data.video.comments = null`` (rate-limit shaping, server hiccup) silently
+ends the download mid-VOD. Observed in production as wildly different message
+counts for the same VOD across runs (117,115 vs 41,566). We retry
+``VideoCommentsByOffsetOrCursor`` responses whose ``comments`` is falsy with
+backoff before letting the library see them; genuinely chat-less VODs still
+terminate (after the short retry budget).
+
+Importing this module applies the patches once (idempotent).
 """
 
+import time
+
 from chat_downloader.sites.twitch import TwitchChatDownloader
+
+from ..logging_config import get_logger
+
+_logger = get_logger(__name__)
 
 # chat_downloader only reads title, lengthSeconds and owner.login from the
 # VideoMetadata response (see TwitchChatDownloader.get_chat_by_vod_id).
@@ -25,6 +42,21 @@ _VIDEO_METADATA_QUERY = (
 )
 
 _PATCH_FLAG = "_stream_sniper_gql_patched"
+
+# Retry budget for comment pages that come back without a comments object.
+_NULL_COMMENTS_RETRIES = 4
+_NULL_COMMENTS_BACKOFF_BASE = 1.5  # seconds; grows 1.5, 3, 6, 12
+
+
+def _comments_missing(response, ops):
+    """True if a VideoCommentsByOffsetOrCursor response lacks the comments object."""
+    if not any(op.get("operationName") == "VideoCommentsByOffsetOrCursor" for op in ops):
+        return False
+    try:
+        video = response[0]["data"]["video"]
+    except (KeyError, IndexError, TypeError):
+        return True
+    return not video or not video.get("comments")
 
 
 def _patched_download_gql(self, ops):
@@ -41,7 +73,26 @@ def _patched_download_gql(self, ops):
                     "sha256Hash": self._OPERATION_HASHES[op["operationName"]],
                 }
             }
-    return self._download_base_gql(ops)
+
+    response = self._download_base_gql(ops)
+
+    # Patch 2: a falsy comments object ends the library's pagination loop, so
+    # a transient degraded response truncates the whole download. Retry before
+    # handing it back; if it is still empty after the budget, the VOD really
+    # has no (more) chat and the normal termination path applies.
+    retry = 0
+    while _comments_missing(response, ops) and retry < _NULL_COMMENTS_RETRIES:
+        delay = _NULL_COMMENTS_BACKOFF_BASE * (2**retry)
+        retry += 1
+        _logger.warning(
+            f"VideoCommentsByOffsetOrCursor returned no comments object "
+            f"(attempt {retry}/{_NULL_COMMENTS_RETRIES}); retrying in {delay:.1f}s "
+            f"to avoid silent mid-VOD truncation"
+        )
+        time.sleep(delay)
+        response = self._download_base_gql(ops)
+
+    return response
 
 
 def apply_patch():

--- a/backend/stream_sniper/database/message_table_gateway.py
+++ b/backend/stream_sniper/database/message_table_gateway.py
@@ -7,7 +7,7 @@ def select_chatter_messages_db(chatter_id, cursor):
     return cursor.fetchall()
 
 
-def insert_message_db(items: [tuple], cursor, connection):
+def insert_message_db(items: list[tuple], cursor, connection):
     cursor.executemany(
         "INSERT INTO "
         "message "

--- a/backend/stream_sniper/database/message_table_gateway.py
+++ b/backend/stream_sniper/database/message_table_gateway.py
@@ -3,7 +3,17 @@ from .decorators import with_cursor
 
 @with_cursor
 def select_chatter_messages_db(chatter_id, cursor):
-    cursor.execute("SELECT message, time FROM message WHERE chatter_id = %s", (chatter_id,))
+    # NOTE: the message table has no "message" column — selecting one used to
+    # silently resolve to the whole-row composite. Join message_text for the
+    # actual text and format time as a string for the JSON response model.
+    cursor.execute(
+        """
+        SELECT (SELECT text FROM message_text WHERE id = message.message_text_id),
+               TO_CHAR(time, 'YYYY-MM-DD HH24:MI:SS')
+        FROM message WHERE chatter_id = %s ORDER BY time
+        """,
+        (chatter_id,),
+    )
     return cursor.fetchall()
 
 

--- a/backend/stream_sniper/tracking/processing_queue.py
+++ b/backend/stream_sniper/tracking/processing_queue.py
@@ -24,6 +24,10 @@ class ProcessingQueue:
     """
     
     def __init__(self, max_concurrent_jobs: int = 3, max_retries: int = 3):
+        if max_concurrent_jobs < 1:
+            raise ValueError("max_concurrent_jobs must be at least 1")
+        if max_retries < 0:
+            raise ValueError("max_retries must not be negative")
         self.max_concurrent_jobs = max_concurrent_jobs
         self.max_retries = max_retries
         self.logger = get_logger(__name__)

--- a/backend/tests/integration/test_api_workflows.py
+++ b/backend/tests/integration/test_api_workflows.py
@@ -77,7 +77,7 @@ class TestAPIWorkflowIntegration:
 
             db_cursor.execute(
                 """
-                INSERT INTO message (chatter_id, stream_id, message_text_id, timestamp, tagged_chatter_id)
+                INSERT INTO message (chatter_id, stream_id, message_text_id, time, tagged_chatter_id)
                 VALUES (%s, %s, %s, %s, %s)
             """,
                 (chatter_id, stream_id, text_id, datetime.now(), tagged_chatter_id),
@@ -103,15 +103,16 @@ class TestAPIWorkflowIntegration:
         assert "max_offset" in data
         assert len(data["streams"]) >= 1
 
-        # Find our test stream
+        # Find our test stream — rows are
+        # (id, display_name, start, end, thumbnail_url, message_count)
         test_stream = None
         for stream in data["streams"]:
-            if stream[1] == stream_data["title"]:  # title field
+            if stream[0] == stream_id:
                 test_stream = stream
                 break
 
         assert test_stream is not None
-        assert test_stream[0] == stream_id  # stream ID
+        assert test_stream[1] == creator_data["display_name"]
 
         # 3. Test GET /stream/{stream_id}/ comprehensive analytics
         response = api_client_with_db.get(f"/stream/{stream_id}/")
@@ -131,9 +132,10 @@ class TestAPIWorkflowIntegration:
         assert csi[5] == creator_data["nick"]  # creator nick
         assert csi[6] == creator_data["display_name"]  # creator display name
 
-        # Verify chatters count
+        # Verify chatters in stream — cis is a list of (chatter_id, nick) rows
         cis = analytics["cis"]
-        assert cis[0][0] == len(chatters)  # number of unique chatters
+        assert len(cis) == len(chatters)
+        assert sorted(row[1] for row in cis) == sorted(chatters)
 
         # 4. Test GET /stream/{stream_id}/chatters
         response = api_client_with_db.get(f"/stream/{stream_id}/chatters")
@@ -283,7 +285,7 @@ class TestAPIWorkflowIntegration:
         # Create message
         db_cursor.execute(
             """
-            INSERT INTO message (chatter_id, stream_id, message_text_id, timestamp)
+            INSERT INTO message (chatter_id, stream_id, message_text_id, time)
             VALUES (%s, %s, %s, %s)
         """,
             (chatter_id, stream_id, text_id, datetime.now()),
@@ -408,7 +410,7 @@ class TestAPIWorkflowIntegration:
         # Create message
         db_cursor.execute(
             """
-            INSERT INTO message (chatter_id, stream_id, message_text_id, timestamp)
+            INSERT INTO message (chatter_id, stream_id, message_text_id, time)
             VALUES (%s, %s, %s, %s)
         """,
             (chatter_id, stream_id, text_id, datetime.now()),

--- a/backend/tests/integration/test_database_operations.py
+++ b/backend/tests/integration/test_database_operations.py
@@ -10,6 +10,7 @@ Tests the complete database workflow including:
 
 from datetime import datetime
 
+import psycopg2.errors
 import pytest
 
 from tests.conftest import create_test_chatter, create_test_creator, create_test_message_text, create_test_stream
@@ -59,7 +60,7 @@ class TestDatabaseIntegration:
         for i, (chatter_id, text_id) in enumerate(zip(chatter_ids, message_text_ids)):
             db_cursor.execute(
                 """
-                INSERT INTO message (chatter_id, stream_id, message_text_id, timestamp)
+                INSERT INTO message (chatter_id, stream_id, message_text_id, time)
                 VALUES (%s, %s, %s, %s)
                 RETURNING id
             """,
@@ -126,7 +127,7 @@ class TestDatabaseIntegration:
         with pytest.raises(Exception):  # Should raise foreign key constraint error
             db_cursor.execute(
                 """
-                INSERT INTO message (chatter_id, stream_id, message_text_id, timestamp)
+                INSERT INTO message (chatter_id, stream_id, message_text_id, time)
                 VALUES (%s, %s, %s, %s)
             """,
                 (999, 1, 1, datetime.now()),
@@ -137,7 +138,7 @@ class TestDatabaseIntegration:
         with pytest.raises(Exception):  # Should raise foreign key constraint error
             db_cursor.execute(
                 """
-                INSERT INTO message (chatter_id, stream_id, message_text_id, timestamp)
+                INSERT INTO message (chatter_id, stream_id, message_text_id, time)
                 VALUES (%s, %s, %s, %s)
             """,
                 (chatter_id, 999, 1, datetime.now()),
@@ -189,7 +190,7 @@ class TestDatabaseIntegration:
         # Create message
         db_cursor.execute(
             """
-            INSERT INTO message (chatter_id, stream_id, message_text_id, timestamp)
+            INSERT INTO message (chatter_id, stream_id, message_text_id, time)
             VALUES (%s, %s, %s, %s)
             RETURNING id
         """,
@@ -201,13 +202,14 @@ class TestDatabaseIntegration:
         db_cursor.execute("SELECT COUNT(*) FROM message WHERE id = %s", (message_id,))
         assert db_cursor.fetchone()[0] == 1
 
-        # Delete chatter - should affect message
-        db_cursor.execute("DELETE FROM chatter WHERE id = %s", (chatter_id,))
+        # Delete chatter — the schema declares plain FKs (no ON DELETE
+        # CASCADE), so deleting a chatter still referenced by messages must
+        # be rejected and the message must survive.
+        with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+            db_cursor.execute("DELETE FROM chatter WHERE id = %s", (chatter_id,))
 
-        # Check if message still exists (depends on cascade settings)
         db_cursor.execute("SELECT COUNT(*) FROM message WHERE id = %s", (message_id,))
-        message_count = db_cursor.fetchone()[0]
-        # This test verifies the current cascade behavior
+        assert db_cursor.fetchone()[0] == 1
 
     def test_data_consistency_across_tables(self, db_cursor):
         """Test data consistency across related tables."""
@@ -223,7 +225,7 @@ class TestDatabaseIntegration:
 
             db_cursor.execute(
                 """
-                INSERT INTO message (chatter_id, stream_id, message_text_id, timestamp)
+                INSERT INTO message (chatter_id, stream_id, message_text_id, time)
                 VALUES (%s, %s, %s, %s)
             """,
                 (chatter_id, stream_id, text_id, datetime.now()),
@@ -256,11 +258,11 @@ class TestDatabaseIntegration:
             # Create some data
             cursor.execute(
                 """
-                INSERT INTO creator (nick, display_name, twitch_id)
-                VALUES (%s, %s, %s)
+                INSERT INTO creator (nick, display_name, profile_image_url, twitch_id)
+                VALUES (%s, %s, %s, %s)
                 RETURNING id
             """,
-                ("rollback_test", "Rollback Test", "123"),
+                ("rollback_test", "Rollback Test", "https://example.com/profile.jpg", "123"),
             )
             creator_id = cursor.fetchone()[0]
 
@@ -276,6 +278,10 @@ class TestDatabaseIntegration:
             assert cursor.fetchone()[0] == 0
 
         finally:
+            # Clear any (possibly aborted) transaction before restoring autocommit;
+            # toggling autocommit inside an open transaction raises ProgrammingError
+            # and would leave the shared session connection wedged for later tests.
+            test_db_connection.rollback()
             test_db_connection.autocommit = True
             cursor.close()
 
@@ -325,7 +331,7 @@ class TestDatabaseIntegration:
                 text_id = create_test_message_text(db_cursor, f"Message from {chatter_id} in {stream_id}")
                 db_cursor.execute(
                     """
-                    INSERT INTO message (chatter_id, stream_id, message_text_id, timestamp)
+                    INSERT INTO message (chatter_id, stream_id, message_text_id, time)
                     VALUES (%s, %s, %s, %s)
                 """,
                     (chatter_id, stream_id, text_id, datetime.now()),
@@ -391,7 +397,7 @@ class TestDatabaseIntegration:
 
             db_cursor.execute(
                 """
-                INSERT INTO message (chatter_id, stream_id, message_text_id, timestamp)
+                INSERT INTO message (chatter_id, stream_id, message_text_id, time)
                 VALUES (%s, %s, %s, %s)
             """,
                 (chatter_id, stream_id, text_id, datetime.now()),

--- a/backend/tests/integration/test_tracking_system.py
+++ b/backend/tests/integration/test_tracking_system.py
@@ -2,7 +2,7 @@
 Integration tests for the tracking system.
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -20,7 +20,15 @@ class TestTrackingSystem:
         with patch('stream_sniper.tracking.stream_monitor.TwitchAPI') as mock_api:
             mock_instance = Mock()
             mock_api.return_value = mock_instance
-            mock_instance.twitch_api_init = Mock()
+            # Async TwitchAPI methods must be AsyncMocks so `await` works
+            mock_instance.twitch_api_init = AsyncMock()
+            mock_instance.get_stream_info_async = AsyncMock(return_value=None)
+            mock_instance.get_available_video_ids_async = AsyncMock(return_value=[])
+            mock_instance.get_creator_info_async = AsyncMock(
+                return_value=("TestStreamer", "http://example.com/avatar.jpg")
+            )
+            mock_instance.get_creator_twitch_id_async = AsyncMock(return_value="123456789")
+            # Sync wrappers
             mock_instance.set_streamer_nickname = Mock()
             mock_instance.get_stream_info = Mock()
             mock_instance.get_available_video_ids = Mock()
@@ -31,9 +39,9 @@ class TestTrackingSystem:
     @pytest.fixture
     def mock_database(self):
         """Mock database operations for testing."""
-        with patch('stream_sniper.database.tracked_streamers_table_gateway.get_pool'), \
-             patch('stream_sniper.database.processing_jobs_table_gateway.get_pool'), \
-             patch('stream_sniper.database.creator_table_gateway.get_pool'):
+        # All table gateways acquire connections via the decorators module's
+        # get_pool (the gateway modules themselves don't import get_pool).
+        with patch('stream_sniper.database.decorators.get_pool'):
             yield
 
     def test_tracked_streamers_database_operations(self, mock_database):
@@ -65,8 +73,8 @@ class TestTrackingSystem:
         monitor = StreamMonitor(check_interval=60)
         await monitor.initialize()
         
-        # Mock stream info response
-        mock_twitch_api.get_stream_info.return_value = None  # Stream offline
+        # Mock stream info response (monitor awaits the async variant)
+        mock_twitch_api.get_stream_info_async.return_value = None  # Stream offline
         
         # Test status check
         status = await monitor.check_streamer_now("teststreamer")


### PR DESCRIPTION
## Summary

Fixes the remaining issues from the improvements backlog:

**Collector (commit 0cc5136c)**
- Retry `VideoCommentsByOffsetOrCursor` responses whose `comments` object is null — a single transient degraded GQL response used to silently end pagination mid-VOD (observed as 117k vs 41k message counts for the same VOD).
- Consume the chat iterator in 20k-message batches instead of materializing the whole VOD (OOM risk on the RPI).

**API bug (commit 6bfec7b)**
- `GET /chatter/{id}/messages` was broken in prod: the gateway selected a nonexistent `message` column (silently resolving to the whole-row composite) and returned a raw `datetime` where the response model requires `str` → 500 on every call. Now joins `message_text` and formats the timestamp.

**Integration tests**
- Repaired schema drift (`timestamp` → `time`), NOT NULL creator fields, FK-violation expectations, AsyncMock for async Twitch API calls, and row-shape assertions. Full suite green locally: 103 unit + 30 integration passed, ruff clean.

**Red workflows**
- `docker.yml`: smoke-test and Trivy steps used mixed-case `github.repository` in image refs (docker requires lowercase → exit 125). The push itself always worked because metadata-action lowercases.
- `security.yml`: CodeQL `paths: stream_sniper/**` matched nothing (package is under `backend/`) → "could not process any of it" hard fail; bandit/semgrep had the same dead path masked by `|| true`. TruffleHog hard-failed on main pushes because `base: main` == `head: HEAD`; now uses event-appropriate refs.

## Test plan
- [x] `uv run ruff check .` clean
- [x] 103 unit + 30 integration tests pass against a fresh Postgres
- [ ] Post-merge: verify Docker Build & Publish, Security Scanning, and CI workflows go green on main

https://claude.ai/code/session_01VRpQqskpuLYdt185y6XrE1