### PR TITLE
Add stream report card + chat data exports

### DIFF
--- a/backend/stream_sniper/analytics/report_stats.py
+++ b/backend/stream_sniper/analytics/report_stats.py
@@ -1,0 +1,65 @@
+"""Pure baseline/percentile math for the stream report card (no DB, no FastAPI).
+
+Operates on plain sequences so it unit-tests hermetically. The nullable=unknown
+contract applies throughout: ``None`` inputs mean "not yet computed", never 0.
+"""
+
+from typing import Any, Dict, List, Optional
+
+
+def median(values: List[float]) -> Optional[float]:
+    """Median of a plain list of numbers; None for an empty list."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    count = len(ordered)
+    mid = count // 2
+    if count % 2:
+        return float(ordered[mid])
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def percentile_rank(baseline: List[float], value: float) -> float:
+    """Mid-rank percentile of ``value`` within ``baseline`` (0..100, 1 decimal).
+
+    Fraction of baseline entries strictly below the value, plus half of the ties.
+    """
+    below = sum(1 for entry in baseline if entry < value)
+    ties = sum(1 for entry in baseline if entry == value)
+    return round((below + ties / 2.0) / len(baseline) * 100, 1)
+
+
+def delta_pct(value: float, baseline_median: float) -> Optional[float]:
+    """Percent change of ``value`` vs the baseline median (1 decimal); None when median is 0."""
+    if baseline_median == 0:
+        return None
+    return round((value - baseline_median) / baseline_median * 100, 1)
+
+
+def build_metric(value: Optional[float], baseline: List[Optional[float]]) -> Dict[str, Any]:
+    """Build the ReportMetric dict shape for one metric.
+
+    ``None`` baseline entries (unknown for that past stream) are dropped; baseline
+    stats require at least 2 known baseline values, otherwise delta_pct, percentile
+    and baseline_median are all None. A None ``value`` keeps baseline_median but
+    yields no delta/percentile (nothing to compare).
+    """
+    clean = [float(entry) for entry in baseline if entry is not None]
+    metric: Dict[str, Any] = {
+        "value": None if value is None else float(value),
+        "delta_pct": None,
+        "percentile": None,
+        "baseline_median": None,
+    }
+    if len(clean) < 2:
+        return metric
+
+    baseline_med = median(clean)
+    assert baseline_med is not None  # len(clean) >= 2
+    metric["baseline_median"] = round(baseline_med, 2)
+    if value is None:
+        return metric
+
+    metric["delta_pct"] = delta_pct(float(value), baseline_med)
+    metric["percentile"] = percentile_rank(clean, float(value))
+    return metric

--- a/backend/stream_sniper/api/api.py
+++ b/backend/stream_sniper/api/api.py
@@ -25,6 +25,7 @@ from .operations_endpoints import router as operations_router
 from .rate_limiter import setup_rate_limiting
 from .stream_endpoints import router as stream_router
 from .stream_insight_endpoints import router as stream_insight_router
+from .stream_report_endpoints import router as stream_report_router
 from .timeline_endpoints import router as timeline_router
 from .tracking_router import router as tracking_router
 
@@ -188,6 +189,9 @@ app.include_router(analytics_router)
 
 # Include stream insight router (mentions, emotes, phrases)
 app.include_router(stream_insight_router)
+
+# Include stream report card + chat-log export router
+app.include_router(stream_report_router)
 
 # Include community overlap router
 app.include_router(community_router)

--- a/backend/stream_sniper/api/export_utils.py
+++ b/backend/stream_sniper/api/export_utils.py
@@ -1,0 +1,55 @@
+"""Shared CSV/NDJSON serialization helpers for export endpoints.
+
+Pure serializers (stdlib csv/json only) so they unit-test hermetically; the
+``csv_response`` wrapper is the one FastAPI-aware convenience for the small
+in-memory aggregate exports.
+"""
+
+import csv
+import io
+import json
+from typing import Any, Dict, Iterable, Iterator, List, Optional
+
+from fastapi import Response
+
+
+def csv_content(fieldnames: List[str], rows: List[Dict[str, Any]]) -> str:
+    """Render dict rows as one in-memory CSV document (header + quoted rows)."""
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row)
+    return buffer.getvalue()
+
+
+def csv_response(
+    fieldnames: List[str],
+    rows: List[Dict[str, Any]],
+    filename: str,
+    extra_headers: Optional[Dict[str, str]] = None,
+) -> Response:
+    """Build an attachment CSV Response from dict rows (small payloads only)."""
+    headers = {"Content-Disposition": f'attachment; filename="{filename}"'}
+    if extra_headers:
+        headers.update(extra_headers)
+    return Response(content=csv_content(fieldnames, rows), media_type="text/csv", headers=headers)
+
+
+def iter_ndjson(rows: Iterable[Dict[str, Any]]) -> Iterator[str]:
+    """Lazily serialize dict rows as NDJSON lines (one JSON object per line)."""
+    for row in rows:
+        yield json.dumps(row, ensure_ascii=False) + "\n"
+
+
+def iter_csv(fieldnames: List[str], rows: Iterable[Dict[str, Any]]) -> Iterator[str]:
+    """Lazily serialize dict rows as CSV: a header line first, then one quoted row per chunk."""
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    yield buffer.getvalue()
+    for row in rows:
+        buffer.seek(0)
+        buffer.truncate()
+        writer.writerow(row)
+        yield buffer.getvalue()

--- a/backend/stream_sniper/api/moment_endpoints.py
+++ b/backend/stream_sniper/api/moment_endpoints.py
@@ -31,9 +31,11 @@ router = APIRouter(tags=["Moments"])
 
 
 def _invalidate_moment_caches() -> None:
-    """Drop cached timeline + queue pages so a curation change is reflected immediately."""
+    """Drop cached timeline, queue and report pages so a curation change is reflected immediately."""
     invalidate_cache_pattern("stream_timeline:*")
     invalidate_cache_pattern("moments_queue:*")
+    # The report card embeds top_moments filtered by review status.
+    invalidate_cache_pattern("stream_report:*")
 
 
 @router.get(

--- a/backend/stream_sniper/api/stream_insight_endpoints.py
+++ b/backend/stream_sniper/api/stream_insight_endpoints.py
@@ -12,6 +12,7 @@ from ..database.stream_phrase_stats_table_gateway import select_stream_phrases_d
 from ..database.stream_table_gateway import select_stream_mentions_db
 from ..logging_config import get_logger
 from .cache import CacheTTL, get_cache
+from .export_utils import csv_response
 from .models import ErrorResponse
 from .monitoring import record_cache_operation
 from .rate_limiter import limiter, rate_limits
@@ -45,7 +46,8 @@ def get_stream_mentions(
     response: Response,
     stream_id: int = Path(..., description="Unique stream ID", json_schema_extra={"example": 1}),
     limit: int = Query(20, ge=1, le=100, description="Max mentioned chatters to return"),
-) -> dict[str, Any]:
+    format: str = Query("json", pattern="^(json|csv)$", description="Response format"),
+) -> Any:
     """Empty when no @mentions were recorded — always 200, never 404."""
     try:
         cache = get_cache()
@@ -54,30 +56,39 @@ def get_stream_mentions(
         if cached_result is not None:
             response.headers["X-Cache"] = "HIT"
             record_cache_operation("hit", "stream_mentions")
-            return cast(dict[str, Any], cached_result)
+            payload = cast(dict[str, Any], cached_result)
+        else:
+            record_cache_operation("miss", "stream_mentions")
+            mentioned_rows, pair_rows = select_stream_mentions_db(stream_id, limit)
 
-        record_cache_operation("miss", "stream_mentions")
-        mentioned_rows, pair_rows = select_stream_mentions_db(stream_id, limit)
+            result = StreamMentions(
+                mentioned=[
+                    MentionedChatter(chatter_id=row[0], nick=row[1], count=row[2])
+                    for row in mentioned_rows
+                ],
+                pairs=[
+                    MentionPair(
+                        from_chatter_id=row[0],
+                        from_nick=row[1],
+                        to_chatter_id=row[2],
+                        to_nick=row[3],
+                        count=row[4],
+                    )
+                    for row in pair_rows
+                ],
+            )
+            payload = result.model_dump()
+            cache.set(cache_key, payload, CacheTTL.STREAM_DETAILS)
+            record_cache_operation("set", "stream_mentions")
+            response.headers["X-Cache"] = "MISS"
 
-        result = StreamMentions(
-            mentioned=[
-                MentionedChatter(chatter_id=row[0], nick=row[1], count=row[2]) for row in mentioned_rows
-            ],
-            pairs=[
-                MentionPair(
-                    from_chatter_id=row[0],
-                    from_nick=row[1],
-                    to_chatter_id=row[2],
-                    to_nick=row[3],
-                    count=row[4],
-                )
-                for row in pair_rows
-            ],
-        )
-        payload = result.model_dump()
-        cache.set(cache_key, payload, CacheTTL.STREAM_DETAILS)
-        record_cache_operation("set", "stream_mentions")
-        response.headers["X-Cache"] = "MISS"
+        if format == "csv":
+            return csv_response(
+                ["chatter_id", "nick", "count"],
+                payload["mentioned"],
+                f"stream_{stream_id}_mentions.csv",
+                extra_headers={"X-Cache": response.headers["X-Cache"]},
+            )
         return payload
     except Exception as exc:
         logger.error(f"Error fetching stream mentions: {exc}")
@@ -98,7 +109,8 @@ def get_stream_emotes(
     response: Response,
     stream_id: int = Path(..., description="Unique stream ID", json_schema_extra={"example": 1}),
     limit: int = Query(25, ge=1, le=100, description="Max emotes to return"),
-) -> dict[str, Any]:
+    format: str = Query("json", pattern="^(json|csv)$", description="Response format"),
+) -> Any:
     """Empty when the stream has no emote rollup yet — always 200, never 404."""
     try:
         cache = get_cache()
@@ -107,27 +119,35 @@ def get_stream_emotes(
         if cached_result is not None:
             response.headers["X-Cache"] = "HIT"
             record_cache_operation("hit", "stream_emotes")
-            return cast(dict[str, Any], cached_result)
+            payload = cast(dict[str, Any], cached_result)
+        else:
+            record_cache_operation("miss", "stream_emotes")
+            rows = select_stream_emotes_db(stream_id, limit)
 
-        record_cache_operation("miss", "stream_emotes")
-        rows = select_stream_emotes_db(stream_id, limit)
+            result = StreamEmotes(
+                emotes=[
+                    EmoteStat(
+                        name=row[0],
+                        source=row[1],
+                        provider_id=row[2],
+                        usage_count=row[3],
+                        chatter_count=row[4],
+                    )
+                    for row in rows
+                ]
+            )
+            payload = result.model_dump()
+            cache.set(cache_key, payload, CacheTTL.STREAM_ANALYTICS)
+            record_cache_operation("set", "stream_emotes")
+            response.headers["X-Cache"] = "MISS"
 
-        result = StreamEmotes(
-            emotes=[
-                EmoteStat(
-                    name=row[0],
-                    source=row[1],
-                    provider_id=row[2],
-                    usage_count=row[3],
-                    chatter_count=row[4],
-                )
-                for row in rows
-            ]
-        )
-        payload = result.model_dump()
-        cache.set(cache_key, payload, CacheTTL.STREAM_ANALYTICS)
-        record_cache_operation("set", "stream_emotes")
-        response.headers["X-Cache"] = "MISS"
+        if format == "csv":
+            return csv_response(
+                ["name", "source", "provider_id", "usage_count", "chatter_count"],
+                payload["emotes"],
+                f"stream_{stream_id}_emotes.csv",
+                extra_headers={"X-Cache": response.headers["X-Cache"]},
+            )
         return payload
     except Exception as exc:
         logger.error(f"Error fetching stream emotes: {exc}")
@@ -148,7 +168,8 @@ def get_stream_phrases(
     response: Response,
     stream_id: int = Path(..., description="Unique stream ID", json_schema_extra={"example": 1}),
     limit: int = Query(25, ge=1, le=100, description="Max phrases to return"),
-) -> dict[str, Any]:
+    format: str = Query("json", pattern="^(json|csv)$", description="Response format"),
+) -> Any:
     """Empty when the stream has no phrase rollup yet — always 200, never 404."""
     try:
         cache = get_cache()
@@ -157,20 +178,28 @@ def get_stream_phrases(
         if cached_result is not None:
             response.headers["X-Cache"] = "HIT"
             record_cache_operation("hit", "stream_phrases")
-            return cast(dict[str, Any], cached_result)
+            payload = cast(dict[str, Any], cached_result)
+        else:
+            record_cache_operation("miss", "stream_phrases")
+            rows = select_stream_phrases_db(stream_id, limit)
 
-        record_cache_operation("miss", "stream_phrases")
-        rows = select_stream_phrases_db(stream_id, limit)
+            result = StreamPhrases(
+                phrases=[
+                    PhraseStat(phrase=row[0], usage_count=row[1], chatter_count=row[2]) for row in rows
+                ]
+            )
+            payload = result.model_dump()
+            cache.set(cache_key, payload, CacheTTL.STREAM_ANALYTICS)
+            record_cache_operation("set", "stream_phrases")
+            response.headers["X-Cache"] = "MISS"
 
-        result = StreamPhrases(
-            phrases=[
-                PhraseStat(phrase=row[0], usage_count=row[1], chatter_count=row[2]) for row in rows
-            ]
-        )
-        payload = result.model_dump()
-        cache.set(cache_key, payload, CacheTTL.STREAM_ANALYTICS)
-        record_cache_operation("set", "stream_phrases")
-        response.headers["X-Cache"] = "MISS"
+        if format == "csv":
+            return csv_response(
+                ["phrase", "usage_count", "chatter_count"],
+                payload["phrases"],
+                f"stream_{stream_id}_phrases.csv",
+                extra_headers={"X-Cache": response.headers["X-Cache"]},
+            )
         return payload
     except Exception as exc:
         logger.error(f"Error fetching stream phrases: {exc}")

--- a/backend/stream_sniper/api/stream_report_endpoints.py
+++ b/backend/stream_sniper/api/stream_report_endpoints.py
@@ -1,0 +1,314 @@
+"""Stream report card (baseline-compared KPI scorecard) + full chat-log export endpoints."""
+
+from typing import Any, Iterator, List, Optional, cast
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, Response
+from fastapi.responses import StreamingResponse
+
+from ..analytics.report_stats import build_metric
+from ..database.connection_pool import get_pool
+from ..database.stream_emote_stats_table_gateway import select_stream_emotes_db
+from ..database.stream_metrics_table_gateway import (
+    select_creator_report_series_db,
+    select_stream_metrics_db,
+)
+from ..database.stream_moment_table_gateway import select_stream_moments_db
+from ..database.stream_phrase_stats_table_gateway import select_stream_phrases_db
+from ..database.stream_table_gateway import select_stream_comprehensive_db
+from ..database.stream_viewer_sample_table_gateway import select_stream_viewer_samples_db
+from ..logging_config import get_logger
+from .auth import UserInDB, get_current_user
+from .cache import CacheTTL, get_cache
+from .export_utils import iter_csv, iter_ndjson
+from .models import ErrorResponse
+from .monitoring import record_cache_operation
+from .rate_limiter import limiter, rate_limits
+from .stream_report_models import (
+    ReportMetric,
+    ReportMetrics,
+    ReportMoment,
+    StreamReport,
+    TopEmote,
+    TopPhrase,
+)
+
+logger = get_logger(__name__)
+
+router = APIRouter(tags=["Streams"])
+
+_ISO_FMT = "%Y-%m-%dT%H:%M:%S"
+
+
+def _iso(value) -> Optional[str]:
+    """Format a stream timestamp as the ISO string used everywhere else (None passes through)."""
+    if value is None or isinstance(value, str):
+        return value
+    return value.strftime(_ISO_FMT)
+
+
+def _sub_share(sub_messages, total_messages) -> Optional[float]:
+    """sub_messages / total_messages; None when either is unknown or total is 0."""
+    if sub_messages is None or total_messages is None or total_messages == 0:
+        return None
+    return sub_messages / total_messages
+
+
+def _previous_rows(series_rows, start_str: Optional[str], stream_id: int, lookback: int) -> list:
+    """Keep series rows strictly before this stream in (start, id) order; last `lookback` of them.
+
+    Rows come from select_creator_report_series_db ascending by start:
+    (stream_id, start_str, duration_seconds, total_messages, messages_per_minute,
+     unique_chatters, new_chatters, returning_chatters, sub_messages, peak_messages).
+    """
+    if start_str is None:
+        return []
+    previous = [
+        row for row in series_rows if row[1] is not None and (row[1], row[0]) < (start_str, stream_id)
+    ]
+    return previous[-lookback:]
+
+
+def _top_moments(moment_rows) -> List[ReportMoment]:
+    """Top 3 persisted moments by ratio DESC (None ratios last), excluding rejected ones."""
+    accepted = [row for row in moment_rows if row[10] != "rejected"]
+    ranked = sorted(accepted, key=lambda row: (row[4] is not None, row[4] or 0.0), reverse=True)
+    return [
+        ReportMoment(
+            bucket_minute=row[0],
+            offset_seconds=row[1],
+            message_count=row[2],
+            ratio=row[4],
+            status=row[10],
+        )
+        for row in ranked[:3]
+    ]
+
+
+@router.get(
+    "/stream/{stream_id}/report",
+    response_model=StreamReport,
+    summary="Get the report card for a stream",
+    description=(
+        "KPI scorecard for one stream, compared against the creator's previous rolled-up "
+        "streams (delta vs baseline median + percentile rank)."
+    ),
+    responses={
+        404: {"model": ErrorResponse, "description": "Stream not found"},
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit(rate_limits.ANALYTICS)
+def get_stream_report(
+    request: Request,
+    response: Response,
+    stream_id: int = Path(..., description="Unique stream ID", json_schema_extra={"example": 1}),
+    lookback: int = Query(10, ge=2, le=30, description="Previous streams to use as baseline"),
+) -> dict[str, Any]:
+    """Build the report card for a single stream.
+
+    404 only when the stream row itself does not exist. An un-rolled-up stream returns
+    200 with all metric values None (nullable = unknown, never coalesced to 0). Baseline
+    math uses only previous rolled-up streams; with fewer than 2 of them every
+    delta_pct/percentile/baseline_median is None.
+    """
+    try:
+        cache = get_cache()
+        cache_key = cache._generate_key("stream_report", stream_id, lookback)
+        cached_result = cache.get(cache_key)
+        if cached_result is not None:
+            response.headers["X-Cache"] = "HIT"
+            record_cache_operation("hit", "stream_report")
+            return cast(dict[str, Any], cached_result)
+
+        record_cache_operation("miss", "stream_report")
+        comprehensive = select_stream_comprehensive_db(stream_id)
+        if comprehensive is None:
+            raise HTTPException(status_code=404, detail="Stream not found")
+
+        creator_id = comprehensive[8]
+        start_str = _iso(comprehensive[1])
+
+        metrics_row = select_stream_metrics_db(stream_id)
+        sample_rows = select_stream_viewer_samples_db(stream_id)
+        emote_rows = select_stream_emotes_db(stream_id, 1)
+        phrase_rows = select_stream_phrases_db(stream_id, 1)
+        moment_rows = select_stream_moments_db(stream_id)
+        series_rows = select_creator_report_series_db(creator_id, lookback + 1)
+
+        baseline_rows = _previous_rows(series_rows, start_str, stream_id, lookback)
+        # Un-rolled-up previous streams (NULL total_messages / messages_per_minute)
+        # never enter baseline math.
+        survivors = [row for row in baseline_rows if row[3] is not None and row[4] is not None]
+        baseline_count = len(survivors)
+
+        if metrics_row is not None:
+            total_messages = metrics_row[0]
+            unique_chatters = metrics_row[1]
+            duration_seconds = metrics_row[2]
+            messages_per_minute = metrics_row[3]
+            peak_messages = metrics_row[4]
+            peak_bucket_minute = metrics_row[5]
+            new_chatters = metrics_row[6]
+            returning_chatters = metrics_row[7]
+            sub_messages = metrics_row[8]
+        else:
+            total_messages = unique_chatters = duration_seconds = None
+            messages_per_minute = peak_messages = peak_bucket_minute = None
+            new_chatters = returning_chatters = sub_messages = None
+
+        viewer_counts = [row[1] for row in sample_rows]
+        avg_viewers = sum(viewer_counts) / len(viewer_counts) if viewer_counts else None
+        peak_viewers = max(viewer_counts) if viewer_counts else None
+
+        metrics = ReportMetrics(
+            messages_per_minute=ReportMetric(
+                **build_metric(messages_per_minute, [row[4] for row in survivors])
+            ),
+            total_messages=ReportMetric(**build_metric(total_messages, [row[3] for row in survivors])),
+            unique_chatters=ReportMetric(**build_metric(unique_chatters, [row[5] for row in survivors])),
+            new_chatters=ReportMetric(**build_metric(new_chatters, [row[6] for row in survivors])),
+            returning_chatters=ReportMetric(
+                **build_metric(returning_chatters, [row[7] for row in survivors])
+            ),
+            sub_share=ReportMetric(
+                **build_metric(
+                    _sub_share(sub_messages, total_messages),
+                    [_sub_share(row[8], row[3]) for row in survivors],
+                )
+            ),
+            peak_messages=ReportMetric(**build_metric(peak_messages, [row[9] for row in survivors])),
+            # No baseline math for viewer metrics — historical viewer matching is out of scope.
+            avg_viewers=ReportMetric(value=avg_viewers),
+            peak_viewers=ReportMetric(value=peak_viewers),
+        )
+
+        result = StreamReport(
+            stream_id=stream_id,
+            creator_id=creator_id,
+            creator_nick=comprehensive[5],
+            title=comprehensive[0],
+            start=start_str,
+            end=_iso(comprehensive[2]),
+            duration_seconds=duration_seconds,
+            baseline_count=baseline_count,
+            lookback=lookback,
+            metrics=metrics,
+            peak_bucket_minute=peak_bucket_minute,
+            top_emote=TopEmote(
+                name=emote_rows[0][0],
+                source=emote_rows[0][1],
+                provider_id=emote_rows[0][2],
+                usage_count=emote_rows[0][3],
+                chatter_count=emote_rows[0][4],
+            )
+            if emote_rows
+            else None,
+            top_phrase=TopPhrase(
+                phrase=phrase_rows[0][0],
+                usage_count=phrase_rows[0][1],
+                chatter_count=phrase_rows[0][2],
+            )
+            if phrase_rows
+            else None,
+            top_moments=_top_moments(moment_rows),
+        )
+        payload = result.model_dump()
+        cache.set(cache_key, payload, CacheTTL.STREAM_ANALYTICS)
+        record_cache_operation("set", "stream_report")
+        response.headers["X-Cache"] = "MISS"
+        return payload
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Error fetching stream report: {exc}")
+        record_cache_operation("error", "stream_report")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+_EXPORT_FIELDNAMES = ["id", "time", "chatter_id", "nick", "text", "is_subscriber", "badges"]
+
+# The message replay SELECT (message_replay_gateway.select_stream_messages_db) without
+# keyset cursor/LIMIT — the server-side cursor below paginates instead.
+_EXPORT_SQL = """
+    SELECT m.id, TO_CHAR(m.time, 'YYYY-MM-DD"T"HH24:MI:SS.US'), m.chatter_id, c.nick,
+           mt.text, m.is_subscriber, m.badges
+    FROM message m
+    JOIN chatter c ON c.id = m.chatter_id
+    JOIN message_text mt ON mt.id = m.message_text_id
+    WHERE m.stream_id = %s
+    ORDER BY m.time ASC, m.id ASC
+"""
+
+
+def _iter_export_rows(stream_id: int) -> Iterator[dict[str, Any]]:
+    """Yield the full chat log as dict rows, holding one pooled connection for the whole stream.
+
+    A psycopg2 NAMED cursor is server-side, so millions of rows never materialize in
+    memory. @with_cursor gateways cannot be used here — they return the connection to
+    the pool before iteration starts. The cursor is closed and the read transaction
+    rolled back before putconn, also on client disconnect (GeneratorExit unwinds
+    through finally/with).
+    """
+    pool = get_pool()
+    with pool.get_connection() as connection:
+        cursor = connection.cursor(name=f"chat_export_{stream_id}_{uuid4().hex}")
+        cursor.itersize = 5000
+        try:
+            cursor.execute(_EXPORT_SQL, (stream_id,))
+            for row in cursor:
+                yield {
+                    "id": row[0],
+                    "time": row[1],
+                    "chatter_id": row[2],
+                    "nick": row[3],
+                    "text": row[4],
+                    "is_subscriber": row[5],
+                    "badges": row[6],
+                }
+        finally:
+            cursor.close()
+            connection.rollback()
+
+
+@router.get(
+    "/stream/{stream_id}/export",
+    summary="Export the full chat log for a stream",
+    description="Streams every chat message of a stream as NDJSON or CSV. Requires authentication.",
+    responses={
+        401: {"description": "Authentication required"},
+        404: {"model": ErrorResponse, "description": "Stream not found"},
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit(rate_limits.HEAVY)
+def export_stream_chat(
+    request: Request,
+    response: Response,
+    stream_id: int = Path(..., description="Unique stream ID", json_schema_extra={"example": 1}),
+    format: str = Query("ndjson", pattern="^(ndjson|csv)$", description="Export format"),
+    current_user: UserInDB = Depends(get_current_user),
+) -> StreamingResponse:
+    """Stream the full chat log. Never cached; row keys match the /messages replay endpoint."""
+    try:
+        comprehensive = select_stream_comprehensive_db(stream_id)
+    except Exception as exc:
+        logger.error(f"Error preparing stream export: {exc}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+    # 404 must be decided BEFORE streaming starts — the status is immutable afterwards.
+    if comprehensive is None:
+        raise HTTPException(status_code=404, detail="Stream not found")
+
+    rows = _iter_export_rows(stream_id)
+    if format == "csv":
+        content: Iterator[str] = iter_csv(_EXPORT_FIELDNAMES, rows)
+        media_type, extension = "text/csv", "csv"
+    else:
+        content = iter_ndjson(rows)
+        media_type, extension = "application/x-ndjson", "ndjson"
+
+    return StreamingResponse(
+        content,
+        media_type=media_type,
+        headers={"Content-Disposition": f'attachment; filename="stream_{stream_id}_chat.{extension}"'},
+    )

--- a/backend/stream_sniper/api/stream_report_models.py
+++ b/backend/stream_sniper/api/stream_report_models.py
@@ -1,0 +1,69 @@
+"""Pydantic contracts for the stream report card endpoint (snake_case wire format)."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class ReportMetric(BaseModel):
+    # None = unknown (stream not rolled up yet, or fewer than 2 rolled-up baseline
+    # streams) — never coalesced to 0 (the nullable=unknown contract).
+    value: Optional[float] = None
+    delta_pct: Optional[float] = None
+    percentile: Optional[float] = None
+    baseline_median: Optional[float] = None
+
+
+class TopEmote(BaseModel):
+    name: str
+    source: str
+    provider_id: Optional[str] = None
+    usage_count: int
+    chatter_count: int
+
+
+class TopPhrase(BaseModel):
+    phrase: str
+    usage_count: int
+    chatter_count: int
+
+
+class ReportMoment(BaseModel):
+    bucket_minute: str
+    offset_seconds: int
+    message_count: int
+    ratio: Optional[float] = None
+    # moment_review status ('bookmarked'; 'rejected' moments are excluded); None = pending.
+    status: Optional[str] = None
+
+
+class ReportMetrics(BaseModel):
+    messages_per_minute: ReportMetric
+    total_messages: ReportMetric
+    unique_chatters: ReportMetric
+    new_chatters: ReportMetric
+    returning_chatters: ReportMetric
+    sub_share: ReportMetric
+    peak_messages: ReportMetric
+    # Viewer metrics carry a value only — historical viewer matching is out of scope,
+    # so delta_pct/percentile/baseline_median stay None.
+    avg_viewers: ReportMetric
+    peak_viewers: ReportMetric
+
+
+class StreamReport(BaseModel):
+    stream_id: int
+    creator_id: int
+    creator_nick: Optional[str] = None
+    title: Optional[str] = None
+    start: Optional[str] = None
+    end: Optional[str] = None
+    duration_seconds: Optional[int] = None
+    # Previous rolled-up streams that actually entered the baseline math (<= lookback).
+    baseline_count: int
+    lookback: int
+    metrics: ReportMetrics
+    peak_bucket_minute: Optional[str] = None
+    top_emote: Optional[TopEmote] = None
+    top_phrase: Optional[TopPhrase] = None
+    top_moments: List[ReportMoment] = []

--- a/backend/stream_sniper/database/stream_metrics_table_gateway.py
+++ b/backend/stream_sniper/database/stream_metrics_table_gateway.py
@@ -69,3 +69,39 @@ def select_creator_metrics_series_db(creator_id, limit, cursor):
         (creator_id, limit),
     )
     return cursor.fetchall()
+
+
+@with_cursor
+def select_creator_report_series_db(creator_id, limit, cursor):
+    # Most-recent `limit` streams, returned ascending by start — same skeleton as
+    # select_creator_metrics_series_db, but WITHOUT COALESCE: un-rolled-up streams
+    # come back with NULL stream_metrics columns so report baseline math can
+    # exclude them (nullable = unknown, never 0).
+    cursor.execute(
+        """
+        SELECT stream_id, start_str, duration_seconds, total_messages, messages_per_minute,
+               unique_chatters, new_chatters, returning_chatters, sub_messages, peak_messages
+        FROM (
+            SELECT
+                s.id AS stream_id,
+                TO_CHAR(s.start, 'YYYY-MM-DD"T"HH24:MI:SS') AS start_str,
+                s.start AS start_raw,
+                sm.duration_seconds AS duration_seconds,
+                sm.total_messages AS total_messages,
+                sm.messages_per_minute::double precision AS messages_per_minute,
+                sm.unique_chatters AS unique_chatters,
+                sm.new_chatters AS new_chatters,
+                sm.returning_chatters AS returning_chatters,
+                sm.sub_messages AS sub_messages,
+                sm.peak_messages AS peak_messages
+            FROM stream s
+            LEFT JOIN stream_metrics sm ON sm.stream_id = s.id
+            WHERE s.creator_id = %s
+            ORDER BY s.start DESC, s.id DESC
+            LIMIT %s
+        ) sub
+        ORDER BY start_raw ASC, stream_id ASC
+        """,
+        (creator_id, limit),
+    )
+    return cursor.fetchall()

--- a/backend/tests/unit/analytics/test_report_stats.py
+++ b/backend/tests/unit/analytics/test_report_stats.py
@@ -1,0 +1,123 @@
+"""Unit tests for the pure report-card baseline math (analytics/report_stats.py)."""
+
+from stream_sniper.analytics.report_stats import (
+    build_metric,
+    delta_pct,
+    median,
+    percentile_rank,
+)
+
+
+class TestMedian:
+    def test_empty_list_is_none(self):
+        assert median([]) is None
+
+    def test_single_value(self):
+        assert median([7.0]) == 7.0
+
+    def test_odd_count_returns_middle(self):
+        assert median([9.0, 1.0, 5.0]) == 5.0
+
+    def test_even_count_averages_middle_pair(self):
+        assert median([1.0, 2.0, 3.0, 10.0]) == 2.5
+
+    def test_returns_float_for_int_inputs(self):
+        result = median([3, 1, 2])
+        assert result == 2.0
+        assert isinstance(result, float)
+
+
+class TestPercentileRank:
+    def test_value_above_all_is_100(self):
+        assert percentile_rank([1.0, 2.0, 3.0], 10.0) == 100.0
+
+    def test_value_below_all_is_0(self):
+        assert percentile_rank([1.0, 2.0, 3.0], 0.5) == 0.0
+
+    def test_midrank_counts_half_of_ties(self):
+        # below=1, ties=2 -> (1 + 1) / 4 * 100
+        assert percentile_rank([1.0, 2.0, 2.0, 3.0], 2.0) == 50.0
+
+    def test_rounded_to_one_decimal(self):
+        # below=2, ties=1 -> (2 + 0.5) / 3 * 100 = 83.33...
+        assert percentile_rank([1.0, 2.0, 3.0], 3.0) == 83.3
+
+
+class TestDeltaPct:
+    def test_zero_median_is_none(self):
+        assert delta_pct(5.0, 0.0) is None
+
+    def test_increase(self):
+        assert delta_pct(15.0, 10.0) == 50.0
+
+    def test_decrease_is_negative(self):
+        assert delta_pct(5.0, 10.0) == -50.0
+
+    def test_rounded_to_one_decimal(self):
+        assert delta_pct(10.0, 3.0) == 233.3
+
+
+class TestBuildMetric:
+    def test_full_shape_with_baseline(self):
+        metric = build_metric(30.0, [10.0, 20.0])
+        assert metric == {
+            "value": 30.0,
+            "delta_pct": 100.0,
+            "percentile": 100.0,
+            "baseline_median": 15.0,
+        }
+
+    def test_none_baseline_entries_dropped(self):
+        metric = build_metric(30.0, [10.0, None, 20.0, None])
+        assert metric["baseline_median"] == 15.0
+        assert metric["delta_pct"] == 100.0
+        assert metric["percentile"] == 100.0
+
+    def test_fewer_than_two_known_baseline_values_guards(self):
+        metric = build_metric(5.0, [10.0, None])
+        assert metric == {
+            "value": 5.0,
+            "delta_pct": None,
+            "percentile": None,
+            "baseline_median": None,
+        }
+
+    def test_empty_baseline_keeps_value_only(self):
+        assert build_metric(5.0, []) == {
+            "value": 5.0,
+            "delta_pct": None,
+            "percentile": None,
+            "baseline_median": None,
+        }
+
+    def test_none_value_keeps_baseline_median_only(self):
+        metric = build_metric(None, [1.0, 2.0, 3.0])
+        assert metric == {
+            "value": None,
+            "delta_pct": None,
+            "percentile": None,
+            "baseline_median": 2.0,
+        }
+
+    def test_all_none_everywhere(self):
+        assert build_metric(None, [None, None]) == {
+            "value": None,
+            "delta_pct": None,
+            "percentile": None,
+            "baseline_median": None,
+        }
+
+    def test_baseline_median_rounded_to_two_decimals(self):
+        metric = build_metric(3.0, [1.111, 2.222, 3.333])
+        assert metric["baseline_median"] == 2.22
+
+    def test_zero_median_gives_none_delta_but_percentile(self):
+        metric = build_metric(5.0, [0.0, 0.0, 0.0])
+        assert metric["delta_pct"] is None
+        assert metric["percentile"] == 100.0
+        assert metric["baseline_median"] == 0.0
+
+    def test_value_coerced_to_float(self):
+        metric = build_metric(1200, [1000, 1100])
+        assert metric["value"] == 1200.0
+        assert isinstance(metric["value"], float)

--- a/backend/tests/unit/api/test_export_utils.py
+++ b/backend/tests/unit/api/test_export_utils.py
@@ -1,0 +1,94 @@
+"""Unit tests for the pure CSV/NDJSON export serializers (api/export_utils.py)."""
+
+import json
+
+from stream_sniper.api.export_utils import csv_content, csv_response, iter_csv, iter_ndjson
+
+
+class TestCsvContent:
+    def test_header_and_rows(self):
+        text = csv_content(
+            ["phrase", "usage_count", "chatter_count"],
+            [
+                {"phrase": "gg wp", "usage_count": 22, "chatter_count": 15},
+                {"phrase": "no way", "usage_count": 10, "chatter_count": 8},
+            ],
+        )
+        assert text.splitlines() == [
+            "phrase,usage_count,chatter_count",
+            "gg wp,22,15",
+            "no way,10,8",
+        ]
+
+    def test_quotes_commas_and_newlines(self):
+        text = csv_content(
+            ["nick", "text"],
+            [{"nick": "a", "text": 'hello, "world"\nbye'}],
+        )
+        # stdlib csv quotes the field and doubles inner quotes.
+        assert text == 'nick,text\r\na,"hello, ""world""\nbye"\r\n'
+
+    def test_none_becomes_empty_field(self):
+        text = csv_content(["name", "provider_id"], [{"name": "KEKW", "provider_id": None}])
+        assert text.splitlines()[1] == "KEKW,"
+
+    def test_empty_rows_is_header_only(self):
+        assert csv_content(["a", "b"], []).splitlines() == ["a,b"]
+
+
+class TestCsvResponse:
+    def test_media_type_and_disposition(self):
+        response = csv_response(["a"], [{"a": 1}], "stream_7_emotes.csv")
+        assert response.media_type == "text/csv"
+        assert response.headers["content-disposition"] == 'attachment; filename="stream_7_emotes.csv"'
+        assert response.body.decode().splitlines() == ["a", "1"]
+
+    def test_extra_headers_merged(self):
+        response = csv_response(["a"], [], "f.csv", extra_headers={"X-Cache": "HIT"})
+        assert response.headers["X-Cache"] == "HIT"
+        assert response.headers["content-disposition"] == 'attachment; filename="f.csv"'
+
+
+class TestIterNdjson:
+    def test_one_json_object_per_line(self):
+        rows = [
+            {"id": 1, "text": "hello"},
+            {"id": 2, "text": "world"},
+        ]
+        lines = list(iter_ndjson(rows))
+        assert all(line.endswith("\n") for line in lines)
+        assert [json.loads(line) for line in lines] == rows
+
+    def test_unicode_kept_literal(self):
+        (line,) = list(iter_ndjson([{"text": "čau KEKW"}]))
+        assert "čau" in line  # ensure_ascii=False — no \u escapes
+
+    def test_empty_input_yields_nothing(self):
+        assert list(iter_ndjson([])) == []
+
+    def test_lazy_generator(self):
+        def rows():
+            yield {"id": 1}
+            raise AssertionError("must not be consumed eagerly")
+
+        iterator = iter_ndjson(rows())
+        assert json.loads(next(iterator)) == {"id": 1}
+
+
+class TestIterCsv:
+    def test_header_first_then_rows(self):
+        chunks = list(
+            iter_csv(
+                ["id", "nick", "text"],
+                [
+                    {"id": 1, "nick": "a", "text": "hi"},
+                    {"id": 2, "nick": "b", "text": "one,two"},
+                ],
+            )
+        )
+        assert chunks[0] == "id,nick,text\r\n"
+        assert chunks[1] == "1,a,hi\r\n"
+        assert chunks[2] == '2,b,"one,two"\r\n'
+
+    def test_empty_rows_yields_header_only(self):
+        assert list(iter_csv(["a", "b"], [])) == ["a,b\r\n"]

--- a/backend/tests/unit/api/test_moment_endpoints.py
+++ b/backend/tests/unit/api/test_moment_endpoints.py
@@ -150,6 +150,7 @@ class TestSetMomentReview:
         mock_upsert.assert_called_once_with(42, "2024-01-15T20:10:00", "bookmarked")
         mock_invalidate.assert_any_call("stream_timeline:*")
         mock_invalidate.assert_any_call("moments_queue:*")
+        mock_invalidate.assert_any_call("stream_report:*")
 
     @patch("stream_sniper.api.moment_endpoints.invalidate_cache_pattern")
     @patch("stream_sniper.api.moment_endpoints.upsert_moment_review_db")
@@ -207,6 +208,7 @@ class TestClearMomentReview:
         mock_delete.assert_called_once_with(42, "2024-01-15T20:10:00")
         mock_invalidate.assert_any_call("stream_timeline:*")
         mock_invalidate.assert_any_call("moments_queue:*")
+        mock_invalidate.assert_any_call("stream_report:*")
 
     @patch("stream_sniper.api.moment_endpoints.invalidate_cache_pattern")
     @patch("stream_sniper.api.moment_endpoints.delete_moment_review_db")

--- a/backend/tests/unit/api/test_stream_insights.py
+++ b/backend/tests/unit/api/test_stream_insights.py
@@ -181,6 +181,144 @@ class TestStreamPhrases:
         assert _client().get("/stream/7/phrases?limit=101").status_code == 422
 
 
+class TestStreamInsightCsvFormat:
+    """format=csv on the per-stream aggregate endpoints (default stays JSON)."""
+
+    @patch("stream_sniper.api.stream_insight_endpoints.get_cache")
+    @patch("stream_sniper.api.stream_insight_endpoints.select_stream_emotes_db")
+    def test_emotes_default_stays_json(self, mock_emotes, mock_get_cache):
+        mock_get_cache.return_value = _miss_cache()
+        mock_emotes.return_value = [("KEKW", "bttv", "abc123", 120, 30)]
+
+        response = _client().get("/stream/7/emotes")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/json")
+        assert "content-disposition" not in response.headers
+        assert response.json()["emotes"][0]["name"] == "KEKW"
+
+    @patch("stream_sniper.api.stream_insight_endpoints.get_cache")
+    @patch("stream_sniper.api.stream_insight_endpoints.select_stream_emotes_db")
+    def test_emotes_csv(self, mock_emotes, mock_get_cache):
+        mock_get_cache.return_value = _miss_cache()
+        mock_emotes.return_value = [
+            ("KEKW", "bttv", "abc123", 120, 30),
+            ("nopixel", "bttv", None, 5, 2),
+        ]
+
+        response = _client().get("/stream/7/emotes?format=csv")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert response.headers["content-disposition"] == 'attachment; filename="stream_7_emotes.csv"'
+        assert response.headers["X-Cache"] == "MISS"
+        assert response.text.splitlines() == [
+            "name,source,provider_id,usage_count,chatter_count",
+            "KEKW,bttv,abc123,120,30",
+            "nopixel,bttv,,5,2",
+        ]
+
+    @patch("stream_sniper.api.stream_insight_endpoints.get_cache")
+    @patch("stream_sniper.api.stream_insight_endpoints.select_stream_emotes_db")
+    def test_emotes_csv_served_from_cache_hit(self, mock_emotes, mock_get_cache):
+        cache = Mock()
+        cache._generate_key = Mock(return_value="k")
+        cache.get = Mock(
+            return_value={
+                "emotes": [
+                    {
+                        "name": "KEKW",
+                        "source": "bttv",
+                        "provider_id": "abc123",
+                        "usage_count": 120,
+                        "chatter_count": 30,
+                    }
+                ]
+            }
+        )
+        cache.set = Mock()
+        mock_get_cache.return_value = cache
+
+        response = _client().get("/stream/7/emotes?format=csv")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert response.headers["X-Cache"] == "HIT"
+        assert response.text.splitlines()[1] == "KEKW,bttv,abc123,120,30"
+        mock_emotes.assert_not_called()
+        cache.set.assert_not_called()  # format never enters the cache flow
+
+    def test_emotes_invalid_format_rejected(self):
+        assert _client().get("/stream/7/emotes?format=bogus").status_code == 422
+
+    @patch("stream_sniper.api.stream_insight_endpoints.get_cache")
+    @patch("stream_sniper.api.stream_insight_endpoints.select_stream_phrases_db")
+    def test_phrases_default_stays_json(self, mock_phrases, mock_get_cache):
+        mock_get_cache.return_value = _miss_cache()
+        mock_phrases.return_value = [("gg wp", 22, 15)]
+
+        response = _client().get("/stream/7/phrases")
+
+        assert response.headers["content-type"].startswith("application/json")
+        assert response.json() == {
+            "phrases": [{"phrase": "gg wp", "usage_count": 22, "chatter_count": 15}]
+        }
+
+    @patch("stream_sniper.api.stream_insight_endpoints.get_cache")
+    @patch("stream_sniper.api.stream_insight_endpoints.select_stream_phrases_db")
+    def test_phrases_csv(self, mock_phrases, mock_get_cache):
+        mock_get_cache.return_value = _miss_cache()
+        mock_phrases.return_value = [("gg wp", 22, 15), ("no, way", 10, 8)]
+
+        response = _client().get("/stream/7/phrases?format=csv")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert response.headers["content-disposition"] == 'attachment; filename="stream_7_phrases.csv"'
+        assert response.text.splitlines() == [
+            "phrase,usage_count,chatter_count",
+            "gg wp,22,15",
+            '"no, way",10,8',
+        ]
+
+    def test_phrases_invalid_format_rejected(self):
+        assert _client().get("/stream/7/phrases?format=bogus").status_code == 422
+
+    @patch("stream_sniper.api.stream_insight_endpoints.get_cache")
+    @patch("stream_sniper.api.stream_insight_endpoints.select_stream_mentions_db")
+    def test_mentions_default_stays_json(self, mock_mentions, mock_get_cache):
+        mock_get_cache.return_value = _miss_cache()
+        mock_mentions.return_value = ([(42, "target_a", 9)], [])
+
+        response = _client().get("/stream/7/mentions")
+
+        assert response.headers["content-type"].startswith("application/json")
+        assert response.json()["mentioned"] == [{"chatter_id": 42, "nick": "target_a", "count": 9}]
+
+    @patch("stream_sniper.api.stream_insight_endpoints.get_cache")
+    @patch("stream_sniper.api.stream_insight_endpoints.select_stream_mentions_db")
+    def test_mentions_csv_exports_mentioned_list(self, mock_mentions, mock_get_cache):
+        mock_get_cache.return_value = _miss_cache()
+        mock_mentions.return_value = (
+            [(42, "target_a", 9), (43, "target_b", 4)],
+            [(7, "caller", 42, "target_a", 5)],
+        )
+
+        response = _client().get("/stream/7/mentions?format=csv")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert response.headers["content-disposition"] == 'attachment; filename="stream_7_mentions.csv"'
+        assert response.text.splitlines() == [
+            "chatter_id,nick,count",
+            "42,target_a,9",
+            "43,target_b,4",
+        ]
+
+    def test_mentions_invalid_format_rejected(self):
+        assert _client().get("/stream/7/mentions?format=bogus").status_code == 422
+
+
 class TestCreatorEmotes:
     @patch("stream_sniper.api.stream_insight_endpoints.get_cache")
     @patch("stream_sniper.api.stream_insight_endpoints.select_creator_emotes_db")

--- a/backend/tests/unit/api/test_stream_report.py
+++ b/backend/tests/unit/api/test_stream_report.py
@@ -1,0 +1,451 @@
+"""Unit tests for the stream report card + full chat-log export endpoints.
+
+The report/export router is mounted on a minimal FastAPI app with the real rate
+limiter; every gateway (and the connection pool for the streaming export) is patched
+at its import path in ``stream_report_endpoints``. The protected export overrides
+``get_current_user`` (the base auth dependency) like the moment review tests do.
+"""
+
+import json
+from contextlib import contextmanager
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stream_sniper.api.auth import get_current_user
+from stream_sniper.api.rate_limiter import setup_rate_limiting
+from stream_sniper.api.stream_report_endpoints import router
+from stream_sniper.api.stream_report_models import ReportMetric, ReportMetrics, StreamReport
+
+_EP = "stream_sniper.api.stream_report_endpoints"
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    setup_rate_limiting(app)
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _user_client() -> TestClient:
+    client = _client()
+    client.app.dependency_overrides[get_current_user] = lambda: SimpleNamespace(
+        id=1, username="viewer", role="user", is_active=True
+    )
+    return client
+
+
+def _miss_cache():
+    cache = Mock()
+    cache._generate_key = Mock(return_value="test-cache-key")
+    cache.get = Mock(return_value=None)
+    cache.set = Mock(return_value=True)
+    return cache
+
+
+# select_stream_comprehensive_db row:
+# (title, start, end, thumbnail_url, message_count, nick, display_name, profile_image_url, creator_id)
+_COMPREHENSIVE = (
+    "Test stream",
+    datetime(2026, 7, 1, 18, 0, 0),
+    datetime(2026, 7, 1, 20, 0, 0),
+    None,
+    1200,
+    "streamer",
+    "Streamer",
+    None,
+    3,
+)
+
+# select_stream_metrics_db row: (total_messages, unique_chatters, duration_seconds,
+# messages_per_minute, peak_messages, peak_bucket_minute, new_chatters,
+# returning_chatters, sub_messages, emote_messages)
+_METRICS = (1200, 300, 7200, 10.0, 60, "2026-07-01T19:00:00", 40, 260, 600, 100)
+
+# select_creator_report_series_db rows (ascending by start): (stream_id, start_str,
+# duration_seconds, total_messages, messages_per_minute, unique_chatters,
+# new_chatters, returning_chatters, sub_messages, peak_messages)
+_SERIES = [
+    (5, "2026-06-01T18:00:00", 7000, 1000, 8.0, 200, 30, 170, 400, 50),
+    (6, "2026-06-15T18:00:00", 7100, 1100, 12.0, 400, 50, 350, 550, 70),
+    (7, "2026-07-01T18:00:00", 7200, 1200, 10.0, 300, 40, 260, 600, 60),  # the stream itself
+]
+
+_SAMPLES = [("2026-07-01T18:00:00", 100), ("2026-07-01T18:05:00", 200)]
+
+# select_stream_moments_db rows (ascending by bucket): (bucket_minute, offset_seconds,
+# message_count, baseline, ratio, unique_chatters, sub_share, emote_share,
+# top_phrases, sample_messages, status)
+_MOMENTS = [
+    ("2026-07-01T18:30:00", 1800, 90, 30.0, 3.0, 50, None, None, None, None, None),
+    ("2026-07-01T19:00:00", 3600, 120, 30.0, 4.0, 60, 0.5, 0.2, None, None, "bookmarked"),
+    ("2026-07-01T19:30:00", 5400, 150, 30.0, 5.0, 70, None, None, None, None, "rejected"),
+    ("2026-07-01T20:00:00", 7200, 45, 30.0, None, 20, None, None, None, None, None),
+]
+
+
+@contextmanager
+def _report_mocks(
+    comprehensive=_COMPREHENSIVE,
+    metrics=_METRICS,
+    samples=(),
+    emotes=(),
+    phrases=(),
+    moments=(),
+    series=(),
+    cache=None,
+):
+    with (
+        patch(f"{_EP}.get_cache", return_value=cache if cache is not None else _miss_cache()),
+        patch(f"{_EP}.select_stream_comprehensive_db", return_value=comprehensive) as mock_comp,
+        patch(f"{_EP}.select_stream_metrics_db", return_value=metrics) as mock_metrics,
+        patch(f"{_EP}.select_stream_viewer_samples_db", return_value=list(samples)) as mock_samples,
+        patch(f"{_EP}.select_stream_emotes_db", return_value=list(emotes)) as mock_emotes,
+        patch(f"{_EP}.select_stream_phrases_db", return_value=list(phrases)) as mock_phrases,
+        patch(f"{_EP}.select_stream_moments_db", return_value=list(moments)) as mock_moments,
+        patch(f"{_EP}.select_creator_report_series_db", return_value=list(series)) as mock_series,
+    ):
+        yield SimpleNamespace(
+            comprehensive=mock_comp,
+            metrics=mock_metrics,
+            samples=mock_samples,
+            emotes=mock_emotes,
+            phrases=mock_phrases,
+            moments=mock_moments,
+            series=mock_series,
+        )
+
+
+class TestStreamReport:
+    def test_success_full_shape(self):
+        with _report_mocks(
+            samples=_SAMPLES,
+            emotes=[("KEKW", "bttv", "abc123", 120, 30)],
+            phrases=[("gg wp", 22, 15)],
+            moments=_MOMENTS,
+            series=_SERIES,
+        ) as mocks:
+            response = _client().get("/stream/7/report")
+
+        assert response.status_code == 200
+        assert response.headers["X-Cache"] == "MISS"
+        mocks.series.assert_called_once_with(3, 11)  # creator_id, lookback + 1
+        assert response.json() == {
+            "stream_id": 7,
+            "creator_id": 3,
+            "creator_nick": "streamer",
+            "title": "Test stream",
+            "start": "2026-07-01T18:00:00",
+            "end": "2026-07-01T20:00:00",
+            "duration_seconds": 7200,
+            "baseline_count": 2,
+            "lookback": 10,
+            "metrics": {
+                "messages_per_minute": {
+                    "value": 10.0,
+                    "delta_pct": 0.0,
+                    "percentile": 50.0,
+                    "baseline_median": 10.0,
+                },
+                "total_messages": {
+                    "value": 1200.0,
+                    "delta_pct": 14.3,
+                    "percentile": 100.0,
+                    "baseline_median": 1050.0,
+                },
+                "unique_chatters": {
+                    "value": 300.0,
+                    "delta_pct": 0.0,
+                    "percentile": 50.0,
+                    "baseline_median": 300.0,
+                },
+                "new_chatters": {
+                    "value": 40.0,
+                    "delta_pct": 0.0,
+                    "percentile": 50.0,
+                    "baseline_median": 40.0,
+                },
+                "returning_chatters": {
+                    "value": 260.0,
+                    "delta_pct": 0.0,
+                    "percentile": 50.0,
+                    "baseline_median": 260.0,
+                },
+                "sub_share": {
+                    "value": 0.5,
+                    "delta_pct": 11.1,
+                    "percentile": 75.0,
+                    "baseline_median": 0.45,
+                },
+                "peak_messages": {
+                    "value": 60.0,
+                    "delta_pct": 0.0,
+                    "percentile": 50.0,
+                    "baseline_median": 60.0,
+                },
+                "avg_viewers": {
+                    "value": 150.0,
+                    "delta_pct": None,
+                    "percentile": None,
+                    "baseline_median": None,
+                },
+                "peak_viewers": {
+                    "value": 200.0,
+                    "delta_pct": None,
+                    "percentile": None,
+                    "baseline_median": None,
+                },
+            },
+            "peak_bucket_minute": "2026-07-01T19:00:00",
+            "top_emote": {
+                "name": "KEKW",
+                "source": "bttv",
+                "provider_id": "abc123",
+                "usage_count": 120,
+                "chatter_count": 30,
+            },
+            "top_phrase": {"phrase": "gg wp", "usage_count": 22, "chatter_count": 15},
+            "top_moments": [
+                {
+                    "bucket_minute": "2026-07-01T19:00:00",
+                    "offset_seconds": 3600,
+                    "message_count": 120,
+                    "ratio": 4.0,
+                    "status": "bookmarked",
+                },
+                {
+                    "bucket_minute": "2026-07-01T18:30:00",
+                    "offset_seconds": 1800,
+                    "message_count": 90,
+                    "ratio": 3.0,
+                    "status": None,
+                },
+                {
+                    "bucket_minute": "2026-07-01T20:00:00",
+                    "offset_seconds": 7200,
+                    "message_count": 45,
+                    "ratio": None,
+                    "status": None,
+                },
+            ],
+        }
+
+    def test_404_when_stream_missing(self):
+        with _report_mocks(comprehensive=None) as mocks:
+            response = _client().get("/stream/999/report")
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Stream not found"}
+        mocks.series.assert_not_called()
+
+    def test_unrolled_stream_returns_200_with_nulls(self):
+        # Un-rolled-up: no stream_metrics row, no samples/emotes/phrases/moments; the
+        # creator's previous streams are un-rolled too (NULL metrics columns).
+        unrolled_series = [
+            (5, "2026-06-01T18:00:00", None, None, None, None, None, None, None, None),
+            (6, "2026-06-15T18:00:00", None, None, None, None, None, None, None, None),
+        ]
+        with _report_mocks(metrics=None, series=unrolled_series):
+            response = _client().get("/stream/7/report")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["baseline_count"] == 0
+        assert data["duration_seconds"] is None
+        assert data["peak_bucket_minute"] is None
+        assert data["top_emote"] is None
+        assert data["top_phrase"] is None
+        assert data["top_moments"] == []
+        for metric in data["metrics"].values():
+            assert metric == {
+                "value": None,
+                "delta_pct": None,
+                "percentile": None,
+                "baseline_median": None,
+            }
+
+    def test_single_baseline_stream_suppresses_baseline_stats(self):
+        with _report_mocks(series=[_SERIES[0], _SERIES[2]]):
+            response = _client().get("/stream/7/report")
+
+        data = response.json()
+        assert data["baseline_count"] == 1
+        assert data["metrics"]["messages_per_minute"] == {
+            "value": 10.0,
+            "delta_pct": None,
+            "percentile": None,
+            "baseline_median": None,
+        }
+
+    def test_streams_after_this_one_excluded_from_baseline(self):
+        newer = (9, "2026-07-10T18:00:00", 7000, 900, 9.0, 250, 20, 230, 450, 55)
+        with _report_mocks(series=[_SERIES[0], _SERIES[2], newer]):
+            response = _client().get("/stream/7/report")
+
+        data = response.json()
+        # Only stream 5 predates this one; the newer stream 9 must not enter the baseline.
+        assert data["baseline_count"] == 1
+        assert data["metrics"]["total_messages"]["baseline_median"] is None
+
+    def test_lookback_forwarded_and_echoed(self):
+        with _report_mocks(series=_SERIES) as mocks:
+            response = _client().get("/stream/7/report?lookback=5")
+
+        assert response.json()["lookback"] == 5
+        mocks.series.assert_called_once_with(3, 6)
+
+    def test_lookback_out_of_range_rejected(self):
+        assert _client().get("/stream/7/report?lookback=1").status_code == 422
+        assert _client().get("/stream/7/report?lookback=31").status_code == 422
+
+    def test_cache_hit_skips_gateways(self):
+        cached_payload = StreamReport(
+            stream_id=7,
+            creator_id=3,
+            baseline_count=0,
+            lookback=10,
+            metrics=ReportMetrics(
+                **{
+                    name: ReportMetric()
+                    for name in (
+                        "messages_per_minute",
+                        "total_messages",
+                        "unique_chatters",
+                        "new_chatters",
+                        "returning_chatters",
+                        "sub_share",
+                        "peak_messages",
+                        "avg_viewers",
+                        "peak_viewers",
+                    )
+                }
+            ),
+        ).model_dump()
+        cache = Mock()
+        cache._generate_key = Mock(return_value="k")
+        cache.get = Mock(return_value=cached_payload)
+        cache.set = Mock()
+        with _report_mocks(cache=cache) as mocks:
+            response = _client().get("/stream/7/report")
+
+        assert response.status_code == 200
+        assert response.headers["X-Cache"] == "HIT"
+        assert response.json() == cached_payload
+        mocks.comprehensive.assert_not_called()
+        mocks.series.assert_not_called()
+        cache.set.assert_not_called()
+
+    def test_gateway_error_returns_500(self):
+        with _report_mocks() as mocks:
+            mocks.comprehensive.side_effect = Exception("boom")
+            response = _client().get("/stream/7/report")
+
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Internal server error"}
+
+
+_EXPORT_ROWS = [
+    (1, "2026-07-01T18:00:00.000000", 11, "alice", "hello, world", True, "subscriber/12"),
+    (2, "2026-07-01T18:00:01.500000", 12, "bob", 'say "hi"\nbye', None, None),
+]
+
+
+def _mock_pool(rows):
+    cursor = MagicMock()
+    cursor.__iter__ = Mock(return_value=iter(rows))
+    connection = MagicMock()
+    connection.cursor.return_value = cursor
+    pool = MagicMock()
+    pool.get_connection.return_value.__enter__ = Mock(return_value=connection)
+    pool.get_connection.return_value.__exit__ = Mock(return_value=False)
+    return pool, connection, cursor
+
+
+class TestStreamExport:
+    def test_unauthenticated_rejected(self):
+        response = _client().get("/stream/7/export")
+        assert response.status_code in (401, 403)
+
+    @patch(f"{_EP}.select_stream_comprehensive_db")
+    @patch(f"{_EP}.get_pool")
+    def test_404_when_stream_missing(self, mock_get_pool, mock_comprehensive):
+        mock_comprehensive.return_value = None
+
+        response = _user_client().get("/stream/999/export")
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Stream not found"}
+        mock_get_pool.assert_not_called()
+
+    @patch(f"{_EP}.select_stream_comprehensive_db")
+    @patch(f"{_EP}.get_pool")
+    def test_ndjson_default(self, mock_get_pool, mock_comprehensive):
+        mock_comprehensive.return_value = _COMPREHENSIVE
+        pool, connection, cursor = _mock_pool(_EXPORT_ROWS)
+        mock_get_pool.return_value = pool
+
+        response = _user_client().get("/stream/7/export")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/x-ndjson")
+        assert response.headers["content-disposition"] == 'attachment; filename="stream_7_chat.ndjson"'
+        lines = response.text.splitlines()
+        assert [json.loads(line) for line in lines] == [
+            {
+                "id": 1,
+                "time": "2026-07-01T18:00:00.000000",
+                "chatter_id": 11,
+                "nick": "alice",
+                "text": "hello, world",
+                "is_subscriber": True,
+                "badges": "subscriber/12",
+            },
+            {
+                "id": 2,
+                "time": "2026-07-01T18:00:01.500000",
+                "chatter_id": 12,
+                "nick": "bob",
+                "text": 'say "hi"\nbye',
+                "is_subscriber": None,
+                "badges": None,
+            },
+        ]
+        # Server-side (named) cursor with the replay SQL, cleaned up after streaming.
+        assert connection.cursor.call_args.kwargs["name"].startswith("chat_export_7_")
+        assert cursor.itersize == 5000
+        assert cursor.execute.call_args.args[1] == (7,)
+        cursor.close.assert_called_once()
+        connection.rollback.assert_called_once()
+
+    @patch(f"{_EP}.select_stream_comprehensive_db")
+    @patch(f"{_EP}.get_pool")
+    def test_csv_format(self, mock_get_pool, mock_comprehensive):
+        mock_comprehensive.return_value = _COMPREHENSIVE
+        pool, _connection, _cursor = _mock_pool(_EXPORT_ROWS)
+        mock_get_pool.return_value = pool
+
+        response = _user_client().get("/stream/7/export?format=csv")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/csv")
+        assert response.headers["content-disposition"] == 'attachment; filename="stream_7_chat.csv"'
+        assert response.text == (
+            "id,time,chatter_id,nick,text,is_subscriber,badges\r\n"
+            '1,2026-07-01T18:00:00.000000,11,alice,"hello, world",True,subscriber/12\r\n'
+            '2,2026-07-01T18:00:01.500000,12,bob,"say ""hi""\nbye",,\r\n'
+        )
+
+    def test_invalid_format_rejected(self):
+        assert _user_client().get("/stream/7/export?format=xml").status_code == 422
+
+    @patch(f"{_EP}.select_stream_comprehensive_db")
+    def test_gateway_error_returns_500(self, mock_comprehensive):
+        mock_comprehensive.side_effect = Exception("boom")
+
+        response = _user_client().get("/stream/7/export")
+
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Internal server error"}

--- a/frontend/components/streams/StreamDownloadMenu.jsx
+++ b/frontend/components/streams/StreamDownloadMenu.jsx
@@ -1,0 +1,172 @@
+'use client'
+import { useState } from 'react'
+import { Dropdown } from 'react-bootstrap'
+import {
+    downloadStreamExport,
+    downloadStreamInsightCsv,
+    getApiErrorMessage,
+} from '@/lib/api'
+import { useAuth } from '@/contexts/AuthContext'
+
+/**
+ * Fetch a blob response and hand it to the browser as a file download.
+ * The JWT lives only in localStorage (attached by the axios interceptor), so
+ * a plain <a href> cannot be used for protected exports — fetch as a blob,
+ * then click a programmatic object-URL anchor.
+ * @param {object} response - axios response with a Blob body
+ * @param {string} filename - suggested download filename
+ */
+const saveBlob = (response, filename) => {
+    const url = URL.createObjectURL(response.data)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = filename
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    URL.revokeObjectURL(url)
+}
+
+/**
+ * Resolve a download error to a UI message. With responseType: 'blob' axios
+ * delivers error bodies as a Blob too, so the API's JSON {"detail": ...} must
+ * be read back into a plain object before getApiErrorMessage can see it.
+ * @param {unknown} downloadError - error thrown by an axios blob call
+ * @returns {Promise<string>} safe message for the menu footer
+ */
+const getDownloadErrorMessage = async downloadError => {
+    const body = downloadError?.response?.data
+    if (body instanceof Blob) {
+        try {
+            downloadError.response.data = JSON.parse(await body.text())
+        } catch {
+            // Not JSON — fall through to the generic axios message.
+        }
+    }
+    return getApiErrorMessage(downloadError, 'Download failed')
+}
+
+/**
+ * Export dropdown for a stream: full chat log (NDJSON/CSV, login required)
+ * and the aggregate emotes/phrases/mentions CSVs. All items download through
+ * the axios blob helpers so the Authorization header is carried; items are
+ * disabled while a download is in flight and errors surface in a menu footer.
+ *
+ * @param {object} props
+ * @param {string|number} props.streamId
+ * @param {string} [props.title] - stream title, used for the toggle aria-label
+ */
+const StreamDownloadMenu = ({ streamId, title }) => {
+    const { token } = useAuth()
+    const [
+        downloading,
+        setDownloading,
+    ] = useState(null)
+    const [
+        errorMessage,
+        setErrorMessage,
+    ] = useState(null)
+
+    /**
+     * Run one download item: fetch the blob, save it, track in-flight state.
+     * @param {string} key - item identifier for the in-flight state
+     * @param {() => Promise<object>} fetcher - axios blob call
+     * @param {string} filename - suggested download filename
+     */
+    const handleDownload = async (key, fetcher, filename) => {
+        if (downloading) {
+            return
+        }
+        setDownloading(key)
+        setErrorMessage(null)
+        try {
+            const response = await fetcher()
+            saveBlob(response, filename)
+        } catch (downloadError) {
+            setErrorMessage(await getDownloadErrorMessage(downloadError))
+        } finally {
+            setDownloading(null)
+        }
+    }
+
+    const items = [
+    ]
+    if (token) {
+        items.push(
+            {
+                key: 'chat-ndjson',
+                label: 'Chat log (NDJSON)',
+                icon: 'bi-file-earmark-text',
+                fetcher: () => downloadStreamExport(streamId, 'ndjson'),
+                filename: `stream_${streamId}_chat.ndjson`,
+            },
+            {
+                key: 'chat-csv',
+                label: 'Chat log (CSV)',
+                icon: 'bi-filetype-csv',
+                fetcher: () => downloadStreamExport(streamId, 'csv'),
+                filename: `stream_${streamId}_chat.csv`,
+            },
+        )
+    }
+    items.push(
+        {
+            key: 'emotes-csv',
+            label: 'Emotes CSV',
+            icon: 'bi-filetype-csv',
+            fetcher: () => downloadStreamInsightCsv(streamId, 'emotes'),
+            filename: `stream_${streamId}_emotes.csv`,
+        },
+        {
+            key: 'phrases-csv',
+            label: 'Phrases CSV',
+            icon: 'bi-filetype-csv',
+            fetcher: () => downloadStreamInsightCsv(streamId, 'phrases'),
+            filename: `stream_${streamId}_phrases.csv`,
+        },
+        {
+            key: 'mentions-csv',
+            label: 'Mentions CSV',
+            icon: 'bi-filetype-csv',
+            fetcher: () => downloadStreamInsightCsv(streamId, 'mentions'),
+            filename: `stream_${streamId}_mentions.csv`,
+        },
+    )
+
+    return (
+        <Dropdown
+            align="end"
+            autoClose="outside">
+            <Dropdown.Toggle
+                variant="outline-primary"
+                size="sm"
+                aria-label={title ? `Export data for ${title}` : 'Export stream data'}>
+                <i
+                    className="bi bi-download me-2"
+                    aria-hidden="true"></i>
+                Export
+            </Dropdown.Toggle>
+            <Dropdown.Menu role="menu">
+                {items.map(item => (
+                    <Dropdown.Item
+                        key={item.key}
+                        role="menuitem"
+                        disabled={Boolean(downloading)}
+                        onClick={() => handleDownload(item.key, item.fetcher, item.filename)}>
+                        <i
+                            className={`bi ${item.icon} me-2`}
+                            aria-hidden="true"></i>
+                        {downloading === item.key ? 'Downloading...' : item.label}
+                    </Dropdown.Item>
+                ))}
+                {errorMessage && (
+                    <Dropdown.ItemText className="text-danger small">
+                        {errorMessage}
+                    </Dropdown.ItemText>
+                )}
+            </Dropdown.Menu>
+        </Dropdown>
+    )
+}
+
+export default StreamDownloadMenu

--- a/frontend/components/streams/StreamInfoCard.jsx
+++ b/frontend/components/streams/StreamInfoCard.jsx
@@ -8,9 +8,12 @@ import ThumbImage from './ThumbImage'
 
 /**
  * Stream hero: thumbnail + identity + key numbers.
+ * @param {object} props
+ * @param {import('react').ReactNode} [props.downloadMenu] - optional export
+ *   dropdown rendered in the page-actions slot next to the Twitch button
  */
 const StreamInfoCard = ({
-    streamInfoData, twitchLink, formattedStartTime, formattedEndTime, timeAgo, duration,
+    streamInfoData, twitchLink, formattedStartTime, formattedEndTime, timeAgo, duration, downloadMenu,
 }) => {
     const {
         title, displayName, messageCount, thumbnailUrl,
@@ -40,6 +43,7 @@ const StreamInfoCard = ({
                             aria-hidden="true"></i>
                         Twitch channel
                     </a>
+                    {downloadMenu}
                 </div>
             </div>
 

--- a/frontend/components/streams/StreamReportCard.jsx
+++ b/frontend/components/streams/StreamReportCard.jsx
@@ -1,0 +1,260 @@
+'use client'
+import { Card } from 'react-bootstrap'
+import { useStreamReport } from '@/hooks/useApiQuery'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorAlert from '@/components/ErrorAlert'
+
+/** Local naive "YYYY-MM-DDTHH:MM:SS" -> "HH:MM" without timezone drift. */
+const clock = ts => (typeof ts === 'string' && ts.length >= 16 ? ts.slice(11, 16) : '--')
+
+/** Render a number with thousands separators (integers). */
+const num = value => Number(value).toLocaleString(undefined, {
+    maximumFractionDigits: 0,
+})
+
+/** Render a number with exactly one decimal place. */
+const dec1 = value => Number(value).toLocaleString(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+})
+
+/** Format a 0..1 share as "XX.X%". */
+const pct = value => `${dec1(value * 100)}%`
+
+/**
+ * Delta chip for a metric: signed percentage vs the baseline median with a
+ * direction arrow. Only rendered when deltaPct is non-null (nullable = unknown).
+ * @param {object} props
+ * @param {number} props.deltaPct - rounded delta percentage vs baseline median
+ */
+const DeltaChip = ({ deltaPct }) => {
+    const direction = deltaPct > 0 ? 'up' : deltaPct < 0 ? 'down' : 'flat'
+    const icon = {
+        up: 'bi-arrow-up-right',
+        down: 'bi-arrow-down-right',
+        flat: 'bi-dash',
+    }[direction]
+    const text = `${deltaPct > 0 ? '+' : ''}${dec1(deltaPct)}%`
+    return (
+        <span
+            className={`report-delta is-${direction}`}
+            aria-label={`${text} vs baseline median`}>
+            <i
+                className={`bi ${icon}`}
+                aria-hidden="true" />
+            {text}
+        </span>
+    )
+}
+
+/**
+ * Stream report card: the rollup metrics as stat tiles, each annotated with a
+ * delta chip and percentile hint against the creator's previous streams, plus
+ * a highlights row (top emote / top phrase / top moments).
+ *
+ * Nullable = unknown contract: tiles with a null value are omitted entirely,
+ * delta/percentile hints are hidden when the baseline is too small (< 2
+ * rolled-up previous streams), and highlight chips are hidden when null/empty.
+ * When nothing is computed yet a single muted hint is shown instead, so the
+ * page still renders without rollups.
+ *
+ * @param {object} props
+ * @param {string|number} props.streamId
+ */
+const StreamReportCard = ({ streamId }) => {
+    const {
+        data,
+        isLoading,
+        error,
+        refetch,
+    } = useStreamReport(streamId)
+
+    if (isLoading) {
+        return (
+            <Card className="stream-report">
+                <Card.Body>
+                    <h3 className="section-label mb-3">Report card</h3>
+                    <LoadingSpinner
+                        size="md"
+                        text="Loading report..."
+                    />
+                </Card.Body>
+            </Card>
+        )
+    }
+
+    if (error) {
+        return (
+            <Card className="stream-report">
+                <Card.Body>
+                    <h3 className="section-label mb-3">Report card</h3>
+                    <ErrorAlert
+                        error={error}
+                        title="Failed to load report"
+                        onRetry={refetch}
+                        showDetails={process.env.NODE_ENV === 'development'}
+                    />
+                </Card.Body>
+            </Card>
+        )
+    }
+
+    const metrics = data?.metrics || {
+    }
+    const baselineCount = data?.baselineCount ?? 0
+
+    const tileDefs = [
+        {
+            key: 'totalMessages',
+            label: 'Total messages',
+            format: num,
+            phosphor: true,
+        },
+        {
+            key: 'messagesPerMinute',
+            label: 'Messages / min',
+            format: dec1,
+        },
+        {
+            key: 'uniqueChatters',
+            label: 'Unique chatters',
+            format: num,
+        },
+        {
+            key: 'peakMessages',
+            label: 'Peak minute',
+            format: num,
+            extraHint: data?.peakBucketMinute ? `at ${clock(data.peakBucketMinute)}` : null,
+        },
+        {
+            key: 'newChatters',
+            label: 'New chatters',
+            format: num,
+        },
+        {
+            key: 'returningChatters',
+            label: 'Returning chatters',
+            format: num,
+        },
+        {
+            key: 'subShare',
+            label: 'Sub share',
+            format: pct,
+        },
+        {
+            key: 'avgViewers',
+            label: 'Avg viewers',
+            format: num,
+        },
+        {
+            key: 'peakViewers',
+            label: 'Peak viewers',
+            format: num,
+            phosphor: true,
+        },
+    ]
+
+    // Nullable = unknown: a null metric value means "not computed", so the tile
+    // is omitted entirely rather than rendering a misleading 0 or bogus delta.
+    const tiles = tileDefs
+        .filter(def => metrics[def.key]?.value != null)
+        .map(def => {
+            const metric = metrics[def.key]
+            const percentileHint = metric.percentile != null
+                ? `P${dec1(metric.percentile)} · vs median ${def.format(metric.baselineMedian)}`
+                : null
+            return {
+                ...def,
+                value: def.format(metric.value),
+                deltaPct: metric.deltaPct,
+                hint: [
+                    def.extraHint,
+                    percentileHint,
+                ].filter(Boolean).join(' · ') || null,
+            }
+        })
+
+    const topEmote = data?.topEmote ?? null
+    const topPhrase = data?.topPhrase ?? null
+    const topMoments = data?.topMoments || []
+    const hasHighlights = Boolean(topEmote || topPhrase || topMoments.length > 0)
+
+    if (tiles.length === 0 && !hasHighlights) {
+        return (
+            <Card className="stream-report">
+                <Card.Body>
+                    <h3 className="section-label mb-3">Report card</h3>
+                    <p className="stat-hint text-muted mb-0">
+                        Metrics not yet computed for this stream.
+                    </p>
+                </Card.Body>
+            </Card>
+        )
+    }
+
+    return (
+        <Card className="stream-report">
+            <Card.Body>
+                <h3 className="section-label mb-3">Report card</h3>
+
+                {tiles.length > 0 && (
+                    <div
+                        className="stat-grid mb-0"
+                        role="list"
+                        aria-label="Stream report metrics">
+                        {tiles.map(tile => (
+                            <div
+                                key={tile.label}
+                                className="stat-tile"
+                                role="listitem">
+                                <div className="stat-label">{tile.label}</div>
+                                <div className={`stat-value${tile.phosphor ? ' text-phosphor' : ''}`}>
+                                    {tile.value}
+                                    {tile.deltaPct != null && <DeltaChip deltaPct={tile.deltaPct} />}
+                                </div>
+                                {tile.hint ? <div className="stat-hint">{tile.hint}</div> : null}
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {(hasHighlights || baselineCount >= 2) && (
+                    <div className="report-highlights">
+                        {topEmote && (
+                            <span className="report-chip">
+                                <span className="report-chip-label">Top emote</span>
+                                <span className="report-chip-value">{topEmote.name}</span>
+                                <span className="report-chip-count mono">{num(topEmote.usageCount)}×</span>
+                            </span>
+                        )}
+                        {topPhrase && (
+                            <span className="report-chip">
+                                <span className="report-chip-label">Top phrase</span>
+                                <span className="report-chip-value">{topPhrase.phrase}</span>
+                                <span className="report-chip-count mono">{num(topPhrase.usageCount)}×</span>
+                            </span>
+                        )}
+                        {topMoments.map(moment => (
+                            <span
+                                key={moment.bucketMinute}
+                                className="report-chip">
+                                <span className="report-chip-label">Moment</span>
+                                <span className="report-chip-value mono">{clock(moment.bucketMinute)}</span>
+                                <span className="report-chip-count mono">
+                                    {num(moment.messageCount)} msgs
+                                </span>
+                            </span>
+                        ))}
+                        {baselineCount >= 2 && (
+                            <span className="stat-hint report-baseline-note">
+                                vs previous {baselineCount} streams
+                            </span>
+                        )}
+                    </div>
+                )}
+            </Card.Body>
+        </Card>
+    )
+}
+
+export default StreamReportCard

--- a/frontend/hooks/useApiQuery.js
+++ b/frontend/hooks/useApiQuery.js
@@ -31,6 +31,11 @@ export {
 } from './useCreatorRegularsQuery'
 
 export {
+    useStreamReport,
+    streamReportKeys,
+} from './useStreamReportQuery'
+
+export {
     streamInsightsKeys,
     useCreatorEmotes,
     useStreamEmotes,

--- a/frontend/hooks/useStreamReportQuery.js
+++ b/frontend/hooks/useStreamReportQuery.js
@@ -1,0 +1,111 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { retrieveStreamReport } from '@/lib/api'
+
+/**
+ * Query key factory for stream report-card queries
+ */
+export const streamReportKeys = {
+    all: [
+        'stream-report',
+    ],
+    details: () => [
+        ...streamReportKeys.all,
+        'detail',
+    ],
+    detail: streamId => [
+        ...streamReportKeys.details(),
+        streamId,
+    ],
+}
+
+/**
+ * Map a snake_case ReportMetric to camelCase, preserving nulls.
+ *
+ * Nullable = unknown contract: null means "not computed / not enough baseline",
+ * never a real 0 — consumers hide the tile/chip instead of rendering 0.
+ * @param {object|null|undefined} metric - {value, delta_pct, percentile, baseline_median}
+ * @returns {object|null}
+ */
+const mapMetric = metric => (metric
+    ? {
+        value: metric.value ?? null,
+        deltaPct: metric.delta_pct ?? null,
+        percentile: metric.percentile ?? null,
+        baselineMedian: metric.baseline_median ?? null,
+    }
+    : null)
+
+/**
+ * Custom hook for a stream's report card (metrics annotated with baseline
+ * delta/percentile, top emote/phrase/moments), mapped to camelCase.
+ *
+ * All nullable analytics fields are preserved via `?? null` — a null metric
+ * value means the rollup has not run, and null delta/percentile means the
+ * baseline was too small (< 2 rolled-up previous streams).
+ *
+ * @param {string|number} streamId - The stream ID
+ * @param {object} options - Additional query options
+ * @returns {object} useQuery result; data = {streamId, creatorId, creatorNick,
+ *   title, start, end, durationSeconds, baselineCount, lookback, metrics,
+ *   peakBucketMinute, topEmote, topPhrase, topMoments}
+ */
+export const useStreamReport = (streamId, options = {}) => useQuery({
+    queryKey: streamReportKeys.detail(streamId),
+    queryFn: async () => {
+        const response = await retrieveStreamReport(streamId)
+        const data = response.data || {
+        }
+        const metrics = data.metrics || {
+        }
+        return {
+            streamId: data.stream_id,
+            creatorId: data.creator_id,
+            creatorNick: data.creator_nick ?? null,
+            title: data.title ?? null,
+            start: data.start ?? null,
+            end: data.end ?? null,
+            durationSeconds: data.duration_seconds ?? null,
+            baselineCount: data.baseline_count ?? 0,
+            lookback: data.lookback,
+            metrics: {
+                messagesPerMinute: mapMetric(metrics.messages_per_minute),
+                totalMessages: mapMetric(metrics.total_messages),
+                uniqueChatters: mapMetric(metrics.unique_chatters),
+                newChatters: mapMetric(metrics.new_chatters),
+                returningChatters: mapMetric(metrics.returning_chatters),
+                subShare: mapMetric(metrics.sub_share),
+                peakMessages: mapMetric(metrics.peak_messages),
+                avgViewers: mapMetric(metrics.avg_viewers),
+                peakViewers: mapMetric(metrics.peak_viewers),
+            },
+            peakBucketMinute: data.peak_bucket_minute ?? null,
+            topEmote: data.top_emote
+                ? {
+                    name: data.top_emote.name,
+                    source: data.top_emote.source,
+                    providerId: data.top_emote.provider_id ?? null,
+                    usageCount: data.top_emote.usage_count,
+                    chatterCount: data.top_emote.chatter_count,
+                }
+                : null,
+            topPhrase: data.top_phrase
+                ? {
+                    phrase: data.top_phrase.phrase,
+                    usageCount: data.top_phrase.usage_count,
+                    chatterCount: data.top_phrase.chatter_count,
+                }
+                : null,
+            topMoments: (data.top_moments || []).map(m => ({
+                bucketMinute: m.bucket_minute,
+                offsetSeconds: m.offset_seconds ?? null,
+                messageCount: m.message_count,
+                ratio: m.ratio ?? null,
+                status: m.status ?? null,
+            })),
+        }
+    },
+    enabled: Boolean(streamId),
+    // Hold the previous render during refetch — no skeleton flash.
+    placeholderData: keepPreviousData,
+    ...options,
+})

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -101,6 +101,16 @@ export const putMomentReview = (streamId: number, bucketMinute: string, status: 
 export const deleteMomentReview = (streamId: number, bucketMinute: string) =>
   api.delete(`/stream/${streamId}/moments/${encodeURIComponent(bucketMinute)}/review`)
 
+// W8 — stream report card + data exports
+export const retrieveStreamReport = (streamId: number, lookback?: number) => api.get(`/stream/${streamId}/report?${qs({ lookback })}`)
+// Blob downloads: the JWT lives in localStorage and is attached by the request
+// interceptor, so exports must go through axios (a plain <a href> has no header).
+// timeout: 0 — a full chat log can exceed the instance default of 10s.
+export const downloadStreamExport = (streamId: number, format: 'ndjson' | 'csv' = 'ndjson') =>
+  api.get(`/stream/${streamId}/export?${qs({ format })}`, { responseType: 'blob', timeout: 0 })
+export const downloadStreamInsightCsv = (streamId: number, kind: 'emotes' | 'phrases' | 'mentions') =>
+  api.get(`/stream/${streamId}/${kind}?format=csv`, { responseType: 'blob', timeout: 0 })
+
 export const retrieveStreamComprehensive = (streamId: string | number) => api.get(`/stream/${streamId}`)
 export const retrieveAllCreators = () => api.get('/creators')
 export const retrieveChatterStreamActivity = (chatterId: string | number) => api.get(`/chatter/${chatterId}/stream-activity`)

--- a/frontend/styles/_stream-report.scss
+++ b/frontend/styles/_stream-report.scss
@@ -1,0 +1,98 @@
+// Stream report card: rollup stat tiles annotated with baseline delta chips
+// and a highlights row (top emote / phrase / moments). Reuses the night-ops
+// .stat-grid/.stat-tile skeleton from _theme.scss; only the delta chip and
+// the highlights row are new.
+
+.stream-report {
+    // The value line holds the number plus an optional delta chip.
+    .stat-value {
+        display: flex;
+        align-items: baseline;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+    }
+}
+
+// Delta vs baseline-median chip: mono, small, signal-colored per direction.
+.report-delta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.15rem;
+    padding: 0.12rem 0.4rem;
+    border: 1px solid $hairline;
+    border-radius: 2px;
+    font-family: $font-family-monospace;
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1.2;
+    font-variant-numeric: tabular-nums;
+
+    &.is-up {
+        color: $teal;
+        border-color: rgba($teal, 0.35);
+        background: rgba($teal, 0.08);
+    }
+
+    &.is-down {
+        color: $signal-red;
+        border-color: rgba($signal-red, 0.35);
+        background: rgba($signal-red, 0.08);
+    }
+
+    &.is-flat {
+        color: $gray-300;
+        background: rgba($gray-500, 0.12);
+    }
+
+    i {
+        font-size: 0.7rem;
+    }
+}
+
+// Compact highlights row under the tile grid: top emote / phrase / moment
+// chips plus the baseline framing note.
+.report-highlights {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 1.1rem;
+    padding-top: 0.9rem;
+    border-top: 1px solid $hairline;
+}
+
+.report-chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.45rem;
+    padding: 0.3rem 0.6rem;
+    border: 1px solid $hairline;
+    border-radius: 2px;
+    background: rgba($bg-raised, 0.5);
+
+    .report-chip-label {
+        font-size: 0.64rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: $gray-400;
+    }
+
+    .report-chip-value {
+        font-size: 0.82rem;
+        color: $gray-100;
+        max-width: 16rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .report-chip-count {
+        font-size: 0.72rem;
+        color: $phosphor;
+        font-variant-numeric: tabular-nums;
+    }
+}
+
+.report-baseline-note {
+    margin-left: auto;
+}

--- a/frontend/styles/style.scss
+++ b/frontend/styles/style.scss
@@ -14,3 +14,4 @@
 @import "charts-community";
 @import "moments-queue";
 @import "stream-insights";
+@import "stream-report";

--- a/frontend/views/Stream.jsx
+++ b/frontend/views/Stream.jsx
@@ -16,8 +16,9 @@ import {
 import LoadingSpinner from '@/components/LoadingSpinner'
 import ErrorAlert from '@/components/ErrorAlert'
 import StreamInfoCard from '@/components/streams/StreamInfoCard'
+import StreamDownloadMenu from '@/components/streams/StreamDownloadMenu'
 import StreamTimeline from '@/components/streams/StreamTimeline'
-import StreamMetrics from '@/components/streams/StreamMetrics'
+import StreamReportCard from '@/components/streams/StreamReportCard'
 import StreamStatsCard from '@/components/streams/StreamStatsCard'
 import MentionsPanel from '@/components/streams/MentionsPanel'
 import EmotesPanel from '@/components/streams/EmotesPanel'
@@ -284,14 +285,20 @@ const Stream = ({ streamId }) => {
                 formattedEndTime={formattedEndTime}
                 timeAgo={timeAgo}
                 duration={duration}
+                downloadMenu={(
+                    <StreamDownloadMenu
+                        streamId={streamId}
+                        title={streamInfoData.title}
+                    />
+                )}
             />
+
+            <StreamReportCard streamId={streamId} />
 
             <StreamTimeline
                 timeline={timeline}
                 onJump={handleJump}
             />
-
-            <StreamMetrics metrics={timeline?.metrics} />
 
             <StreamStatsCard
                 mostActiveChatters={mostActiveChatters}


### PR DESCRIPTION
## What

**Post-stream report card** — the verdict view for a stream. `GET /stream/{id}/report` composes the already-deployed rollups (msgs/min, unique/new/returning chatters, sub share, peak minute, avg/peak viewers, top emote, top phrase, top persisted moments) and annotates each metric with **delta vs baseline median** and **percentile rank** against the creator's previous N rolled-up streams (`?lookback=10`, 2–30). The frontend `StreamReportCard` replaces `StreamMetrics` on the Stream page: same tiles, now with up/down delta chips and `P{percentile} · vs median` hints, plus top-emote/phrase/moment chips and "vs previous N streams" framing.

**Data export** — an Export dropdown in the Stream page header:
- `?format=csv` on the existing `/stream/{id}/emotes`, `/phrases`, `/mentions` endpoints (in-memory CSV from the cached JSON payload).
- New JWT-protected `GET /stream/{id}/export?format=ndjson|csv` streaming the **full chat log** through a psycopg2 named (server-side) cursor — constant memory even for million-message streams; connection held inside the generator and released on completion/disconnect. `HEAVY` rate-limit tier, never cached.

## Design decisions

- **nullable = unknown everywhere**: un-rolled-up streams return 200 with null metrics (never 404, never 0); un-rolled-up previous streams are excluded from baselines (new `select_creator_report_series_db` gateway deliberately does not COALESCE); with <2 baseline streams all deltas/percentiles are null; the frontend omits null tiles and chips.
- Viewer metrics (avg/peak) are value-only — historical viewer window-matching per past stream is out of scope.
- Top moments come from persisted `stream_moment` rows only (rejected excluded); moment review changes now also invalidate `stream_report:*` caches.
- Both `@limiter.limit` endpoints declare `request: Request` + `response: Response` (PR #34 gotcha).
- Downloads go through an authorized axios blob fetch (a bare `<a href>` wouldn't carry the JWT); blob error bodies are parsed so API `detail` messages still surface.

## How it was built

Multi-agent session: ideation panel (5 lenses + independent Codex opinion — Codex's #1 pick matched this feature), pattern-mapping readers, parallel backend/frontend implementers against a locked contract, gate verification, adversarial review (2 findings, both fixed).

## Verification

- `uv run ruff check .` — clean
- `uv run pytest tests/unit/api tests/unit/analytics tests/unit/utils` — **246 passed** (3 pre-existing `TestMomentQueueGateway` errors need Postgres, fail identically on main)
- `npm run typecheck` + `npm run build` — clean
- New tests: report math (median/percentile/delta edge cases), report endpoint (shape, null rollup, cache hit, 404, lookback forwarding), CSV/NDJSON serializers (quoting, unicode), export endpoint (auth 401/403, format 422, streamed content), CSV format on insight endpoints, moment-review cache invalidation.

## After merge

No migration needed (rev 0008 suffices). Deploys automatically on push to main.

https://claude.ai/code/session_01EXfaau3UEsTSdpFmxZKKnc