### PR TITLE
Search autocomplete (3 surfaces) + Alembic schema migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Component-specific docs:
 
 - **Backend** (`backend/`, Python 3.14 + FastAPI, uv-managed with committed `uv.lock`): packages `api/`, `auth/`, `collector/`, `database/`, `tracking/`. Entry points: `stream-sniper <username>` (collection), `stream-sniper-api` (REST), `stream-sniper-tracking` (automation).
 - **Frontend** (`frontend/`, Next.js 16 App Router + React 19, Bootstrap/SASS): `app|components|views|contexts|lib|hooks|styles`, admin UI under `app/(app)/admin/`. See `frontend/CLAUDE.md`.
-- **Database**: PostgreSQL, normalized schema in the `stream_sniper` namespace — **external**, not in Docker Compose. Schema source of truth: `backend/stream_sniper/database/create_table.sql`. Tables: `creator`, `stream`, `chatter`, `message_text` (deduplicated content), `message`, plus `users`, `tracked_streamers`, `processing_jobs`.
+- **Database**: PostgreSQL, normalized schema in the `stream_sniper` namespace — **external**, not in Docker Compose. Schema is versioned with **Alembic** (`backend/stream_sniper/database/migrations/`, hand-written raw-SQL migrations — no ORM/autogenerate). `create_table.sql` is a **reference-only** snapshot of the baseline table set, mirrored by revision `0001` (which additionally creates the `stream_sniper` schema). Tables: `creator`, `stream`, `chatter`, `message_text` (deduplicated content), `message`, plus `users`, `tracked_streamers`, `processing_jobs`.
 
 ## Quick Start
 
@@ -35,11 +35,13 @@ Required env: the API/tracking fail fast without a JWT signing secret — set `J
 
 ```bash
 psql -U postgres -c "CREATE DATABASE stream_sniper;"
-psql -U postgres -d stream_sniper -f backend/stream_sniper/database/create_table.sql
+cd backend && uv run alembic upgrade head    # creates schema + tables + indexes (fresh DB)
 # Bootstrap admin: POST /auth/register, then PUT /auth/users/<id>/role {"role":"admin"} with a JWT
 ```
 
-Containers do **not** manage DB schema — apply changes manually.
+`alembic upgrade head` creates the `stream_sniper` schema itself (no manual `CREATE SCHEMA`). For an **existing** DB predating Alembic (e.g. prod), stamp the baseline first — see the one-time prod runbook below.
+
+Schema is versioned via Alembic and is **not** auto-run on deploy (a revision may build an index `CONCURRENTLY` on a large table). After deploying, run migrations explicitly: `docker exec stream-sniper-api stream-sniper-migrate upgrade head`.
 
 ## Testing
 
@@ -57,6 +59,23 @@ Deployed on RPI infrastructure (pi5ram8), HTTPS via VPS reverse proxy:
 ```bash
 docker-compose -f docker-compose.prod.yml up -d stream-sniper-frontend
 ```
+
+### Database migrations (manual — not auto-run on deploy)
+
+Migrations run via the packaged `stream-sniper-migrate` entry point (works inside the
+source-less prod image; `uv run alembic` is dev-only). **One-time bootstrap** on the
+existing prod DB (it already has every table but no `alembic_version`) — stamp the
+baseline `0001` (**never `head`**, or `0002` never builds the index), then upgrade:
+
+```bash
+docker exec stream-sniper-api stream-sniper-migrate current   # expect empty
+docker exec stream-sniper-api stream-sniper-migrate stamp 0001
+docker exec stream-sniper-api stream-sniper-migrate upgrade head   # builds the index CONCURRENTLY
+docker exec stream-sniper-api stream-sniper-migrate current   # -> 0002 (head)
+```
+
+After each future deploy that adds a revision, run `docker exec stream-sniper-api stream-sniper-migrate upgrade head`.
+If a `CONCURRENTLY` build is interrupted it leaves an INVALID index — `DROP INDEX CONCURRENTLY stream_sniper.<name>;` then re-run.
 
 ## Gotchas
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -36,6 +36,7 @@ uv run mypy stream_sniper/    # type check (advisory)
 - `stream-sniper <username>` → `stream_sniper.cli:main` — data collection CLI
 - `stream-sniper-api` → `stream_sniper.api.server:run` — REST API on :5002
 - `stream-sniper-tracking` → `stream_sniper.tracking_service:run_tracking_service` — automated tracking
+- `stream-sniper-migrate` → `stream_sniper.database.migrate:main` — packaged Alembic wrapper (the prod/container way to run migrations; needs no `alembic.ini` or cwd)
 
 ## Architecture
 
@@ -49,8 +50,10 @@ Packages under `stream_sniper/`:
   (`creator_table_gateway.py`, `stream_table_gateway.py`, `user_table_gateway.py`,
   `tracked_streamers_table_gateway.py`, `processing_jobs_table_gateway.py`, …).
   `connection_pool.py` holds a `psycopg2` `ThreadedConnectionPool`; `decorators.py`
-  provides `@with_connection`. Schema source of truth:
-  `database/create_table.sql` (containers do **not** manage schema — apply by hand).
+  provides `@with_connection`. Schema is versioned with **Alembic** in
+  `database/migrations/` — hand-written raw SQL (`op.execute` / `op.create_*`, **not**
+  autogenerate; there are no ORM models). `database/create_table.sql` is a
+  reference-only baseline snapshot mirrored by revision `0001`.
 - **`api/`** — FastAPI app (`api/api.py:app`), auth (`auth.py`,
   `auth_endpoints.py`), tracking endpoints (`tracking_endpoints.py`), rate limiting
   (`rate_limiter.py`, slowapi), caching (`cache.py`, Redis), health/metrics
@@ -73,6 +76,32 @@ creator_id = CreatorTableGateway().get_creator_id_by_nick("streamer")
 
 Use `DatabaseBuffer` (`collector/database_buffer.py`) for bulk message inserts;
 always parameterize queries.
+
+### Database migrations (Alembic)
+
+```bash
+cd backend
+uv run alembic revision -m "add X" --rev-id NNNN   # then edit upgrade()/downgrade() with raw SQL
+uv run alembic upgrade head                        # local dev
+uv run alembic current | history | heads           # inspect
+```
+
+Rules:
+- **Hand-written raw SQL only** — no autogenerate, no models. Schema-qualify every
+  object (`stream_sniper.<name>`) so offline (`--sql`) mode works.
+- **`CREATE INDEX CONCURRENTLY` / any non-transactional DDL must use
+  `with op.get_context().autocommit_block():`** and be the sole DDL in its revision
+  (Alembic wraps migrations in a transaction by default). Such revisions must refuse
+  offline mode (check `op.get_context().as_sql`). See `0002_chatter_nick_lower_prefix_idx.py`.
+- **Schema creation lives in `env.py`** (a separate committed transaction, before the
+  version table), because `version_table_schema="stream_sniper"` makes Alembic create
+  `alembic_version` before any migration runs. `env.py` reuses `connection_pool.py`'s
+  env precedence (`POSTGRES_*` → legacy) — no new DB env is introduced.
+- **Prod is manual:** `docker exec stream-sniper-api stream-sniper-migrate upgrade head`
+  (see root `CLAUDE.md` runbook). Migrations are intentionally **not** in `deploy.yml`.
+  `uv run alembic` is **dev-only** (no `uv`/source in the prod image; use
+  `stream-sniper-migrate` there — the migrations dir is packaged into the wheel, so it
+  works inside `stream-sniper-api` / `stream-sniper-tracking`).
 
 ## Authentication
 

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,155 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/stream_sniper/database/migrations
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+# Or organize into date-based subdirectories (requires recursive_version_locations = true)
+# file_template = %%(year)d/%%(month).2d/%%(day).2d_%%(hour).2d%%(minute).2d_%%(second).2d_%%(rev)s_%%(slug)s
+# Deterministic, sortable revision filenames (0001_..., 0002_...); we also pass
+# --rev-id explicitly, so this is belt-and-suspenders.
+file_template = %%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the tzdata library which can be installed by adding
+# `alembic[tz]` to the pip requirements.
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+# IMPORTANT: leave sqlalchemy.url UNSET. env.py builds the URL from environment
+# variables (POSTGRES_* with legacy fallback), so this is never read. Do NOT put
+# credentials here.
+# sqlalchemy.url =
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     # Monitoring and utilities
     "prometheus-client>=0.20.0",
     "psutil>=6.0.0",
+    "alembic>=1.18.5",
 ]
 
 [dependency-groups]
@@ -64,6 +65,7 @@ dev = [
 stream-sniper = "stream_sniper.cli:main"
 stream-sniper-api = "stream_sniper.api.server:run"
 stream-sniper-tracking = "stream_sniper.tracking_service:run_tracking_service"
+stream-sniper-migrate = "stream_sniper.database.migrate:main"
 
 [project.urls]
 Homepage = "https://github.com/slanycukr/stream-sniper"

--- a/backend/stream_sniper/api/api.py
+++ b/backend/stream_sniper/api/api.py
@@ -11,7 +11,7 @@ from fastapi.middleware.gzip import GZipMiddleware
 from pydantic import BaseModel, Field
 from slowapi.util import get_remote_address
 
-from ..database.chatter_table_gateway import select_all_chatters_on_stream_db
+from ..database.chatter_table_gateway import select_all_chatters_on_stream_db, select_chatters_by_prefix_db
 from ..database.connection_pool import close_pool
 from ..database.creator_table_gateway import select_creator_top_chatters_db, select_creators_db
 from ..database.message_table_gateway import (
@@ -462,6 +462,66 @@ def get_chatter_id(
     except Exception as e:
         logger.error(f"Error fetching chatter ID: {e}")
         record_cache_operation("error", "chatter_id")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@app.get(
+    "/chatters/search",
+    response_model=List[List[Any]],
+    tags=["Chatters"],
+    summary="Search chatters by nickname prefix",
+    description=f"""
+    Case-insensitive prefix search over chatter nicknames, for autocomplete.
+    Returns a list of [chatter_id, nick] pairs ordered by nick.
+    Queries shorter than 2 characters return an empty list.
+
+    **Rate Limit**: {rate_limits.SEARCH}
+    """,
+    responses={
+        200: {
+            "description": "List of matching [id, nick] pairs",
+            "content": {"application/json": {"example": [[42, "ninja"], [77, "ninjastreams"]]}},
+        },
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit(rate_limits.SEARCH)
+def search_chatters(
+    request: Request,
+    response: Response,
+    q: str = Query(..., description="Nickname prefix to search for", json_schema_extra={"example": "nin"}),
+    limit: int = Query(10, ge=1, le=25, description="Maximum number of suggestions"),
+):
+    """Prefix-search chatter nicknames for autocomplete suggestions."""
+    prefix = q.strip()
+    # Avoid scanning the index on 1-character prefixes (too many matches).
+    if len(prefix) < 2:
+        return []
+
+    try:
+        # Try cache first
+        cache = get_cache()
+        cache_key = cache._generate_key("chatter_search", prefix.lower(), limit)
+        cached_result = cache.get(cache_key)
+
+        if cached_result is not None:
+            response.headers["X-Cache"] = "HIT"
+            record_cache_operation("hit", "chatter_search")
+            return cached_result
+
+        # Cache miss - fetch from database
+        record_cache_operation("miss", "chatter_search")
+        result = select_chatters_by_prefix_db(prefix, limit)
+
+        # Cache the result (empty results are cached too, to absorb repeat typing)
+        cache.set(cache_key, result, CacheTTL.CHATTER_SEARCH)
+        record_cache_operation("set", "chatter_search")
+        response.headers["X-Cache"] = "MISS"
+
+        return result
+    except Exception as e:
+        logger.error(f"Error searching chatters: {e}")
+        record_cache_operation("error", "chatter_search")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/backend/stream_sniper/api/cache.py
+++ b/backend/stream_sniper/api/cache.py
@@ -344,6 +344,10 @@ class CacheTTL:
     STREAM_DETAILS = 1800  # 30 minutes
     CHATTER_MESSAGES = 1800  # 30 minutes
 
+    # Search / autocomplete (short-lived, high churn)
+    CHATTER_SEARCH = 300  # 5 minutes
+    TWITCH_SEARCH = 60  # 1 minute
+
     # Volatile data
     HEALTH_CHECK = 300  # 5 minutes
     LIVE_STATS = 60  # 1 minute

--- a/backend/stream_sniper/api/tracking_endpoints.py
+++ b/backend/stream_sniper/api/tracking_endpoints.py
@@ -31,7 +31,8 @@ from ..database.tracked_streamers_table_gateway import (
 from ..logging_config import get_logger
 from ..tracking.scheduler import get_scheduler
 from .auth import UserInDB, get_current_admin_user
-from .rate_limiter import limiter
+from .cache import CacheTTL, get_cache
+from .rate_limiter import limiter, rate_limits
 
 logger = get_logger(__name__)
 
@@ -264,8 +265,8 @@ async def add_tracked_streamer(
         if not creator_id:
             # Create new creator using Twitch API
             try:
-                twitch_api = TwitchAPI()
-                await twitch_api.twitch_api_init()
+                twitch_api = TwitchAPI.instance()
+                await twitch_api.ensure_initialized()
                 twitch_api.set_streamer_nickname(streamer_data.twitch_username)
                 
                 display_name, profile_image_url = await twitch_api.get_creator_info_async()
@@ -332,6 +333,79 @@ async def add_tracked_streamer(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error"
         )
+
+
+class TwitchChannelResult(BaseModel):
+    """A single Twitch channel search suggestion."""
+    login: str = Field(..., description="Twitch login (username)")
+    display_name: str = Field(..., description="Channel display name")
+    profile_image_url: str = Field("", description="Profile thumbnail URL")
+    is_live: bool = Field(False, description="Whether the channel is currently live")
+
+
+@router.get(
+    "/twitch-search",
+    response_model=List[TwitchChannelResult],
+    summary="Search Twitch channels",
+    description=f"""
+    Search live Twitch channels by name, for the add-streamer autocomplete.
+    Backed by the Twitch Helix search API (channels active in the last 6 months).
+
+    Requires admin role.
+
+    **Rate Limit**: {rate_limits.SEARCH}
+    """,
+    responses={
+        200: {"description": "List of matching Twitch channels"},
+        401: {"description": "Authentication required"},
+        403: {"description": "Admin role required"},
+        429: {"description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit(rate_limits.SEARCH)
+async def search_twitch_channels(
+    request: Request,
+    response: Response,
+    q: str = Query(..., description="Channel name to search for"),
+    limit: int = Query(8, ge=1, le=20, description="Maximum number of suggestions"),
+    current_user: UserInDB = Depends(get_current_admin_user),
+):
+    """Search Twitch channels by name for the add-streamer typeahead (admin only)."""
+    query = q.strip()
+    if len(query) < 2:
+        return []
+
+    cache = get_cache()
+    cache_key = cache._generate_key("twitch_search", query.lower(), limit)
+    cached_result = cache.get(cache_key)
+    if cached_result is not None:
+        response.headers["X-Cache"] = "HIT"
+        return cached_result
+
+    try:
+        twitch_api = TwitchAPI.instance()
+        await twitch_api.ensure_initialized()
+        channels = await twitch_api.search_channels_async(query, limit)
+    except Exception as e:
+        logger.error(f"Error searching Twitch channels for '{query}': {e}")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to search Twitch channels",
+        )
+
+    result = [
+        {
+            "login": channel.broadcaster_login,
+            "display_name": channel.display_name,
+            "profile_image_url": channel.thumbnail_url or "",
+            "is_live": bool(channel.is_live),
+        }
+        for channel in channels
+    ]
+
+    cache.set(cache_key, result, CacheTTL.TWITCH_SEARCH)
+    response.headers["X-Cache"] = "MISS"
+    return result
 
 
 @router.get(

--- a/backend/stream_sniper/collector/twitch_api.py
+++ b/backend/stream_sniper/collector/twitch_api.py
@@ -32,6 +32,30 @@ class TwitchAPI:
             )
         self.twitch = await Twitch(client_id, client_secret)
 
+    async def ensure_initialized(self):
+        """
+        Initialize the Twitch client once and reuse it (idempotent).
+        Long-lived callers such as the API process (channel-search autocomplete,
+        add-streamer) should use this to avoid re-running the OAuth handshake on
+        every request. The reused aiohttp session stays bound to the API's single
+        event loop, which is where these coroutines are awaited.
+        """
+        if getattr(self, "twitch", None) is None:
+            await self.twitch_api_init()
+
+    async def search_channels_async(self, query: str, limit: int = 8) -> List[Any]:
+        """
+        Search Twitch channels by name for autocomplete. Returns SearchChannelResult
+        objects (broadcaster_login, display_name, id, is_live, thumbnail_url, ...).
+        Only channels that streamed within the past 6 months are returned by Twitch.
+        """
+        results: List[Any] = []
+        async for channel in self.twitch.search_channels(query, first=limit):
+            results.append(channel)
+            if len(results) >= limit:
+                break
+        return results
+
     @staticmethod
     def get_async_result(async_generator, return_all_values: bool = False) -> Union[List, Any]:
         """

--- a/backend/stream_sniper/database/chatter_table_gateway.py
+++ b/backend/stream_sniper/database/chatter_table_gateway.py
@@ -71,6 +71,30 @@ def insert_new_chatters_db(nicks: List[str], cursor, connection) -> List[int]:
 
 
 @with_cursor
+def select_chatters_by_prefix_db(prefix: str, limit: int, cursor):
+    """
+    Case-insensitive prefix search over chatter nicks for autocomplete.
+    Relies on the functional index chatter_nick_lower_prefix_idx
+    (lower(nick) text_pattern_ops) so the LIKE prefix scan stays fast.
+    :param prefix: The nick prefix the user has typed
+    :param limit: Maximum number of suggestions to return
+    :return: List of (id, nick) tuples ordered by nick
+    """
+    sql = """
+    SELECT
+        id,
+        nick
+    FROM
+        chatter
+    WHERE lower(nick) LIKE lower(%s) || '%%'
+    ORDER BY lower(nick)
+    LIMIT %s
+    """
+    cursor.execute(sql, (prefix, limit))
+    return cursor.fetchall()
+
+
+@with_cursor
 def select_all_chatters_db(cursor) -> dict:
     sql = """
     SELECT

--- a/backend/stream_sniper/database/create_table.sql
+++ b/backend/stream_sniper/database/create_table.sql
@@ -1,3 +1,13 @@
+-- REFERENCE ONLY — do not apply by hand.
+-- Human-readable snapshot of the BASELINE table/constraint set, mirrored by Alembic
+-- revision 0001 (stream_sniper/database/migrations/versions/0001_...). NOTE: revision
+-- 0001 additionally issues CREATE SCHEMA IF NOT EXISTS stream_sniper (online schema
+-- creation lives in env.py); this file assumes the schema already exists, as it always did.
+-- Schema is now versioned with Alembic; build/upgrade a DB with:
+--   cd backend && uv run alembic upgrade head        (fresh DB)
+-- Anything added after baseline (e.g. chatter_nick_lower_prefix_idx) lives ONLY
+-- in a migration, NOT here. See backend/CLAUDE.md "Database migrations".
+
 create table stream_sniper.chatter
 (
     id   serial       primary key,

--- a/backend/stream_sniper/database/migrate.py
+++ b/backend/stream_sniper/database/migrate.py
@@ -1,0 +1,41 @@
+"""Packaged Alembic entry point: `stream-sniper-migrate`.
+
+Runs Alembic WITHOUT needing an alembic.ini, a source checkout, or a specific
+cwd. The migrations directory ships inside the installed `stream_sniper` wheel,
+so this works in the source-less prod container (no uv; only /app/.venv/bin on
+PATH). alembic.ini is a dev-only convenience; this entry point ignores it and
+sets script_location programmatically.
+
+Examples:
+    stream-sniper-migrate upgrade head
+    stream-sniper-migrate stamp 0001
+    stream-sniper-migrate current
+    stream-sniper-migrate heads
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from alembic.config import CommandLine, Config
+
+
+def main(argv: list[str] | None = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+    migrations_dir = str(Path(__file__).resolve().parent / "migrations")
+    cli = CommandLine(prog="stream-sniper-migrate")
+    options = cli.parser.parse_args(argv)
+    if not hasattr(options, "cmd"):
+        cli.parser.error("too few arguments")
+        return
+    # No file_=... -> config_file_name is None -> env.py skips fileConfig and
+    # builds the engine from environment variables (same as connection_pool.py).
+    cfg = Config(cmd_opts=options)
+    cfg.set_main_option("script_location", migrations_dir)
+    cli.run_cmd(cfg, options)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/stream_sniper/database/migrations/README
+++ b/backend/stream_sniper/database/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/backend/stream_sniper/database/migrations/env.py
+++ b/backend/stream_sniper/database/migrations/env.py
@@ -1,0 +1,141 @@
+"""Alembic environment for Stream Sniper.
+
+Migrations are HAND-WRITTEN raw SQL (op.execute / op.create_*). There are no ORM
+models and no autogenerate; target_metadata is None.
+
+The database URL and schema are reproduced EXACTLY from
+stream_sniper.database.connection_pool.DatabaseConnectionPool._get_db_config:
+  * load_dotenv() first,
+  * POSTGRES_* preferred with legacy un-prefixed fallback (empty string falls through),
+  * port default 5432,
+  * schema `stream_sniper` applied via libpq search_path (same as the app), and
+    alembic_version kept in that schema via version_table_schema.
+
+CRITICAL ordering note: because version_table_schema="stream_sniper", Alembic
+emits `CREATE TABLE stream_sniper.alembic_version` BEFORE running revision 0001's
+upgrade(). On a FRESH/empty DB the schema does not exist yet, so we MUST create it
+here first, on a SEPARATE short-lived transaction, before opening the migration
+connection. Doing it on the migration connection (before context.configure) would
+corrupt transaction_per_migration and break 0002's autocommit_block(); doing it in
+0001.upgrade() is too late. It is idempotent (harmless on prod, whose schema
+already exists).
+"""
+
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, pool
+from sqlalchemy.engine import URL
+
+# Alembic Config object. config_file_name is None when invoked via the packaged
+# `stream-sniper-migrate` entry point (no ini); non-None under `uv run alembic`.
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Hand-written migrations -> no autogenerate metadata.
+target_metadata = None
+
+SCHEMA = "stream_sniper"
+
+
+def _db_env(prefixed: str, legacy: str, default: str | None = None) -> str:
+    """Exact reproduction of connection_pool._db_env precedence:
+    POSTGRES_* first, legacy un-prefixed fallback, empty-string falls through
+    (Python `or` semantics), fail-fast if still unset."""
+    value = os.environ.get(prefixed) or os.environ.get(legacy) or default
+    if value is None:
+        raise RuntimeError(
+            f"Database configuration missing: set {prefixed} (or legacy {legacy}) in the environment"
+        )
+    return value
+
+
+def _build_url() -> URL:
+    # Mirror the app: read .env before touching os.environ. load_dotenv() does
+    # NOT override already-exported vars, so explicit env wins (used by CI/verify).
+    load_dotenv()
+    # URL.create() takes RAW components — no manual URL-encoding of the password;
+    # SQLAlchemy hands username/password/host/port/database to psycopg2 verbatim,
+    # so special characters (@ : / # ? % space) need zero escaping.
+    return URL.create(
+        drivername="postgresql+psycopg2",
+        username=_db_env("POSTGRES_USER", "USER"),
+        password=_db_env("POSTGRES_PASSWORD", "PASSWORD"),
+        host=_db_env("POSTGRES_HOST", "HOST"),
+        database=_db_env("POSTGRES_DB", "DATABASE"),
+        port=int(_db_env("POSTGRES_PORT", "PORT", "5432")),
+    )
+
+
+def _connect_args() -> dict:
+    # Identical to connection_pool.py's psycopg2 kwargs: search_path via libpq
+    # `options`, plus connect_timeout. NO sslmode (libpq default `prefer`), and
+    # NO statement_timeout (must never abort CREATE INDEX CONCURRENTLY).
+    return {
+        "options": f"-c search_path={SCHEMA}",
+        "connect_timeout": int(os.environ.get("DB_CONNECT_TIMEOUT", "10")),
+    }
+
+
+def run_migrations_offline() -> None:
+    """--sql mode: emit SQL with no DB connection.
+
+    No connection means libpq `options` can't set search_path, so migrations MUST
+    schema-qualify every object (they do). We emit CREATE SCHEMA FIRST so the
+    generated script is applicable to a genuinely fresh DB before the
+    schema-qualified alembic_version table is created. version_table_schema
+    qualifies the alembic_version bookkeeping. The CONCURRENTLY index (0002) is
+    NOT meant for offline and refuses to run there (see 0002).
+    """
+    context.configure(
+        url=_build_url(),
+        target_metadata=target_metadata,
+        version_table_schema=SCHEMA,
+        include_schemas=True,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        # Emit before the version table / any migration so offline --sql output is
+        # self-sufficient on a fresh DB. Parity with the online bootstrap below.
+        context.execute(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA}")
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = create_engine(
+        _build_url(),
+        poolclass=pool.NullPool,          # short-lived migration engine
+        connect_args=_connect_args(),     # search_path=stream_sniper, like the app
+    )
+
+    # STEP 1 — ensure the schema exists on a SEPARATE, fully-committed transaction,
+    # BEFORE Alembic touches (and schema-qualifies) alembic_version. Must NOT be on
+    # the migration connection, or transaction_per_migration / autocommit_block break.
+    with connectable.begin() as bootstrap:
+        bootstrap.exec_driver_sql(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA}")
+
+    # STEP 2 — run migrations on a fresh connection.
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table_schema=SCHEMA,       # alembic_version lives in stream_sniper
+            include_schemas=True,              # harmless now; ready if autogenerate is ever added
+            transaction_per_migration=True,    # each migration in its own tx; keeps
+                                               # autocommit_block() (CONCURRENTLY) clean
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+    connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/stream_sniper/database/migrations/script.py.mako
+++ b/backend/stream_sniper/database/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/backend/stream_sniper/database/migrations/versions/0001_baseline_pre_index_schema.py
+++ b/backend/stream_sniper/database/migrations/versions/0001_baseline_pre_index_schema.py
@@ -1,0 +1,156 @@
+"""baseline pre-index schema
+
+Reproduces the pre-Alembic production schema (8 tables + inline PK/UNIQUE/FK/CHECK
+constraints + their implicit constraint-backed indexes and serial sequences).
+Reproduces the same TABLE/CONSTRAINT set as create_table.sql, plus a
+`CREATE SCHEMA IF NOT EXISTS stream_sniper` prologue that create_table.sql never
+contained (schema creation was always a manual prerequisite there; it now lives in
+env.py for the online path and here for offline/self-contained runs). Deliberately
+EXCLUDES chatter_nick_lower_prefix_idx — that is revision 0002. Type/FK quirks are
+preserved on purpose (message.tagged_chatter_id has no FK; message.message_text_id
+is bigint referencing message_text.id serial).
+
+On a fresh DB: this runs (schema already ensured by env.py; CREATE TABLEs execute).
+On prod: this is `stamp`-ed, never run (tables already exist).
+
+Revision ID: 0001
+Revises:
+"""
+
+from alembic import op
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+CREATE SCHEMA IF NOT EXISTS stream_sniper;
+
+CREATE TABLE stream_sniper.chatter
+(
+    id   serial       PRIMARY KEY,
+    nick varchar(255) NOT NULL,
+    CONSTRAINT chatter_name_uindex UNIQUE (nick)
+);
+
+CREATE TABLE stream_sniper.creator
+(
+    id                serial       PRIMARY KEY,
+    nick              varchar(255) NOT NULL,
+    display_name      varchar(255) NOT NULL,
+    profile_image_url varchar(255) NOT NULL,
+    twitch_id         bigint,
+    CONSTRAINT creator_nick_uindex UNIQUE (nick)
+);
+
+CREATE TABLE stream_sniper.stream
+(
+    id            serial        PRIMARY KEY,
+    twitch_id     bigint        NOT NULL,
+    title         varchar(255)  NOT NULL,
+    start         timestamp     NOT NULL,
+    "end"         timestamp     NULL,
+    thumbnail_url varchar(255)  NULL,
+    message_count int DEFAULT 0 NOT NULL,
+    creator_id    int           NULL,
+    CONSTRAINT stream__twitch_id_uindex UNIQUE (twitch_id),
+    CONSTRAINT stream__creator_id_fk
+        FOREIGN KEY (creator_id) REFERENCES stream_sniper.creator (id)
+);
+
+CREATE TABLE stream_sniper.message_text
+(
+    id   serial PRIMARY KEY,
+    text text   NOT NULL,
+    CONSTRAINT text_uq UNIQUE (text)
+);
+
+CREATE TABLE stream_sniper.message
+(
+    id                serial PRIMARY KEY,
+    chatter_id        int                                 NULL,
+    tagged_chatter_id int                                 NULL,
+    stream_id         int                                 NULL,
+    message_text_id   bigint                              NOT NULL,
+    time              timestamp DEFAULT current_timestamp NULL,
+    CONSTRAINT message_chatter_id_fk
+        FOREIGN KEY (chatter_id) REFERENCES stream_sniper.chatter (id),
+    CONSTRAINT message_stream_id_fk
+        FOREIGN KEY (stream_id) REFERENCES stream_sniper.stream (id),
+    CONSTRAINT message_text_id_fk
+        FOREIGN KEY (message_text_id) REFERENCES stream_sniper.message_text (id)
+);
+
+CREATE TABLE stream_sniper.users
+(
+    id            serial       PRIMARY KEY,
+    username      varchar(255) NOT NULL,
+    email         varchar(255) NOT NULL,
+    password_hash varchar(255) NOT NULL,
+    role          varchar(50)  NOT NULL DEFAULT 'user',
+    is_active     boolean      NOT NULL DEFAULT true,
+    created_at    timestamp    NOT NULL DEFAULT current_timestamp,
+    updated_at    timestamp    NOT NULL DEFAULT current_timestamp,
+    CONSTRAINT users_username_uindex UNIQUE (username),
+    CONSTRAINT users_email_uindex UNIQUE (email)
+);
+
+CREATE TABLE stream_sniper.tracked_streamers
+(
+    id                       serial       PRIMARY KEY,
+    creator_id               int          NOT NULL,
+    twitch_username          varchar(255) NOT NULL,
+    display_name             varchar(255) NOT NULL,
+    is_active                boolean      NOT NULL DEFAULT true,
+    last_stream_check        timestamp    NULL,
+    last_processed_stream_id bigint       NULL,
+    processing_enabled       boolean      NOT NULL DEFAULT true,
+    created_at               timestamp    NOT NULL DEFAULT current_timestamp,
+    updated_at               timestamp    NOT NULL DEFAULT current_timestamp,
+    created_by               int          NULL,
+    notes                    text         NULL,
+    CONSTRAINT tracked_streamers_creator_id_fk
+        FOREIGN KEY (creator_id) REFERENCES stream_sniper.creator (id),
+    CONSTRAINT tracked_streamers_created_by_fk
+        FOREIGN KEY (created_by) REFERENCES stream_sniper.users (id),
+    CONSTRAINT tracked_streamers_creator_id_uindex UNIQUE (creator_id),
+    CONSTRAINT tracked_streamers_twitch_username_uindex UNIQUE (twitch_username)
+);
+
+CREATE TABLE stream_sniper.processing_jobs
+(
+    id                  serial       PRIMARY KEY,
+    tracked_streamer_id int          NOT NULL,
+    twitch_stream_id    bigint       NOT NULL,
+    status              varchar(50)  NOT NULL DEFAULT 'pending',
+    started_at          timestamp    NULL,
+    completed_at        timestamp    NULL,
+    error_message       text         NULL,
+    retry_count         int          NOT NULL DEFAULT 0,
+    created_at          timestamp    NOT NULL DEFAULT current_timestamp,
+    updated_at          timestamp    NOT NULL DEFAULT current_timestamp,
+    CONSTRAINT processing_jobs_tracked_streamer_id_fk
+        FOREIGN KEY (tracked_streamer_id) REFERENCES stream_sniper.tracked_streamers (id),
+    CONSTRAINT processing_jobs_status_check
+        CHECK (status IN ('pending', 'in_progress', 'completed', 'failed'))
+);
+""")
+
+
+def downgrade() -> None:
+    # Drop in reverse FK order (children before parents). The schema itself is
+    # intentionally NOT dropped, so alembic_version (which lives in stream_sniper)
+    # survives a full downgrade. serial sequences drop automatically with their tables.
+    op.execute("""
+DROP TABLE IF EXISTS stream_sniper.processing_jobs;
+DROP TABLE IF EXISTS stream_sniper.tracked_streamers;
+DROP TABLE IF EXISTS stream_sniper.message;
+DROP TABLE IF EXISTS stream_sniper.users;
+DROP TABLE IF EXISTS stream_sniper.message_text;
+DROP TABLE IF EXISTS stream_sniper.stream;
+DROP TABLE IF EXISTS stream_sniper.creator;
+DROP TABLE IF EXISTS stream_sniper.chatter;
+""")

--- a/backend/stream_sniper/database/migrations/versions/0002_chatter_nick_lower_prefix_idx.py
+++ b/backend/stream_sniper/database/migrations/versions/0002_chatter_nick_lower_prefix_idx.py
@@ -1,0 +1,60 @@
+"""chatter lower(nick) prefix index, built CONCURRENTLY
+
+Adds stream_sniper.chatter_nick_lower_prefix_idx = lower(nick) text_pattern_ops,
+enabling `lower(nick) LIKE 'foo%'` to use an index under a non-C collation
+(GET /chatters/search autocomplete).
+
+CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction; Alembic wraps
+migrations in one by default, so both directions use autocommit_block(). Offline
+(--sql) mode cannot honor autocommit_block (it emits BEGIN/COMMIT around each
+migration), so this revision REFUSES to run offline.
+
+Operational caveats:
+  * IF NOT EXISTS / IF EXISTS make re-runs safe.
+  * INVALID-index trap: if a CONCURRENTLY build is interrupted, Postgres leaves an
+    INVALID index and IF NOT EXISTS then SKIPS the rebuild. If upgrade fails mid
+    index, manually `DROP INDEX CONCURRENTLY stream_sniper.chatter_nick_lower_prefix_idx;`
+    before re-running. The prod runbook and verification recipe assert indisvalid = 't'.
+  * Do not add other DDL to this file — autocommit_block() would commit it prematurely.
+
+Revision ID: 0002
+Revises: 0001
+"""
+
+from alembic import op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def _guard_online() -> None:
+    # MigrationContext exposes offline mode via `.as_sql` (True under --sql);
+    # is_offline_mode() lives on EnvironmentContext, not here.
+    if op.get_context().as_sql:
+        raise RuntimeError(
+            "0002 builds an index CONCURRENTLY and cannot be emitted for offline "
+            "(--sql) execution; run it online (stream-sniper-migrate / uv run alembic upgrade)."
+        )
+
+
+def upgrade() -> None:
+    _guard_online()
+    # autocommit_block() unconditionally commits the preceding tx, so this DDL
+    # MUST be alone in its own migration (it is).
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS chatter_nick_lower_prefix_idx "
+            "ON stream_sniper.chatter (lower(nick) text_pattern_ops)"
+        )
+
+
+def downgrade() -> None:
+    _guard_online()
+    # DROP INDEX CONCURRENTLY is also non-transactional. Qualify by the INDEX's
+    # own schema (stream_sniper), not the table name.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS stream_sniper.chatter_nick_lower_prefix_idx"
+        )

--- a/backend/tests/unit/api/test_api.py
+++ b/backend/tests/unit/api/test_api.py
@@ -8,11 +8,22 @@ Tests all API endpoints with mocked database responses to ensure:
 - Request validation
 """
 
-from unittest.mock import Mock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 
 from fastapi.testclient import TestClient
 
 from stream_sniper.api.api import app
+from stream_sniper.api.auth import get_current_admin_user
+
+
+def _miss_cache():
+    """A mock cache that always misses, so endpoint tests don't depend on Redis state."""
+    cache = Mock()
+    cache._generate_key = Mock(return_value="test-cache-key")
+    cache.get = Mock(return_value=None)
+    cache.set = Mock(return_value=True)
+    return cache
 
 
 class TestChattersEndpoints:
@@ -501,3 +512,142 @@ class TestAPIDocumentation:
 
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
+
+
+class TestChatterSearchEndpoint:
+    """Test suite for the /chatters/search autocomplete endpoint."""
+
+    @patch("stream_sniper.api.api.get_cache")
+    @patch("stream_sniper.api.api.select_chatters_by_prefix_db")
+    def test_search_chatters_success(self, mock_search, mock_get_cache):
+        """Prefix search returns [id, nick] pairs and calls the gateway."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_search.return_value = [[42, "ninja"], [77, "ninjastreams"]]
+
+        with TestClient(app) as client:
+            response = client.get("/chatters/search?q=nin")
+
+        assert response.status_code == 200
+        assert response.json() == [[42, "ninja"], [77, "ninjastreams"]]
+        mock_search.assert_called_once_with("nin", 10)
+
+    @patch("stream_sniper.api.api.get_cache")
+    @patch("stream_sniper.api.api.select_chatters_by_prefix_db")
+    def test_search_chatters_trims_and_honors_limit(self, mock_search, mock_get_cache):
+        """Whitespace is trimmed and the limit query param is passed through."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_search.return_value = []
+
+        with TestClient(app) as client:
+            response = client.get("/chatters/search?q=%20nin%20&limit=5")
+
+        assert response.status_code == 200
+        assert response.json() == []
+        mock_search.assert_called_once_with("nin", 5)
+
+    @patch("stream_sniper.api.api.get_cache")
+    @patch("stream_sniper.api.api.select_chatters_by_prefix_db")
+    def test_search_chatters_short_query_skips_db(self, mock_search, mock_get_cache):
+        """Queries shorter than 2 chars return [] without touching the database."""
+        mock_get_cache.return_value = _miss_cache()
+
+        with TestClient(app) as client:
+            response = client.get("/chatters/search?q=n")
+
+        assert response.status_code == 200
+        assert response.json() == []
+        mock_search.assert_not_called()
+
+    @patch("stream_sniper.api.api.get_cache")
+    @patch("stream_sniper.api.api.select_chatters_by_prefix_db")
+    def test_search_chatters_server_error(self, mock_search, mock_get_cache):
+        """A database error surfaces as a 500."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_search.side_effect = Exception("Database connection failed")
+
+        with TestClient(app) as client:
+            response = client.get("/chatters/search?q=nin")
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Internal server error"
+
+    def test_search_chatters_missing_query(self):
+        """The q param is required."""
+        with TestClient(app) as client:
+            response = client.get("/chatters/search")
+
+        assert response.status_code == 422
+
+
+class TestTwitchSearchEndpoint:
+    """Test suite for the admin /admin/tracking/twitch-search endpoint."""
+
+    @staticmethod
+    def _override_admin():
+        app.dependency_overrides[get_current_admin_user] = lambda: SimpleNamespace(
+            id=1, username="admin", role="admin"
+        )
+
+    @staticmethod
+    def _clear_admin():
+        app.dependency_overrides.pop(get_current_admin_user, None)
+
+    @patch("stream_sniper.api.tracking_endpoints.get_cache")
+    @patch("stream_sniper.api.tracking_endpoints.TwitchAPI")
+    def test_search_twitch_channels_success(self, mock_twitch_cls, mock_get_cache):
+        """Channel results are mapped to {login, display_name, profile_image_url, is_live}."""
+        mock_get_cache.return_value = _miss_cache()
+        channel = SimpleNamespace(
+            broadcaster_login="ninja",
+            display_name="Ninja",
+            thumbnail_url="http://img/ninja.png",
+            is_live=True,
+        )
+        instance = mock_twitch_cls.instance.return_value
+        instance.ensure_initialized = AsyncMock()
+        instance.search_channels_async = AsyncMock(return_value=[channel])
+
+        self._override_admin()
+        try:
+            with TestClient(app) as client:
+                response = client.get("/admin/tracking/twitch-search?q=nin")
+        finally:
+            self._clear_admin()
+
+        assert response.status_code == 200
+        assert response.json() == [
+            {
+                "login": "ninja",
+                "display_name": "Ninja",
+                "profile_image_url": "http://img/ninja.png",
+                "is_live": True,
+            }
+        ]
+        instance.search_channels_async.assert_awaited_once_with("nin", 8)
+
+    @patch("stream_sniper.api.tracking_endpoints.get_cache")
+    @patch("stream_sniper.api.tracking_endpoints.TwitchAPI")
+    def test_search_twitch_channels_short_query_skips_twitch(self, mock_twitch_cls, mock_get_cache):
+        """Short queries return [] without hitting the Twitch API."""
+        mock_get_cache.return_value = _miss_cache()
+        instance = mock_twitch_cls.instance.return_value
+        instance.ensure_initialized = AsyncMock()
+        instance.search_channels_async = AsyncMock(return_value=[])
+
+        self._override_admin()
+        try:
+            with TestClient(app) as client:
+                response = client.get("/admin/tracking/twitch-search?q=n")
+        finally:
+            self._clear_admin()
+
+        assert response.status_code == 200
+        assert response.json() == []
+        instance.search_channels_async.assert_not_awaited()
+
+    def test_search_twitch_channels_requires_auth(self):
+        """Without an admin token the endpoint rejects the request."""
+        with TestClient(app) as client:
+            response = client.get("/admin/tracking/twitch-search?q=nin")
+
+        assert response.status_code in (401, 403)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -86,6 +86,20 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/cc/ac0bed8e562e7407fe55c3ba85a4dce86e6dbd8730887bd1e406a6c5c18a/alembic-1.18.5.tar.gz", hash = "sha256:1554982221dd17e9a749b53902407578eb305e453f71999e8c7f0a48389fff8e", size = 2060480, upload-time = "2026-06-25T15:20:54.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/78/5fe6dc3a3a5b2f5a2a4faef8bfe336d5fa049a38884ab3172e0098160c01/alembic-1.18.5-py3-none-any.whl", hash = "sha256:06d8ba9d04558022f5395e9317de03d270f3dced49cee01f89fe7a13c26f14bc", size = 264664, upload-time = "2026-06-25T15:20:56.673Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -462,6 +476,45 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -572,6 +625,48 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -995,6 +1090,33 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/f1/a7a892f18d4d224e6b26f706531eafccc41e37594d37d304786969ee13cb/sqlalchemy-2.0.51.tar.gz", hash = "sha256:804dccd8a4a6242c4e30ad961e540e18a588f6527202f2d6791b01845d59fdc9", size = 9912201, upload-time = "2026-06-15T15:41:20.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/49/a739be2e1d02a96a658eb71ab45d921c874249252358ad24a5bffdd02525/sqlalchemy-2.0.51-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6ea306caaae6bd5afd0a46050003c88f6bf33227377a49298c498c3cb88ff491", size = 2158999, upload-time = "2026-06-15T16:08:51.759Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6b/2e0e38cf75c8780eca78d9b2e78164f8bcfd70125e5caa588ff5cbb9c9f4/sqlalchemy-2.0.51-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c45a496d6bc05dec41dcd4c3a2b183723f47473255c159cd80b503c8f246424d", size = 3282539, upload-time = "2026-06-15T16:19:51.065Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a1/e77854cb5336fd37dc3c6ae3b71de242c98caac5725120be0b526b31cbd0/sqlalchemy-2.0.51-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4004ada0aafe8ae1991b2cd1d99c6d9146126e123bd6f883c260d974aa012e54", size = 3287545, upload-time = "2026-06-15T16:26:44.735Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ab/9e17272fd4dac8df3b83c4fbe52b998a1c9d89a843c8c35ff29b74ff7364/sqlalchemy-2.0.51-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f6bcad487aee1c638d707235682fc96f741de00663619881ab235400d03289e", size = 3230929, upload-time = "2026-06-15T16:19:52.625Z" },
+    { url = "https://files.pythonhosted.org/packages/02/3c/52f408ea701781caee975606beccc48845f2aee8711ac29843d612c0306c/sqlalchemy-2.0.51-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:39a76529db6305693d8d4affa58ad5b5e2e18edd62daea628b29b97930b3513d", size = 3252888, upload-time = "2026-06-15T16:26:46.454Z" },
+    { url = "https://files.pythonhosted.org/packages/24/16/3efd2ee6bc4ca4693a30a1dd17a91b606cae15d517d2a4746611d9b73ce8/sqlalchemy-2.0.51-cp314-cp314-win32.whl", hash = "sha256:08a204d8b5638717c26a24df18fcf40af45a6b22e35b70b1d62f0113c2e278e8", size = 2120551, upload-time = "2026-06-15T16:23:15.629Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/78/55b12e70f45bccc40d9e483925c065027b3b98ea4cbbdf6f8c2546feaf6c/sqlalchemy-2.0.51-cp314-cp314-win_amd64.whl", hash = "sha256:96747bfbadb055466e5b46d572618170046b45ce5a4879167f50d70a5319a499", size = 2146318, upload-time = "2026-06-15T16:23:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/21/db/a9574ed40fed418924b1b1a3e54f47ee3963053b3d3d325a0d36b41f2c08/sqlalchemy-2.0.51-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e5ea1a213be1fcd5e49d9904c3b9939211ded90bc2a64e93f4c01963474285de", size = 2178920, upload-time = "2026-06-15T15:59:56.285Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/90/a1bb5c7cbba76b7bc1fbd586d0a5479a7bc9c27b4a8298f22ec9423b2bb3/sqlalchemy-2.0.51-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c6b36ed71f41942bdcd2ad2522be46bfce09d5705be5640ecf19bbc7660e4b7", size = 3566534, upload-time = "2026-06-15T15:58:35.024Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4b/481f1fed30e0e9e8dd24aecbb49f29eb57fe7657ece5cf06ee9b84bb97d8/sqlalchemy-2.0.51-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c2c62877097e1a0db401fba5cb4debee33265e5b2a55c4ccb489c02c53b4f72", size = 3535844, upload-time = "2026-06-15T16:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/02/71/0aa64aeda645510af0a43f7d9ee70932f0d1dc4263aed34c50ee891d9df3/sqlalchemy-2.0.51-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0378d055e9e8cd6ce4d8dff683bdd3d7d413533c4ee51d67a2b1e0f9eacc0f23", size = 3475355, upload-time = "2026-06-15T15:58:36.592Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/6061db32316446135a3abae5f308d144ab988a34234726042da3e58b1c63/sqlalchemy-2.0.51-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6e46fc36029eff666391e0531e5387b62ce6c4f1d8e50b3fb3099eaca1b42522", size = 3486591, upload-time = "2026-06-15T16:02:45.346Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c9/f14fdf71bb8957e0c7e39db69bbdf12b5c80f4ef775fdfa127bf4e0d6760/sqlalchemy-2.0.51-cp314-cp314t-win32.whl", hash = "sha256:9161cfc9efce70d1715f47d6ff40f79c6778c00d53be4fbc09d70301e4b83ba7", size = 2151313, upload-time = "2026-06-15T16:03:39.127Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c6/673e618e6f4f297e126d9b56ea2f6478708f6c1af4e3223835c22e2c3697/sqlalchemy-2.0.51-cp314-cp314t-win_amd64.whl", hash = "sha256:159bb6ba32059f57ad7375a8f50d844dd2f19d14954ecf820cd33e20debd46b2", size = 2186280, upload-time = "2026-06-15T16:03:40.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/22/dbf013a12ec759e54a34a119e9e217435b3f71b2dd5c61a7ade0a25dae87/sqlalchemy-2.0.51-py3-none-any.whl", hash = "sha256:bb024d8b621d0be75f4f44ecc7c950450026e76d66dc8f791bb5331d7fed59d5", size = 1944334, upload-time = "2026-06-15T16:09:22.418Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1011,6 +1133,7 @@ name = "stream-sniper"
 version = "2.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "alembic" },
     { name = "bcrypt" },
     { name = "chat-downloader" },
     { name = "email-validator" },
@@ -1043,6 +1166,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.18.5" },
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "chat-downloader", specifier = "~=0.2.8" },
     { name = "email-validator", specifier = ">=2.0.0" },

--- a/frontend/components/AsyncSearchSelect.jsx
+++ b/frontend/components/AsyncSearchSelect.jsx
@@ -1,0 +1,52 @@
+'use client'
+import { useCallback, useRef } from 'react'
+import AsyncSelect from 'react-select/async'
+import AsyncCreatableSelect from 'react-select/async-creatable'
+
+/**
+ * Debounced async react-select wrapper for server-backed autocomplete.
+ *
+ * react-select's AsyncSelect calls loadOptions on every keystroke; we wrap it in
+ * a small setTimeout debounce so a suggestion request only fires once the user
+ * pauses typing. Set `creatable` to allow selecting a value the search didn't
+ * surface (used by the add-streamer field, since Twitch search only returns
+ * channels active in the last 6 months).
+ *
+ * @param {object} props
+ * @param {(query: string) => Promise<Array>} props.loadOptions - returns option objects
+ * @param {number} [props.debounceMs=300] - debounce window in milliseconds
+ * @param {boolean} [props.creatable=false] - allow free-text created options
+ */
+const DEFAULT_DEBOUNCE_MS = 300
+
+const AsyncSearchSelect = ({
+    loadOptions,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    creatable = false,
+    ...selectProps
+}) => {
+    const timerRef = useRef(null)
+
+    const debouncedLoadOptions = useCallback(inputValue => new Promise((resolve, reject) => {
+        if (timerRef.current) {
+            clearTimeout(timerRef.current)
+        }
+        timerRef.current = setTimeout(() => {
+            Promise.resolve(loadOptions(inputValue)).then(resolve, reject)
+        }, debounceMs)
+    }), [
+        loadOptions,
+        debounceMs,
+    ])
+
+    const SelectComponent = creatable ? AsyncCreatableSelect : AsyncSelect
+
+    return (
+        <SelectComponent
+            loadOptions={debouncedLoadOptions}
+            {...selectProps}
+        />
+    )
+}
+
+export default AsyncSearchSelect

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -32,6 +32,8 @@ api.interceptors.response.use(
 // Data endpoints (baseURL '/api' already applied; paths are backend-relative after /api strip)
 export const retrieveMessages = (chatterId: string | number) => api.get(`/chatter/${chatterId}/messages`)
 export const retrieveChatterId = (nick: string) => api.get(`/chatter/${nick}/chatter_id`)
+export const retrieveChatterSearch = (q: string, limit = 10) => api.get(`/chatters/search?q=${encodeURIComponent(q)}&limit=${limit}`)
+export const retrieveTwitchChannelSearch = (q: string, limit = 8) => api.get(`/admin/tracking/twitch-search?q=${encodeURIComponent(q)}&limit=${limit}`)
 export const retrieveChattersOnStream = (streamId: string | number) => api.get(`/stream/${streamId}/chatters`)
 export const retrieveStreams = (creatorId: string | number, offset: number) => api.get(`/streams?creator_id=${creatorId}&offset=${offset}`)
 export const retrieveStreamComprehensive = (streamId: string | number) => api.get(`/stream/${streamId}`)

--- a/frontend/views/ChatterFootprint.jsx
+++ b/frontend/views/ChatterFootprint.jsx
@@ -3,40 +3,25 @@ import {
     useState, useCallback, useMemo,
 } from 'react'
 import {
-    Card, Form, Button, Table,
+    Card, Table,
 } from 'react-bootstrap'
 import Link from 'next/link'
 import {
-    useChatterId, useChatterStreamActivity,
+    useChatterStreamActivity,
 } from '@/hooks/useApiQuery'
+import { retrieveChatterSearch } from '@/lib/api'
+import AsyncSearchSelect from '@/components/AsyncSearchSelect'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorAlert from '@/components/ErrorAlert'
 import { formatStreamTimestamp } from '@/utils/dateUtils'
 
 const ChatterFootprint = () => {
     const [
-        nickInput,
-        setNickInput,
-    ] = useState('')
-    const [
-        submittedNick,
-        setSubmittedNick,
-    ] = useState('')
+        selectedChatter,
+        setSelectedChatter,
+    ] = useState(null)
 
-    const {
-        data: chatterIdData,
-        isLoading: chatterIdLoading,
-        error: chatterIdError,
-        refetch: refetchChatterId,
-    } = useChatterId(submittedNick, Boolean(submittedNick))
-
-    // The chatter_id endpoint returns a list of ints, e.g. [42]
-    const chatterId = useMemo(() => {
-        if (Array.isArray(chatterIdData)) return chatterIdData[0] || null
-        return chatterIdData || null
-    }, [
-        chatterIdData,
-    ])
+    const chatterId = selectedChatter?.value || null
 
     const {
         data: activityData,
@@ -56,18 +41,39 @@ const ChatterFootprint = () => {
     ])
 
     /**
-     * Handles the nick lookup form submission
-     * @param {object} event
+     * Prefix-search chatter nicks for the autocomplete dropdown.
+     * The backend returns [[id, nick], ...]; map to react-select options.
+     * @param {string} query
+     * @returns {Promise<Array<{value: number, label: string}>>}
      */
-    const handleSubmit = useCallback(event => {
-        event.preventDefault()
-        setSubmittedNick(nickInput.trim())
+    const loadChatterOptions = useCallback(async query => {
+        const trimmed = query.trim()
+        if (trimmed.length < 2) {
+            return []
+        }
+        try {
+            const { data } = await retrieveChatterSearch(trimmed)
+            return (data || []).map(([
+                id,
+                nick,
+            ]) => ({
+                value: id,
+                label: nick,
+            }))
+        } catch {
+            return []
+        }
     }, [
-        nickInput,
     ])
 
-    const isNotFound = chatterIdError?.response?.status === 404
-    const isLoading = chatterIdLoading || activityLoading
+    const noOptionsMessage = useCallback(({ inputValue }) => (
+        inputValue && inputValue.trim().length >= 2
+            ? `No chatters matching "${inputValue}"`
+            : 'Type at least 2 characters to search'
+    ), [
+    ])
+
+    const isLoading = Boolean(chatterId) && activityLoading
 
     return (
         <>
@@ -78,8 +84,7 @@ const ChatterFootprint = () => {
                 </div>
             </div>
 
-            <Form
-                onSubmit={handleSubmit}
+            <div
                 className="toolbar"
                 role="search"
             >
@@ -95,42 +100,35 @@ const ChatterFootprint = () => {
                     >
                         Chatter nickname
                     </label>
-                    <Form.Control
-                        id="footprint-nick-input"
-                        type="text"
-                        value={nickInput}
-                        onChange={event => setNickInput(event.target.value)}
-                        placeholder="Enter chatter nickname..."
+                    <AsyncSearchSelect
+                        instanceId="footprint-nick-select"
+                        inputId="footprint-nick-input"
+                        loadOptions={loadChatterOptions}
+                        value={selectedChatter}
+                        onChange={setSelectedChatter}
+                        noOptionsMessage={noOptionsMessage}
+                        placeholder="Search for a chatter..."
+                        isClearable
                         aria-label="Chatter nickname"
                     />
                 </div>
-                <Button
-                    type="submit"
-                    variant="primary"
-                    disabled={!nickInput.trim()}
-                >
-                    <i
-                        className="bi bi-crosshair me-2"
-                        aria-hidden="true"></i>
-                    Trace
-                </Button>
-                {submittedNick && activity.length > 0 && !isLoading && (
+                {selectedChatter && activity.length > 0 && !isLoading && (
                     <span className="toolbar-readout">
-                        <strong>{activity.length}</strong> streams · target <strong>{submittedNick}</strong>
+                        <strong>{activity.length}</strong> streams · target <strong>{selectedChatter.label}</strong>
                     </span>
                 )}
-            </Form>
+            </div>
 
             <Card>
-                <Card.Body className={!submittedNick || isNotFound || (chatterId && activity.length === 0 && !isLoading) ? 'p-0' : ''}>
-                    {!submittedNick && (
+                <Card.Body className={!selectedChatter || (chatterId && activity.length === 0 && !isLoading) ? 'p-0' : ''}>
+                    {!selectedChatter && (
                         <div className="empty-state">
                             <div
                                 className="empty-scope"
                                 aria-hidden="true" />
                             <p className="empty-title">Awaiting target</p>
                             <p className="empty-hint">
-                                Enter a chatter nickname to see every captured stream they appear in.
+                                Search for a chatter nickname to see every captured stream they appear in.
                             </p>
                         </div>
                     )}
@@ -139,27 +137,6 @@ const ChatterFootprint = () => {
                         <LoadingSpinner
                             size="lg"
                             text="Tracing chatter footprint..."
-                        />
-                    )}
-
-                    {isNotFound && !isLoading && (
-                        <div className="empty-state">
-                            <div
-                                className="empty-scope"
-                                aria-hidden="true" />
-                            <p className="empty-title">No signal</p>
-                            <p className="empty-hint">
-                                No chatter found with the nickname <strong>{submittedNick}</strong>.
-                            </p>
-                        </div>
-                    )}
-
-                    {chatterIdError && !isNotFound && !isLoading && (
-                        <ErrorAlert
-                            error={chatterIdError}
-                            title="Failed to look up chatter"
-                            onRetry={refetchChatterId}
-                            showDetails={process.env.NODE_ENV === 'development'}
                         />
                     )}
 

--- a/frontend/views/admin/ProcessingJobs.jsx
+++ b/frontend/views/admin/ProcessingJobs.jsx
@@ -5,6 +5,7 @@ import {
 import {
     Card, Table, Alert, Spinner, Form, Pagination,
 } from 'react-bootstrap'
+import Select from 'react-select'
 import { api } from '@/lib/api'
 
 /**
@@ -43,59 +44,67 @@ const StatisticsCards = ({ stats }) => (
  * Filters Toolbar Component
  */
 const JobFilters = ({
-    filters, setFilters, total,
-}) => (
-    <div className="toolbar">
-        <span
-            className="toolbar-label"
-            aria-hidden="true">
-            Filter
-        </span>
-        <div className="toolbar-field">
-            <label
-                htmlFor="jobs-status-filter"
-                className="visually-hidden"
-            >
-                Filter by status
-            </label>
-            <Form.Select
-                id="jobs-status-filter"
-                value={filters.status}
-                onChange={e => setFilters(prev => ({
-                    ...prev,
-                    status: e.target.value,
-                }))}
-            >
-                <option value="">All statuses</option>
-                <option value="pending">Pending</option>
-                <option value="in_progress">In Progress</option>
-                <option value="completed">Completed</option>
-                <option value="failed">Failed</option>
-            </Form.Select>
+    filters, setFilters, total, streamerOptions,
+}) => {
+    const selectedStreamer = streamerOptions.find(
+        option => String(option.value) === String(filters.tracked_streamer_id)
+    ) || null
+
+    return (
+        <div className="toolbar">
+            <span
+                className="toolbar-label"
+                aria-hidden="true">
+                Filter
+            </span>
+            <div className="toolbar-field">
+                <label
+                    htmlFor="jobs-status-filter"
+                    className="visually-hidden"
+                >
+                    Filter by status
+                </label>
+                <Form.Select
+                    id="jobs-status-filter"
+                    value={filters.status}
+                    onChange={e => setFilters(prev => ({
+                        ...prev,
+                        status: e.target.value,
+                    }))}
+                >
+                    <option value="">All statuses</option>
+                    <option value="pending">Pending</option>
+                    <option value="in_progress">In Progress</option>
+                    <option value="completed">Completed</option>
+                    <option value="failed">Failed</option>
+                </Form.Select>
+            </div>
+            <div className="toolbar-field">
+                <label
+                    htmlFor="jobs-streamer-filter"
+                    className="visually-hidden"
+                >
+                    Filter by streamer
+                </label>
+                <Select
+                    instanceId="jobs-streamer-filter-select"
+                    inputId="jobs-streamer-filter"
+                    options={streamerOptions}
+                    value={selectedStreamer}
+                    onChange={option => setFilters(prev => ({
+                        ...prev,
+                        tracked_streamer_id: option?.value ?? '',
+                    }))}
+                    placeholder="Filter by streamer"
+                    isClearable
+                />
+            </div>
+            <span className="toolbar-readout">
+                {total} jobs
+            </span>
         </div>
-        <div className="toolbar-field">
-            <label
-                htmlFor="jobs-streamer-filter"
-                className="visually-hidden"
-            >
-                Filter by streamer ID
-            </label>
-            <Form.Control
-                id="jobs-streamer-filter"
-                type="number"
-                value={filters.tracked_streamer_id}
-                onChange={e => setFilters(prev => ({
-                    ...prev,
-                    tracked_streamer_id: e.target.value,
-                }))}
-                placeholder="Filter by streamer ID"
-            />
-        </div>
-        <span className="toolbar-readout">
-            {total} jobs
-        </span>
-    </div>
-)
+    )
+}
 
 const ProcessingJobs = () => {
     const [
@@ -131,6 +140,11 @@ const ProcessingJobs = () => {
         stats,
         setStats,
     ] = useState({})
+    const [
+        streamerOptions,
+        setStreamerOptions,
+    ] = useState([
+    ])
 
     const fetchJobs = useCallback(async () => {
         try {
@@ -178,12 +192,31 @@ const ProcessingJobs = () => {
     }, [
     ])
 
+    const fetchStreamerOptions = useCallback(async () => {
+        try {
+            const { data } = await api.get('/admin/tracking/streamers?limit=1000')
+            setStreamerOptions((data.streamers || []).map(streamer => ({
+                value: streamer.id,
+                label: streamer.twitch_username,
+            })))
+        } catch (optionsError) {
+            console.error('Error fetching streamer options:', optionsError)
+        }
+    }, [
+    ])
+
     useEffect(() => {
         fetchJobs()
         fetchStats()
     }, [
         fetchJobs,
         fetchStats,
+    ])
+
+    useEffect(() => {
+        fetchStreamerOptions()
+    }, [
+        fetchStreamerOptions,
     ])
 
     const handlePageChange = page => {
@@ -251,7 +284,8 @@ const ProcessingJobs = () => {
             <JobFilters
                 filters={filters}
                 setFilters={setFilters}
-                total={pagination.total} />
+                total={pagination.total}
+                streamerOptions={streamerOptions} />
 
             <Card>
                 <Card.Body className={!loading && jobs.length === 0 ? 'p-0' : ''}>

--- a/frontend/views/admin/StreamerTracking.jsx
+++ b/frontend/views/admin/StreamerTracking.jsx
@@ -5,7 +5,8 @@ import {
 import {
     Card, Table, Button, Alert, Spinner, Modal, Form, Pagination,
 } from 'react-bootstrap'
-import { api } from '@/lib/api'
+import { api, retrieveTwitchChannelSearch } from '@/lib/api'
+import AsyncSearchSelect from '@/components/AsyncSearchSelect'
 
 const StreamerTracking = () => {
     const [
@@ -128,6 +129,30 @@ const StreamerTracking = () => {
             setFormSubmitting(false)
         }
     }
+
+    /**
+     * Search live Twitch channels for the add-streamer typeahead.
+     * @param {string} query
+     * @returns {Promise<Array<{value: string, label: string}>>}
+     */
+    const loadChannelOptions = useCallback(async query => {
+        const trimmed = query.trim()
+        if (trimmed.length < 2) {
+            return []
+        }
+        try {
+            const { data } = await retrieveTwitchChannelSearch(trimmed)
+            return (data || []).map(channel => ({
+                value: channel.login,
+                label: channel.display_name
+                    ? `${channel.display_name} (${channel.login})`
+                    : channel.login,
+            }))
+        } catch {
+            return []
+        }
+    }, [
+    ])
 
     const handleToggleActive = async (streamerId, currentStatus) => {
         try {
@@ -417,16 +442,25 @@ const StreamerTracking = () => {
                 <Form onSubmit={handleAddStreamer}>
                     <Modal.Body>
                         <Form.Group className="mb-3">
-                            <Form.Label>Twitch Username *</Form.Label>
-                            <Form.Control
-                                type="text"
-                                value={newStreamer.twitch_username}
-                                onChange={e => setNewStreamer(prev => ({
+                            <Form.Label htmlFor="add-streamer-username">Twitch Username *</Form.Label>
+                            <AsyncSearchSelect
+                                creatable
+                                instanceId="add-streamer-username-select"
+                                inputId="add-streamer-username"
+                                loadOptions={loadChannelOptions}
+                                value={newStreamer.twitch_username
+                                    ? {
+                                        value: newStreamer.twitch_username,
+                                        label: newStreamer.twitch_username,
+                                    }
+                                    : null}
+                                onChange={option => setNewStreamer(prev => ({
                                     ...prev,
-                                    twitch_username: e.target.value,
+                                    twitch_username: option?.value ?? '',
                                 }))}
-                                required
-                                placeholder="Enter Twitch username"
+                                placeholder="Search Twitch or type a username"
+                                formatCreateLabel={value => `Track "${value}"`}
+                                isClearable
                             />
                         </Form.Group>
                         <Form.Group className="mb-3">
@@ -474,7 +508,7 @@ const StreamerTracking = () => {
                         <Button
                             variant="primary"
                             type="submit"
-                            disabled={formSubmitting}>
+                            disabled={formSubmitting || !newStreamer.twitch_username.trim()}>
                             {formSubmitting ? (
                                 <>
                                     <Spinner


### PR DESCRIPTION
## Summary

Two related pieces of work:

### 1. Autocomplete on the three plain-text search inputs
The app's creator dropdowns already had typeahead; these three did not.

- **Chatter footprint** — server-backed prefix search via new `GET /chatters/search` (SEARCH rate limit, cached, min-2-char guard) + a `select_chatters_by_prefix_db` gateway (case-insensitive `lower(nick) LIKE 'foo%'`). The view now selects a chatter directly, dropping the old exact-match lookup + its 404 branch.
- **Add streamer (admin)** — typeahead against the **live Twitch search API** via new `GET /admin/tracking/twitch-search` + `TwitchAPI.search_channels_async`, with a lazy-init guard so OAuth runs once. Creatable select, so an admin can still type a username Twitch search doesn't surface (it only returns channels active in the last 6 months).
- **Processing jobs (admin)** — the raw numeric streamer-ID input becomes a tracked-streamer name typeahead reusing the existing list endpoint (also removes the per-keystroke refetch).

Shared `components/AsyncSearchSelect.jsx` wraps react-select's `async`/`async-creatable` with a debounce — **no new dependency**. Adds 8 endpoint tests.

### 2. Alembic schema migrations
Motivated by needing to ship the chatter prefix index to the already-populated prod DB — schema changes stop being hand-applied `psql`.

- Full Alembic env for the raw-psycopg2 backend (hand-written raw-SQL migrations, **no ORM/autogenerate**). `env.py` reuses `connection_pool.py`'s env precedence, targets the `stream_sniper` schema, and creates the schema on a separate transaction *before* the version table (required because `version_table_schema` makes Alembic create `alembic_version` first).
- **Rev 0001** = baseline pre-index schema (applied on fresh DBs, **stamped** on prod). **Rev 0002** = `chatter_nick_lower_prefix_idx` built `CONCURRENTLY` via `autocommit_block`; refuses offline mode.
- `stream-sniper-migrate` packaged entry point runs migrations inside the source-less prod container. `create_table.sql` demoted to a reference-only baseline snapshot.
- Migrations are **manual, not auto-run on deploy** (a revision may build an index `CONCURRENTLY` on a large table).

## Verification

- **Frontend**: `tsc` clean, ESLint 0 errors, production build prerenders all affected pages.
- **Backend**: ruff clean; 90 unit tests pass (8 new), no regressions (21 errors are pre-existing — they need the external Postgres).
- **Alembic**: verified end-to-end against a disposable **Postgres 16** — fresh-DB upgrade (with the schema-bootstrap fix), downgrade-to-base, simulated-prod `stamp 0001 → upgrade head` (adds only the index, recreates nothing), offline `CONCURRENTLY` refusal, and `pg_dump` fidelity of rev 0001 vs `create_table.sql`.

## ⚠️ Post-merge action required

The prod DB (external RPI, not reachable from CI) needs a **one-time** bootstrap after deploy:

    docker exec stream-sniper-api stream-sniper-migrate stamp 0001   # NOT head
    docker exec stream-sniper-api stream-sniper-migrate upgrade head # builds the index CONCURRENTLY

New app code is safe to deploy before the index lands — `lower(nick) LIKE 'foo%'` just seq-scans without it.

https://claude.ai/code/session_0197rEyQS297AjGB1qz9Hz1c