### PR TITLE
Implement chatter messages page: paginated cross-stream message log

### DIFF
--- a/backend/stream_sniper/api/api.py
+++ b/backend/stream_sniper/api/api.py
@@ -16,6 +16,7 @@ from ..database.connection_pool import close_pool
 from ..database.creator_table_gateway import select_creator_top_chatters_db, select_creators_db
 from ..database.message_table_gateway import (
     select_chatter_id_db,
+    select_chatter_message_count_db,
     select_chatter_messages_db,
     select_chatter_stream_activity_db,
 )
@@ -144,6 +145,15 @@ class StreamsResponse(BaseModel):
 
     streams: List[List[Any]] = Field(..., description="List of stream data tuples")
     max_offset: int = Field(..., description="Maximum offset for pagination", json_schema_extra={"example": 1000})
+
+
+class ChatterMessagesResponse(BaseModel):
+    """Paginated cross-stream chatter message log"""
+
+    messages: List[List[Any]] = Field(
+        ..., description="List of [stream_id, stream_title, streamer_display_name, text, timestamp] tuples"
+    )
+    total: int = Field(..., description="Total messages sent by the chatter", json_schema_extra={"example": 1234})
 
 
 class ErrorResponse(BaseModel):
@@ -348,63 +358,82 @@ async def metrics_middleware(request: Request, call_next):
 
 @app.get(
     "/chatter/{chatter_id}/messages",
-    response_model=List[List[str]],
+    response_model=ChatterMessagesResponse,
     tags=["Chatters"],
     summary="Get messages by chatter",
     description=f"""
-    Retrieve all messages sent by a specific chatter across all streams.
-    Returns a list of [message_text, timestamp] tuples.
-    
+    Retrieve messages sent by a specific chatter across all streams, newest first,
+    with pagination. Each row is a
+    [stream_id, stream_title, streamer_display_name, message_text, timestamp] tuple;
+    `total` is the chatter's overall message count.
+
     **Rate Limit**: {rate_limits.GENERAL}
     """,
     responses={
         200: {
-            "description": "List of messages with timestamps",
+            "description": "Paginated list of messages with stream context",
             "content": {
                 "application/json": {
-                    "example": [
-                        ["Hello everyone!", "2024-01-15 20:30:15"],
-                        ["Great stream!", "2024-01-15 20:45:22"],
-                        ["@streamer keep it up!", "2024-01-15 21:10:03"],
-                    ]
+                    "example": {
+                        "messages": [
+                            [7, "Epic Gaming Session", "SomeStreamer", "Hello everyone!", "2024-01-15 20:30:15"],
+                            [7, "Epic Gaming Session", "SomeStreamer", "Great stream!", "2024-01-15 20:45:22"],
+                        ],
+                        "total": 1234,
+                    }
                 }
             },
         },
-        404: {"model": ErrorResponse, "description": "Chatter not found"},
         429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
     },
 )
 @limiter.limit(rate_limits.GENERAL)
 def get_chatter_messages(
-    request: Request, response: Response, chatter_id: int = Path(..., description="Unique chatter ID", json_schema_extra={"example": 42})
+    request: Request,
+    response: Response,
+    chatter_id: int = Path(..., description="Unique chatter ID", json_schema_extra={"example": 42}),
+    offset: int = Query(0, ge=0, description="Row offset for pagination", json_schema_extra={"example": 0}),
+    limit: int = Query(50, ge=1, le=200, description="Maximum messages per page"),
 ):
-    """Get all messages sent by a specific chatter"""
+    """Get paginated messages sent by a specific chatter across all streams"""
     try:
-        # Try cache first
         cache = get_cache()
-        cache_key = cache._generate_key("chatter_messages", chatter_id)
-        cached_result = cache.get(cache_key)
 
-        if cached_result is not None:
-            response.headers["X-Cache"] = "HIT"
+        messages_cache_key = cache._generate_key("chatter_messages", chatter_id, limit, offset)
+        cached_messages = cache.get(messages_cache_key)
+
+        count_cache_key = cache._generate_key("chatter_message_count", chatter_id)
+        cached_count = cache.get(count_cache_key)
+
+        messages_from_cache = cached_messages is not None
+        count_from_cache = cached_count is not None
+
+        if not messages_from_cache:
+            record_cache_operation("miss", "chatter_messages")
+            messages = select_chatter_messages_db(chatter_id, limit, offset)
+            cache.set(messages_cache_key, messages, CacheTTL.CHATTER_MESSAGES)
+            record_cache_operation("set", "chatter_messages")
+        else:
             record_cache_operation("hit", "chatter_messages")
-            return cached_result
+            messages = cached_messages
 
-        # Cache miss - fetch from database
-        record_cache_operation("miss", "chatter_messages")
-        result = select_chatter_messages_db(chatter_id)
+        if not count_from_cache:
+            record_cache_operation("miss", "chatter_message_count")
+            total = select_chatter_message_count_db(chatter_id)
+            cache.set(count_cache_key, total, CacheTTL.CHATTER_MESSAGES)
+            record_cache_operation("set", "chatter_message_count")
+        else:
+            record_cache_operation("hit", "chatter_message_count")
+            total = cached_count
 
-        if not result:
-            raise HTTPException(status_code=404, detail="Chatter not found or has no messages")
+        if messages_from_cache and count_from_cache:
+            response.headers["X-Cache"] = "HIT"
+        elif messages_from_cache or count_from_cache:
+            response.headers["X-Cache"] = "PARTIAL"
+        else:
+            response.headers["X-Cache"] = "MISS"
 
-        # Cache the result
-        cache.set(cache_key, result, CacheTTL.CHATTER_MESSAGES)
-        record_cache_operation("set", "chatter_messages")
-        response.headers["X-Cache"] = "MISS"
-
-        return result
-    except HTTPException:
-        raise
+        return {"messages": messages, "total": total}
     except Exception as e:
         logger.error(f"Error fetching chatter messages: {e}")
         record_cache_operation("error", "chatter_messages")

--- a/backend/stream_sniper/database/__init__.py
+++ b/backend/stream_sniper/database/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "select_creator_top_chatters_db",
     # Message gateway functions
     "select_chatter_messages_db",
+    "select_chatter_message_count_db",
     "insert_message_db",
     "select_chatter_id_db",
     "select_chatter_stream_activity_db",

--- a/backend/stream_sniper/database/message_table_gateway.py
+++ b/backend/stream_sniper/database/message_table_gateway.py
@@ -2,19 +2,28 @@ from .decorators import with_cursor
 
 
 @with_cursor
-def select_chatter_messages_db(chatter_id, cursor):
-    # NOTE: the message table has no "message" column — selecting one used to
-    # silently resolve to the whole-row composite. Join message_text for the
-    # actual text and format time as a string for the JSON response model.
+def select_chatter_messages_db(chatter_id, limit, offset, cursor):
     cursor.execute(
         """
-        SELECT (SELECT text FROM message_text WHERE id = message.message_text_id),
-               TO_CHAR(time, 'YYYY-MM-DD HH24:MI:SS')
-        FROM message WHERE chatter_id = %s ORDER BY time
+        SELECT m.stream_id, s.title, cr.display_name, mt.text,
+               TO_CHAR(m.time, 'YYYY-MM-DD HH24:MI:SS')
+        FROM message m
+        JOIN stream s ON s.id = m.stream_id
+        JOIN creator cr ON cr.id = s.creator_id
+        JOIN message_text mt ON mt.id = m.message_text_id
+        WHERE m.chatter_id = %s
+        ORDER BY m.time DESC
+        LIMIT %s OFFSET %s
         """,
-        (chatter_id,),
+        (chatter_id, limit, offset),
     )
     return cursor.fetchall()
+
+
+@with_cursor
+def select_chatter_message_count_db(chatter_id, cursor):
+    cursor.execute("SELECT COUNT(*) FROM message WHERE chatter_id = %s", (chatter_id,))
+    return cursor.fetchone()[0]
 
 
 def insert_message_db(items: list[tuple], cursor, connection):

--- a/backend/tests/integration/test_api_workflows.py
+++ b/backend/tests/integration/test_api_workflows.py
@@ -162,7 +162,11 @@ class TestAPIWorkflowIntegration:
         response = api_client_with_db.get(f"/chatter/{test_chatter_id}/messages/")
         assert response.status_code == 200
         chatter_messages = response.json()
-        assert len(chatter_messages) >= 1
+        assert chatter_messages["total"] >= 1
+        assert len(chatter_messages["messages"]) >= 1
+        # Each row is [stream_id, stream_title, streamer_display_name, text, timestamp]
+        assert chatter_messages["messages"][0][0] == stream_id
+        assert chatter_messages["messages"][0][3] in messages
 
         # Test GET /stream/{stream_id}/chatter/{chatter_id}/messages
         response = api_client_with_db.get(f"/stream/{stream_id}/chatter/{test_chatter_id}/messages")

--- a/backend/tests/integration/test_api_workflows.py
+++ b/backend/tests/integration/test_api_workflows.py
@@ -234,9 +234,10 @@ class TestAPIWorkflowIntegration:
         assert response.status_code == 404
         assert "detail" in response.json()
 
-        # Non-existent chatter
+        # Non-existent chatter — messages endpoint returns an empty page, not a 404
         response = api_client_with_db.get("/chatter/99999/messages/")
-        assert response.status_code == 404
+        assert response.status_code == 200
+        assert response.json() == {"messages": [], "total": 0}
 
         # Non-existent chatter nick
         response = api_client_with_db.get("/chatter/nonexistent_chatter/chatter_id")
@@ -329,8 +330,9 @@ class TestAPIWorkflowIntegration:
         assert chatter_found
 
         # Chatter should have messages
-        assert len(chatter_messages) >= 1
-        assert chatter_messages[0][0] == "Consistency test message"
+        assert chatter_messages["total"] >= 1
+        # Each row is [stream_id, stream_title, streamer_display_name, text, timestamp]
+        assert chatter_messages["messages"][0][3] == "Consistency test message"
 
     def test_api_health_check_workflow(self, api_client_with_db):
         """Test health check endpoint with real database."""
@@ -438,5 +440,6 @@ class TestAPIWorkflowIntegration:
         messages = response.json()
 
         # Verify unicode message content
-        assert len(messages) >= 1
-        assert "Hello! 😀🎮 你好世界 ★☆♦" in messages[0][0]
+        assert messages["total"] >= 1
+        # Each row is [stream_id, stream_title, streamer_display_name, text, timestamp]
+        assert "Hello! 😀🎮 你好世界 ★☆♦" in messages["messages"][0][3]

--- a/backend/tests/unit/api/test_api.py
+++ b/backend/tests/unit/api/test_api.py
@@ -29,37 +29,65 @@ def _miss_cache():
 class TestChattersEndpoints:
     """Test suite for chatter-related API endpoints."""
 
+    @patch("stream_sniper.api.api.get_cache")
+    @patch("stream_sniper.api.api.select_chatter_message_count_db")
     @patch("stream_sniper.api.api.select_chatter_messages_db")
-    def test_get_chatter_messages_success(self, mock_select):
-        """Test successful retrieval of chatter messages."""
+    def test_get_chatter_messages_success(self, mock_select, mock_count, mock_get_cache):
+        """Test successful retrieval of paginated chatter messages with stream context."""
+        mock_get_cache.return_value = _miss_cache()
         mock_select.return_value = [
-            ["Hello everyone!", "2024-01-15 20:30:15"],
-            ["Great stream!", "2024-01-15 20:45:22"],
+            [7, "Epic Gaming Session", "SomeStreamer", "Hello everyone!", "2024-01-15 20:30:15"],
+            [8, "Chill Stream", "OtherStreamer", "Great stream!", "2024-01-14 20:45:22"],
         ]
+        mock_count.return_value = 1234
 
         with TestClient(app) as client:
             response = client.get("/chatter/42/messages")
 
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 2
-        assert data[0] == ["Hello everyone!", "2024-01-15 20:30:15"]
-        mock_select.assert_called_once_with(42)
+        assert data["total"] == 1234
+        assert len(data["messages"]) == 2
+        assert data["messages"][0] == [7, "Epic Gaming Session", "SomeStreamer", "Hello everyone!", "2024-01-15 20:30:15"]
+        mock_select.assert_called_once_with(42, 50, 0)
+        mock_count.assert_called_once_with(42)
 
+    @patch("stream_sniper.api.api.get_cache")
+    @patch("stream_sniper.api.api.select_chatter_message_count_db")
     @patch("stream_sniper.api.api.select_chatter_messages_db")
-    def test_get_chatter_messages_not_found(self, mock_select):
-        """Test chatter messages endpoint when chatter not found."""
-        mock_select.return_value = None
+    def test_get_chatter_messages_pagination_params(self, mock_select, mock_count, mock_get_cache):
+        """Test that limit and offset query params are passed to the gateway."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_select.return_value = []
+        mock_count.return_value = 0
+
+        with TestClient(app) as client:
+            response = client.get("/chatter/42/messages?offset=100&limit=25")
+
+        assert response.status_code == 200
+        mock_select.assert_called_once_with(42, 25, 100)
+
+    @patch("stream_sniper.api.api.get_cache")
+    @patch("stream_sniper.api.api.select_chatter_message_count_db")
+    @patch("stream_sniper.api.api.select_chatter_messages_db")
+    def test_get_chatter_messages_empty_returns_200(self, mock_select, mock_count, mock_get_cache):
+        """Test that a chatter with no messages returns an empty page, not a 404."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_select.return_value = []
+        mock_count.return_value = 0
 
         with TestClient(app) as client:
             response = client.get("/chatter/999/messages")
 
-        assert response.status_code == 404
-        assert response.json()["detail"] == "Chatter not found or has no messages"
+        assert response.status_code == 200
+        assert response.json() == {"messages": [], "total": 0}
 
+    @patch("stream_sniper.api.api.get_cache")
+    @patch("stream_sniper.api.api.select_chatter_message_count_db")
     @patch("stream_sniper.api.api.select_chatter_messages_db")
-    def test_get_chatter_messages_server_error(self, mock_select):
+    def test_get_chatter_messages_server_error(self, mock_select, mock_count, mock_get_cache):
         """Test chatter messages endpoint with database error."""
+        mock_get_cache.return_value = _miss_cache()
         mock_select.side_effect = Exception("Database connection failed")
 
         with TestClient(app) as client:

--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -17,6 +17,7 @@ export const API_CONFIG = {
 export const PAGINATION = {
     DEFAULT_OFFSET: 0,
     ITEMS_PER_PAGE: 20,
+    MESSAGES_PER_PAGE: 50,
     MAX_VISIBLE_PAGES: 5,
 }
 

--- a/frontend/hooks/useMessagesQuery.js
+++ b/frontend/hooks/useMessagesQuery.js
@@ -3,6 +3,7 @@ import {
     retrieveMessages,
     retrieveChatterOnStreamMessages,
 } from '@/lib/api'
+import { PAGINATION } from '@/constants'
 
 /**
  * Query key factory for messages-related queries
@@ -15,9 +16,12 @@ export const messagesKeys = {
         ...messagesKeys.all,
         'list',
     ],
-    list: chatterId => [
+    list: (chatterId, offset) => [
         ...messagesKeys.lists(),
-        { chatterId },
+        {
+            chatterId,
+            offset,
+        },
     ],
     streamMessages: () => [
         ...messagesKeys.all,
@@ -33,17 +37,25 @@ export const messagesKeys = {
 }
 
 /**
- * Custom hook for fetching messages from a specific chatter using TanStack Query
+ * Custom hook for fetching a page of a chatter's cross-stream message log using TanStack Query
  * @param {string|number} chatterId - The chatter ID
+ * @param {number} offset - Page index (0-based); converted to a row offset for the API
  * @param {object} options - Additional query options
- * @returns {object} useQuery result with data, isLoading, error, etc.
+ * @returns {object} useQuery result with data ({messages, total}), isLoading, error, etc.
  */
-export const useMessages = (chatterId, options = {}) => useQuery({
-    queryKey: messagesKeys.list(chatterId),
+export const useMessages = (chatterId, offset = 0, options = {}) => useQuery({
+    queryKey: messagesKeys.list(chatterId, offset),
     queryFn: async () => {
-        const response = await retrieveMessages(chatterId)
-        return response.data || [
-        ]
+        const response = await retrieveMessages(
+            chatterId,
+            offset * PAGINATION.MESSAGES_PER_PAGE,
+            PAGINATION.MESSAGES_PER_PAGE,
+        )
+        return response.data || {
+            messages: [
+            ],
+            total: 0,
+        }
     },
     enabled: Boolean(chatterId), // Only enabled when chatterId is provided
     ...options,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -30,7 +30,7 @@ api.interceptors.response.use(
 )
 
 // Data endpoints (baseURL '/api' already applied; paths are backend-relative after /api strip)
-export const retrieveMessages = (chatterId: string | number) => api.get(`/chatter/${chatterId}/messages`)
+export const retrieveMessages = (chatterId: string | number, offset = 0, limit = 50) => api.get(`/chatter/${chatterId}/messages?offset=${offset}&limit=${limit}`)
 export const retrieveChatterId = (nick: string) => api.get(`/chatter/${nick}/chatter_id`)
 export const retrieveChatterSearch = (q: string, limit = 10) => api.get(`/chatters/search?q=${encodeURIComponent(q)}&limit=${limit}`)
 export const retrieveTwitchChannelSearch = (q: string, limit = 8) => api.get(`/admin/tracking/twitch-search?q=${encodeURIComponent(q)}&limit=${limit}`)

--- a/frontend/views/UserMessages.jsx
+++ b/frontend/views/UserMessages.jsx
@@ -1,49 +1,100 @@
 'use client'
 import {
-    useMemo,
+    useState, useCallback, useMemo,
 } from 'react'
 import {
-    Card,
+    Card, Table,
 } from 'react-bootstrap'
-import { useStreams } from '@/hooks/useApiQuery'
+import Link from 'next/link'
+import { useMessages } from '@/hooks/useApiQuery'
+import { retrieveChatterSearch } from '@/lib/api'
+import AsyncSearchSelect from '@/components/AsyncSearchSelect'
+import PaginationComponent from '@/components/streams/PaginationComponent'
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorAlert from '@/components/ErrorAlert'
+import { formatStreamTimestamp } from '@/utils/dateUtils'
+import { PAGINATION } from '@/constants'
 
 const UserMessages = () => {
-    // Use TanStack Query hook for fetching streams
-    const {
-        data: streamsData,
-        isLoading,
-        error,
-        refetch,
-    } = useStreams(-1, 0) // Get all streams from first page
+    const [
+        selectedChatter,
+        setSelectedChatter,
+    ] = useState(null)
+    const [
+        offset,
+        setOffset,
+    ] = useState(PAGINATION.DEFAULT_OFFSET)
 
-    // Memoize streams data extraction
-    const streams = useMemo(() => streamsData?.streams || [
+    const chatterId = selectedChatter?.value || null
+
+    const {
+        data: messagesData,
+        isLoading: messagesLoading,
+        error: messagesError,
+        refetch: refetchMessages,
+    } = useMessages(chatterId, offset)
+
+    const messages = useMemo(() => messagesData?.messages || [
     ], [
-        streamsData?.streams,
+        messagesData?.messages,
     ])
 
-    if (isLoading) {
-        return (
-            <LoadingSpinner
-                size="lg"
-                text="Loading user messages..."
-                card
-            />
-        )
-    }
+    const total = messagesData?.total || 0
+    const pagesCount = Math.ceil(total / PAGINATION.MESSAGES_PER_PAGE)
 
-    if (error) {
-        return (
-            <ErrorAlert
-                error={error}
-                title="Failed to load streams"
-                onRetry={refetch}
-                showDetails={process.env.NODE_ENV === 'development'}
-            />
-        )
-    }
+    /**
+     * Selects a chatter and resets pagination back to the first page.
+     * @param {{value: number, label: string}|null} option
+     */
+    const handleChatterChange = useCallback(option => {
+        setSelectedChatter(option)
+        setOffset(PAGINATION.DEFAULT_OFFSET)
+    }, [
+    ])
+
+    /**
+     * Updates offset
+     * @param {Number} offsetParam
+     */
+    const updateOffset = useCallback(offsetParam => {
+        setOffset(offsetParam)
+    }, [
+    ])
+
+    /**
+     * Prefix-search chatter nicks for the autocomplete dropdown.
+     * The backend returns [[id, nick], ...]; map to react-select options.
+     * @param {string} query
+     * @returns {Promise<Array<{value: number, label: string}>>}
+     */
+    const loadChatterOptions = useCallback(async query => {
+        const trimmed = query.trim()
+        if (trimmed.length < 2) {
+            return []
+        }
+        try {
+            const { data } = await retrieveChatterSearch(trimmed)
+            return (data || []).map(([
+                id,
+                nick,
+            ]) => ({
+                value: id,
+                label: nick,
+            }))
+        } catch {
+            return []
+        }
+    }, [
+    ])
+
+    const noOptionsMessage = useCallback(({ inputValue }) => (
+        inputValue && inputValue.trim().length >= 2
+            ? `No chatters matching "${inputValue}"`
+            : 'Type at least 2 characters to search'
+    ), [
+    ])
+
+    const isLoading = Boolean(chatterId) && messagesLoading
 
     return (
         <>
@@ -54,24 +105,131 @@ const UserMessages = () => {
                 </div>
             </div>
 
-            <Card>
-                <Card.Body className="p-0">
-                    <div
-                        className="empty-state"
-                        role="status"
-                        aria-live="polite"
-                        aria-labelledby="chatter-messages-heading"
+            <div
+                className="toolbar"
+                role="search"
+            >
+                <span
+                    className="toolbar-label"
+                    aria-hidden="true">
+                    Target
+                </span>
+                <div className="toolbar-field">
+                    <label
+                        htmlFor="chatter-messages-nick-input"
+                        className="visually-hidden"
                     >
+                        Chatter nickname
+                    </label>
+                    <AsyncSearchSelect
+                        instanceId="chatter-messages-nick-select"
+                        inputId="chatter-messages-nick-input"
+                        loadOptions={loadChatterOptions}
+                        value={selectedChatter}
+                        onChange={handleChatterChange}
+                        noOptionsMessage={noOptionsMessage}
+                        placeholder="Search for a chatter..."
+                        isClearable
+                        aria-label="Chatter nickname"
+                    />
+                </div>
+                {selectedChatter && total > 0 && !isLoading && (
+                    <span className="toolbar-readout">
+                        <strong>{total.toLocaleString()}</strong> messages · target <strong>{selectedChatter.label}</strong>
+                    </span>
+                )}
+            </div>
+
+            <Card>
+                <Card.Body className={!selectedChatter || (chatterId && messages.length === 0 && !isLoading) ? 'p-0' : ''}>
+                    {!selectedChatter && (
+                        <div className="empty-state">
+                            <div
+                                className="empty-scope"
+                                aria-hidden="true" />
+                            <p className="empty-title">Awaiting target</p>
+                            <p className="empty-hint">
+                                Search for a chatter nickname to read everything they have written across captured streams.
+                            </p>
+                        </div>
+                    )}
+
+                    {isLoading && (
+                        <LoadingSpinner
+                            size="lg"
+                            text="Loading chatter messages..."
+                        />
+                    )}
+
+                    {messagesError && !isLoading && (
+                        <ErrorAlert
+                            error={messagesError}
+                            title="Failed to load chatter messages"
+                            onRetry={refetchMessages}
+                            showDetails={process.env.NODE_ENV === 'development'}
+                        />
+                    )}
+
+                    {chatterId && !isLoading && !messagesError && (
                         <div
-                            className="empty-scope"
-                            aria-hidden="true" />
-                        <p className="empty-title">Module under construction</p>
-                        <p className="empty-hint">
-                            Chatter message analysis is not wired up yet.
-                            {' '}{streams.length.toLocaleString()} streams are already captured and waiting —
-                            in the meantime, open a stream and use its chat replay.
-                        </p>
-                    </div>
+                            role="region"
+                            aria-labelledby="chatter-messages-heading"
+                            aria-live="polite"
+                        >
+                            {messages.length === 0
+                                ? (
+                                    <div className="empty-state">
+                                        <div
+                                            className="empty-scope"
+                                            aria-hidden="true" />
+                                        <p className="empty-title">No messages</p>
+                                        <p className="empty-hint">This chatter has no recorded messages.</p>
+                                    </div>
+                                )
+                                : (
+                                    <>
+                                        <div className="visually-hidden">
+                                            {`Showing ${messages.length} of ${total} messages on page ${offset + 1} of ${pagesCount}`}
+                                        </div>
+                                        <Table
+                                            hover
+                                            responsive
+                                        >
+                                            <thead>
+                                                <tr>
+                                                    <th scope="col">Time</th>
+                                                    <th scope="col">Streamer</th>
+                                                    <th scope="col">Stream</th>
+                                                    <th scope="col">Message</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {messages.map((row, rowIndex) => (
+                                                    <tr key={`${offset}-${rowIndex}`}>
+                                                        <td
+                                                            className="mono small text-nowrap">
+                                                            {formatStreamTimestamp(row[4])}
+                                                        </td>
+                                                        <td>{row[2]}</td>
+                                                        <td>
+                                                            <Link href={`/stream/${row[0]}`}>
+                                                                {row[1]}
+                                                            </Link>
+                                                        </td>
+                                                        <td>{row[3]}</td>
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </Table>
+                                        <PaginationComponent
+                                            pagesCount={pagesCount}
+                                            offset={offset}
+                                            updateOffset={updateOffset}
+                                        />
+                                    </>
+                                )}
+                        </div>
+                    )}
                 </Card.Body>
             </Card>
         </>


### PR DESCRIPTION
## Summary

https://stream-sniper.slanycukr.com/chatter-messages was a "Module under construction" placeholder. This PR turns it into a working feature: search a chatter by nickname (prefix autocomplete), then browse everything they wrote across all captured streams — newest first, with stream context and pagination.

## Backend

- `GET /chatter/{id}/messages` (previously unused by the frontend, returned **all** messages unbounded with no stream context) now returns `{messages, total}` with `limit` (default 50, max 200) / `offset` params. Each row is `[stream_id, stream_title, streamer_display_name, text, timestamp]`.
- Empty results return `200 {messages: [], total: 0}` instead of 404, consistent with `/chatter/{id}/stream-activity`.
- Page + count queries use the same dual-key caching pattern as `/streams` (HIT/PARTIAL/MISS headers).
- New gateway: `select_chatter_message_count_db`; `select_chatter_messages_db` now joins stream/creator/message_text with LIMIT/OFFSET.

## Frontend

- `UserMessages` view rebuilt on the `ChatterFootprint` pattern: `AsyncSearchSelect` target picker, toolbar readout (total messages + target), message table with per-row links to `/stream/{id}`, `PaginationComponent` at 50 messages/page, night-ops empty states.
- `useMessages(chatterId, offset)` hook updated for the paginated shape; page resets when the target chatter changes.

## Verification

- 55 backend unit tests pass (`tests/unit/api`), ruff clean; integration test updated for the new response shape.
- Verified end-to-end against a scratch Postgres container (Alembic migrations + seeded data, 125 messages across 2 streams/2 streamers): autocomplete search, table rendering, page 1→2→3 navigation, partial last page (25 rows), empty-chatter case, and the login flow — all through the real Next.js dev server + API in a browser.
- Frontend `npm run lint` (0 errors) and `npm run build` pass.

https://claude.ai/code/session_013PdX79e8VwetgJWPiHWjvy