### PR TITLE
Fix /metrics 500 (unpack bug) and insert_new_chatters_db return type

### DIFF
--- a/backend/stream_sniper/api/monitoring.py
+++ b/backend/stream_sniper/api/monitoring.py
@@ -295,7 +295,7 @@ class MetricsCollector:
                         "error_rate": round((stats["error_count"] / max(stats["count"], 1)) * 100, 2),
                         "cache_hit_rate": round((stats["cache_hits"] / max(stats["count"], 1)) * 100, 2),
                     }
-                    for endpoint, stats in dict(top_endpoints)
+                    for endpoint, stats in top_endpoints
                 },
             }
 

--- a/backend/stream_sniper/database/chatter_table_gateway.py
+++ b/backend/stream_sniper/database/chatter_table_gateway.py
@@ -51,12 +51,11 @@ def insert_new_chatter_db(nick, cursor, connection):
 
 
 @with_cursor_connection
-def insert_new_chatters_db(nicks: List[str], cursor, connection) -> List[int]:
+def insert_new_chatters_db(nicks: List[str], cursor, connection) -> None:
     """
-    Tries to insert new chatters. If it can, then it returns their IDs.
-    If this function cannot insert, it returns existing chatters IDs.
+    Insert new chatters, skipping any that already exist (ON CONFLICT DO NOTHING).
+    Callers fetch the resulting IDs separately via select_all_chatters_db().
     :param nicks: Nicks of the chatters
-    :return: Created chatters IDs or Existing chatters IDs
     """
     sql = """
     INSERT INTO 


### PR DESCRIPTION
Two pre-existing issues logged in IMPROVEMENTS.md.

## `GET /metrics` 500
`monitoring.py` did `for endpoint, stats in dict(top_endpoints)` — iterating a dict yields **keys**, so it tried to unpack each endpoint-path string into `(endpoint, stats)` and raised `too many values to unpack (expected 2)` whenever any request had been recorded (the empty-stats case worked, masking it). `top_endpoints` is already a list of `(endpoint, stats)` tuples — iterate it directly.

Verified: `get_monitoring_data()` with a recorded endpoint now returns correct per-endpoint metrics (avg/min/max/error-rate/cache-hit) instead of raising.

## `insert_new_chatters_db` return type
Annotated `-> List[int]` but the body has no `return` (returns `None`). The only caller discards the result and fetches IDs via `select_all_chatters_db()`. Corrected to `-> None` and fixed the misleading docstring (it's `ON CONFLICT DO NOTHING`; no IDs are returned).

90 unit tests pass; ruff clean.

https://claude.ai/code/session_0197rEyQS297AjGB1qz9Hz1c