### PR TITLE
Fix 500 on /metrics and /cache/stats (slowapi response param)

### DIFF
--- a/backend/stream_sniper/api/api.py
+++ b/backend/stream_sniper/api/api.py
@@ -1196,7 +1196,7 @@ stream_sniper_component_health{component="cache"} 1.0
     },
 )
 @limiter.limit(rate_limits.GENERAL)
-def prometheus_metrics(request: Request):
+def prometheus_metrics(request: Request, response: Response):
     """Get Prometheus-compatible metrics"""
     try:
         health_checker = get_health_checker()
@@ -1240,7 +1240,7 @@ stream_sniper_metrics_error 1 {error_time}
     },
 )
 @limiter.limit(rate_limits.GENERAL)
-def get_metrics(request: Request):
+def get_metrics(request: Request, response: Response):
     """Get comprehensive API performance metrics"""
     try:
         metrics_data = get_monitoring_data()
@@ -1267,7 +1267,7 @@ def get_metrics(request: Request):
     },
 )
 @limiter.limit(rate_limits.GENERAL)
-def get_cache_stats(request: Request):
+def get_cache_stats(request: Request, response: Response):
     """Get detailed cache performance statistics"""
     try:
         cache = get_cache()
@@ -1305,7 +1305,7 @@ def get_cache_stats(request: Request):
     },
 )
 @limiter.limit(rate_limits.HEAVY)
-def flush_cache(request: Request):
+def flush_cache(request: Request, response: Response):
     """Flush all cached data"""
     try:
         cache = get_cache()


### PR DESCRIPTION
## Problem

`GET /metrics` and `GET /cache/stats` returned **HTTP 500** in production even after PR #33 fixed the `dict(top_endpoints)` unpack bug. The unpack fix unmasked a second, pre-existing failure:

```
Exception: parameter `response` must be an instance of starlette.responses.Response
  File ".../slowapi/extension.py", line 383, in _inject_headers
```

slowapi runs with `headers_enabled=True`, so its `_inject_headers` hook must attach the `X-RateLimit-*` headers to a `Response` object. It looks for a `response: Response` parameter on the endpoint. Four rate-limited endpoints declared only `request: Request`:

- `prometheus_metrics`
- `get_metrics`
- `get_cache_stats`
- `flush_cache`

so every call to them raised and returned 500. All the data endpoints already declare `response: Response`, which is why only these four were affected.

## Fix

Add `response: Response` to the four endpoint signatures. `Response` is already imported in `api.py`.

## Verification

Local `TestClient` (raise_server_exceptions=False):

| path | before | after |
|------|--------|-------|
| `/metrics` | 500 | **200** |
| `/metrics/prometheus` | 500 | **200** |
| `/cache/stats` | 500 | **200** |

`ruff check` clean; `tests/unit/api` + `tests/unit/tracking` → 61 passed. (DB gateway unit tests error locally only because Postgres is external/unreachable — unrelated.)

Closes the last IMPROVEMENTS.md item for `/metrics` (the unpack fix alone was insufficient).

https://claude.ai/code/session_0197rEyQS297AjGB1qz9Hz1c