### PR TITLE
Add scene expansion: live-now, leaderboard, copypasta library, bot detection

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -66,6 +66,7 @@ stream-sniper-api = "stream_sniper.api.server:run"
 stream-sniper-tracking = "stream_sniper.tracking_service:run_tracking_service"
 stream-sniper-migrate = "stream_sniper.database.migrate:main"
 stream-sniper-rollup = "stream_sniper.analytics.backfill:main"
+stream-sniper-classify-bots = "stream_sniper.analytics.bot_detection:main"
 
 [project.urls]
 Homepage = "https://github.com/slanycukr/stream-sniper"

--- a/backend/stream_sniper/analytics/bot_detection.py
+++ b/backend/stream_sniper/analytics/bot_detection.py
@@ -1,0 +1,164 @@
+"""Bot/spam-chatter classification CLI: `stream-sniper-classify-bots`.
+
+Marks chatter rows as bots (chatter.is_bot / bot_reason) using cheap, high-precision
+signals that never scan the raw `message` table:
+
+  1. Known-name list (100% precision): a curated set of well-known Twitch service bots,
+     matched on lower(nick). Reason ``known_bot``.
+  2. Cross-channel ubiquity: chatters present in more than ``--min-channels`` distinct
+     creators' audiences (from the creator_chatter_stats rollup). Reason ``ubiquity:<n>``.
+  3. Superhuman message rate: chatters sustaining >= 12 msgs/min in >= 3 streams with
+     >= 200 messages each (from the stream_chatter_stats rollup). Reason ``rate``.
+
+Marking is monotonic: an already-marked bot is never un-marked or re-reasoned (the gateway
+UPDATEs guard on ``is_bot IS NOT TRUE``), so the first classification reason sticks.
+
+Bots are excluded only at the cross-channel layer (community overlap, regulars); per-stream
+rollups keep them as the factual record. After a non-dry run this triggers a blocking
+community-overlap recompute so the exclusion takes effect immediately.
+"""
+
+import argparse
+import sys
+
+from dotenv import load_dotenv
+
+from ..database.chatter_table_gateway import (
+    count_bots_db,
+    mark_bots_by_ids_db,
+    mark_bots_by_nick_db,
+    select_bot_candidates_rate_db,
+    select_bot_candidates_ubiquity_db,
+)
+from ..logging_config import get_logger, setup_logging
+from .community import recompute_creator_overlap
+
+# Well-known Twitch service bots (chat bots, viewer bots, alert/soundboard bots). Matched on
+# lower(nick); expand as new ones appear. This is the primary, 100%-precision signal.
+KNOWN_BOTS: frozenset[str] = frozenset(
+    {
+        "nightbot",
+        "streamelements",
+        "streamlabs",
+        "moobot",
+        "fossabot",
+        "wizebot",
+        "botisimo",
+        "coebot",
+        "deepbot",
+        "phantombot",
+        "sery_bot",
+        "soundalerts",
+        "commanderroot",
+        "anotherttvviewer",
+        "own3d",
+        "tangiabot",
+        "kofistreambot",
+        "blerp",
+        "pokemoncommunitygame",
+        "sound_alerts",
+        "regressz",
+        "lurxx",
+        "streamholics",
+        "aliceydra",
+        "creatisbot",
+        "tarsai",
+        "frostytoolsdotcom",
+        "dinu",
+        "peepostreambot",
+    }
+)
+
+DEFAULT_MIN_CHANNELS = 20
+
+
+def classify_bots(min_channels: int = DEFAULT_MIN_CHANNELS, *, dry_run: bool = False) -> dict:
+    """Run the three classification passes and return a counts summary.
+
+    Returns a dict with keys ``known``, ``ubiquity``, ``rate`` (rows marked this run, or the
+    candidate count under ``--dry-run``) and ``total_bots`` (chatters currently flagged). With
+    ``dry_run`` set no UPDATE runs — the candidate passes are still evaluated and reported.
+    """
+    counts = {"known": 0, "ubiquity": 0, "rate": 0, "total_bots": 0}
+
+    # 1. Known-name list.
+    if dry_run:
+        counts["known"] = len(KNOWN_BOTS)
+    else:
+        counts["known"] = mark_bots_by_nick_db(sorted(KNOWN_BOTS), "known_bot")
+
+    # 2. Cross-channel ubiquity (reads the small creator_chatter_stats rollup).
+    ubiquity_candidates = select_bot_candidates_ubiquity_db(min_channels)
+    counts["ubiquity"] = len(ubiquity_candidates)
+    if not dry_run and ubiquity_candidates:
+        mark_bots_by_ids_db([row[0] for row in ubiquity_candidates], f"ubiquity:{min_channels}")
+
+    # 3. Superhuman sustained message rate (reads the stream_chatter_stats rollup).
+    rate_candidates = select_bot_candidates_rate_db()
+    counts["rate"] = len(rate_candidates)
+    if not dry_run and rate_candidates:
+        mark_bots_by_ids_db([row[0] for row in rate_candidates], "rate")
+
+    counts["total_bots"] = count_bots_db()
+    return counts
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="stream-sniper-classify-bots",
+        description="Classify chatters as bots via known-name + cross-channel + rate heuristics.",
+    )
+    parser.add_argument(
+        "--min-channels",
+        type=int,
+        default=DEFAULT_MIN_CHANNELS,
+        help=f"Ubiquity threshold: chatters in more than this many distinct creators "
+        f"are flagged (default {DEFAULT_MIN_CHANNELS}).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be marked without writing any UPDATE.",
+    )
+    parser.add_argument(
+        "--skip-overlap-recompute",
+        action="store_true",
+        help="Do not recompute community overlap after marking (advanced/testing).",
+    )
+    args = parser.parse_args()
+
+    load_dotenv()
+    setup_logging(environment="development")
+    logger = get_logger(__name__)
+
+    try:
+        counts = classify_bots(args.min_channels, dry_run=args.dry_run)
+    except Exception as e:
+        logger.error(f"Bot classification failed: {e}", exc_info=True)
+        sys.exit(1)
+
+    prefix = "[dry-run] " if args.dry_run else ""
+    logger.info(
+        f"{prefix}Bot classification: known={counts['known']}, "
+        f"ubiquity={counts['ubiquity']} (>{args.min_channels} channels), "
+        f"rate={counts['rate']}; total bots now {counts['total_bots']}."
+    )
+
+    if args.dry_run:
+        logger.info("Dry run complete: no rows were modified.")
+        return
+
+    if args.skip_overlap_recompute:
+        logger.info("Skipping community-overlap recompute (--skip-overlap-recompute).")
+        return
+
+    try:
+        recompute_creator_overlap(blocking=True)
+        logger.info("Community overlap recomputed (bots now excluded).")
+    except Exception as e:
+        logger.error(f"Community overlap recompute failed: {e}", exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/stream_sniper/analytics/rollup_engine.py
+++ b/backend/stream_sniper/analytics/rollup_engine.py
@@ -6,6 +6,10 @@ from ..database.stream_chatter_stats_table_gateway import (
     recompute_stream_rollup_db,
     select_stream_creator_id_db,
 )
+from ..database.stream_copypasta_stats_table_gateway import (
+    replace_stream_copypasta_stats_db,
+    select_stream_copypasta_source_db,
+)
 from ..database.stream_metrics_table_gateway import select_stream_header_db
 from ..database.stream_moment_table_gateway import replace_stream_text_rollups_db
 from ..database.stream_time_bucket_table_gateway import select_stream_buckets_db
@@ -60,6 +64,13 @@ def compute_stream_rollup(stream_id: int, *, refresh_overlap: bool = True) -> No
     except Exception as e:
         logger.error(f"compute_stream_rollup: text rollups failed for stream {stream_id}: {e}", exc_info=True)
 
+    try:
+        _compute_and_store_copypasta_rollup(stream_id)
+    except Exception as e:
+        logger.error(
+            f"compute_stream_rollup: copypasta rollup failed for stream {stream_id}: {e}", exc_info=True
+        )
+
     if refresh_overlap:
         try:
             community.recompute_creator_overlap(blocking=False)
@@ -85,3 +96,14 @@ def _compute_and_store_text_rollups(stream_id: int) -> None:
     moment_rows = enrich_moments(stream_id, buckets, stream_start, usage, emote_names)
 
     replace_stream_text_rollups_db(stream_id, phrase_rows, moment_rows)
+
+
+def _compute_and_store_copypasta_rollup(stream_id: int) -> None:
+    """Fill stream_copypasta_stats for a stream from its own bot/junk-filtered SQL source.
+
+    Whole-message copypasta identity (keyed on message_text_id), separate from the tokenized
+    phrase rollup. Runs inside the per-stream flow, so `stream-sniper-rollup --all --force`
+    backfills it for free.
+    """
+    rows = select_stream_copypasta_source_db(stream_id)
+    replace_stream_copypasta_stats_db(stream_id, rows)

--- a/backend/stream_sniper/api/analytics_endpoints.py
+++ b/backend/stream_sniper/api/analytics_endpoints.py
@@ -89,6 +89,7 @@ def get_creator_regulars(
     dir: str = Query("desc", pattern="^(asc|desc)$"),
     min_streams: int = Query(2, description="Minimum streams attended to qualify", ge=1, le=1000),
     limit: int = Query(50, description="Maximum number of regulars to return", ge=1, le=200),
+    include_bots: bool = Query(False, description="Include chatters flagged as bots"),
 ) -> CreatorRegulars:
     """Get a creator's recurring chatters with attendance rates."""
     try:
@@ -97,7 +98,7 @@ def get_creator_regulars(
         count_cache_key = cache._generate_key("creator_stream_count", creator_id)
         cached_count = cache.get(count_cache_key)
         regulars_cache_key = cache._generate_key(
-            "creator_regulars", creator_id, sort, dir, min_streams, limit
+            "creator_regulars", creator_id, sort, dir, min_streams, limit, include_bots
         )
         cached_regulars = cache.get(regulars_cache_key)
         count_from_cache = cached_count is not None
@@ -117,7 +118,9 @@ def get_creator_regulars(
             rows = cached_regulars
         else:
             record_cache_operation("miss", "creator_regulars")
-            rows = select_creator_regulars_db(creator_id, min_streams, limit, sort=sort, dir=dir)
+            rows = select_creator_regulars_db(
+                creator_id, min_streams, limit, sort=sort, dir=dir, include_bots=include_bots
+            )
             cache.set(regulars_cache_key, rows, CacheTTL.STREAM_DETAILS)
             record_cache_operation("set", "creator_regulars")
 

--- a/backend/stream_sniper/api/api.py
+++ b/backend/stream_sniper/api/api.py
@@ -23,6 +23,7 @@ from .moment_endpoints import router as moment_router
 from .monitoring import record_request_metrics, setup_monitoring
 from .operations_endpoints import router as operations_router
 from .rate_limiter import setup_rate_limiting
+from .scene_endpoints import router as scene_router
 from .stream_endpoints import router as stream_router
 from .stream_insight_endpoints import router as stream_insight_router
 from .stream_report_endpoints import router as stream_report_router
@@ -195,6 +196,9 @@ app.include_router(stream_report_router)
 
 # Include community overlap router
 app.include_router(community_router)
+
+# Include scene router (live-now, leaderboard, copypasta library)
+app.include_router(scene_router)
 
 # Include highlight queue + moment review router
 app.include_router(moment_router)

--- a/backend/stream_sniper/api/chatter_endpoints.py
+++ b/backend/stream_sniper/api/chatter_endpoints.py
@@ -85,9 +85,12 @@ def get_chatter_messages(
 
 @router.get(
     "/chatter/{nick}/chatter_id",
-    response_model=list[int],
+    response_model=list[Any],
     summary="Get chatter ID by nickname",
-    description="Look up a chatter's unique ID using their nickname.",
+    description=(
+        "Look up a chatter's unique ID using their nickname. "
+        "Returns [id, is_bot] where is_bot is null when the chatter has not been classified yet."
+    ),
     responses={
         404: {"model": ErrorResponse, "description": "Chatter not found"},
         429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
@@ -98,8 +101,8 @@ def get_chatter_id(
     request: Request,
     response: Response,
     nick: str = Path(..., description="Chatter nickname", json_schema_extra={"example": "viewer123"}),
-) -> list[int]:
-    """Get a chatter ID by nickname."""
+) -> list[Any]:
+    """Get a chatter ID (and bot flag) by nickname."""
     try:
         cache = get_cache()
         cache_key = cache._generate_key("chatter_id", nick)
@@ -118,7 +121,7 @@ def get_chatter_id(
         cache.set(cache_key, result, CacheTTL.CHATTER_MESSAGES)
         record_cache_operation("set", "chatter_id")
         response.headers["X-Cache"] = "MISS"
-        return cast(list[int], result)
+        return cast(list[Any], result)
     except HTTPException:
         raise
     except Exception as exc:
@@ -131,7 +134,10 @@ def get_chatter_id(
     "/chatters/search",
     response_model=list[list[Any]],
     summary="Search chatters by nickname prefix",
-    description="Case-insensitive prefix search over chatter nicknames for autocomplete.",
+    description=(
+        "Case-insensitive prefix search over chatter nicknames for autocomplete. "
+        "Rows are [id, nick, is_bot]; is_bot is null when unclassified — bots are badged, not hidden."
+    ),
     responses={429: {"model": ErrorResponse, "description": "Rate limit exceeded"}},
 )
 @limiter.limit(rate_limits.SEARCH)

--- a/backend/stream_sniper/api/scene_endpoints.py
+++ b/backend/stream_sniper/api/scene_endpoints.py
@@ -1,0 +1,204 @@
+"""Read-only scene endpoints: live-now dashboard, creator leaderboard, copypasta library.
+
+All three are public (no auth), following the analytics/community endpoint conventions:
+sync `def` handlers (psycopg2 blocks), `request: Request` + `response: Response` for slowapi,
+in-process TTL cache keyed on the query params, nullable = unknown (never coalesce NULL -> 0).
+"""
+
+from typing import Literal, Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+
+from ..database.scene_table_gateway import (
+    select_scene_leaderboard_db,
+    select_scene_peak_viewers_db,
+)
+from ..database.stream_copypasta_stats_table_gateway import select_scene_copypastas_db
+from ..database.stream_viewer_sample_table_gateway import (
+    select_latest_sample_time_db,
+    select_live_now_db,
+)
+from ..logging_config import get_logger
+from .cache import CacheTTL, get_cache
+from .models import ErrorResponse
+from .monitoring import record_cache_operation
+from .rate_limiter import limiter, rate_limits
+from .scene_models import (
+    Copypasta,
+    LeaderboardEntry,
+    LiveStreamer,
+    SceneCopypastas,
+    SceneLeaderboard,
+    SceneLive,
+)
+
+logger = get_logger(__name__)
+
+# Live data refreshes every ~5 min (one sample per streamer per live poll), so a short cache
+# TTL keeps the dashboard fresh; the hour-scale STREAM_ANALYTICS TTL would be absurd here.
+_LIVE_CACHE_TTL_SECONDS = 60
+
+router = APIRouter(tags=["Scene"])
+
+
+@router.get(
+    "/scene/live",
+    response_model=SceneLive,
+    summary="Get currently-live tracked streamers",
+    description="Tracked streamers inferred live from fresh viewer samples, sorted by viewer count.",
+    responses={429: {"model": ErrorResponse, "description": "Rate limit exceeded"}},
+)
+@limiter.limit(rate_limits.GENERAL)
+def get_scene_live(request: Request, response: Response) -> SceneLive:
+    """Get the live-now dashboard: streamers with a viewer sample in the last 10 minutes."""
+    try:
+        cache = get_cache()
+        cache_key = cache._generate_key("scene_live")
+        cached_result = cache.get(cache_key)
+        if cached_result is not None:
+            response.headers["X-Cache"] = "HIT"
+            record_cache_operation("hit", "scene_live")
+            return SceneLive(**cached_result)
+
+        record_cache_operation("miss", "scene_live")
+        rows = select_live_now_db()
+        last_sample_at = select_latest_sample_time_db()
+
+        live = [
+            LiveStreamer(
+                creator_id=row[0],
+                nick=row[1],
+                display_name=row[2],
+                profile_image_url=row[3],
+                viewer_count=row[4],
+                title=row[5],
+                session_started_at=row[6],
+                sampled_at=row[7],
+            )
+            for row in rows
+        ]
+        live.sort(key=lambda s: s.viewer_count, reverse=True)
+
+        result = SceneLive(live=live, live_count=len(live), last_sample_at=last_sample_at)
+        cache.set(cache_key, result.model_dump(), _LIVE_CACHE_TTL_SECONDS)
+        record_cache_operation("set", "scene_live")
+        response.headers["X-Cache"] = "MISS"
+        return result
+    except Exception as exc:
+        logger.error(f"Error fetching scene live: {exc}")
+        record_cache_operation("error", "scene_live")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get(
+    "/scene/leaderboard",
+    response_model=SceneLeaderboard,
+    summary="Get the scene creator leaderboard",
+    description="Creators ranked by total messages over a 7- or 30-day window.",
+    responses={429: {"model": ErrorResponse, "description": "Rate limit exceeded"}},
+)
+@limiter.limit(rate_limits.ANALYTICS)
+def get_scene_leaderboard(
+    request: Request,
+    response: Response,
+    window: int = Query(7, description="Window length in days (7 or 30)"),
+) -> SceneLeaderboard:
+    """Get the scene-wide creator leaderboard for the window (ranked by total messages)."""
+    # Only two windows are supported; validate before the try so it 422s (not 500). A Literal[7, 30]
+    # query param would 422 for free, but this FastAPI version won't coerce the "30" string to int.
+    if window not in (7, 30):
+        raise HTTPException(status_code=422, detail="window must be 7 or 30")
+    try:
+        cache = get_cache()
+        cache_key = cache._generate_key("scene_leaderboard", window)
+        cached_result = cache.get(cache_key)
+        if cached_result is not None:
+            response.headers["X-Cache"] = "HIT"
+            record_cache_operation("hit", "scene_leaderboard")
+            return SceneLeaderboard(**cached_result)
+
+        record_cache_operation("miss", "scene_leaderboard")
+        rows = select_scene_leaderboard_db(window)
+        peak_map = {row[0]: row[1] for row in select_scene_peak_viewers_db(window)}
+
+        entries = [
+            LeaderboardEntry(
+                rank=rank,
+                creator_id=row[0],
+                nick=row[1],
+                display_name=row[2],
+                profile_image_url=row[3],
+                streams=row[4],
+                hours_streamed=row[5],
+                total_messages=row[6],
+                msgs_per_min=row[7],
+                chatter_appearances=row[8],
+                peak_viewers=peak_map.get(row[0]),
+            )
+            for rank, row in enumerate(rows, start=1)
+        ]
+
+        result = SceneLeaderboard(window_days=window, entries=entries)
+        cache.set(cache_key, result.model_dump(), CacheTTL.STREAM_ANALYTICS)
+        record_cache_operation("set", "scene_leaderboard")
+        response.headers["X-Cache"] = "MISS"
+        return result
+    except Exception as exc:
+        logger.error(f"Error fetching scene leaderboard: {exc}")
+        record_cache_operation("error", "scene_leaderboard")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get(
+    "/scene/copypastas",
+    response_model=SceneCopypastas,
+    summary="Get the scene copypasta library",
+    description="Deduplicated copypastas aggregated scene-wide, filterable by window and creator.",
+    responses={429: {"model": ErrorResponse, "description": "Rate limit exceeded"}},
+)
+@limiter.limit(rate_limits.ANALYTICS)
+def get_scene_copypastas(
+    request: Request,
+    response: Response,
+    days: Optional[int] = Query(None, ge=1, description="Window in days; omit for all-time"),
+    creator_id: Optional[int] = Query(None, description="Restrict to one creator"),
+    sort: Literal["usage", "spread", "recent"] = Query("usage", description="Sort order"),
+    limit: int = Query(25, ge=1, le=100, description="Page size"),
+    offset: int = Query(0, ge=0, description="Row offset for pagination"),
+) -> SceneCopypastas:
+    """Get a page of scene-wide copypastas, sorted by usage, channel spread, or recency."""
+    try:
+        cache = get_cache()
+        cache_key = cache._generate_key("scene_copypastas", days, creator_id, sort, limit, offset)
+        cached_result = cache.get(cache_key)
+        if cached_result is not None:
+            response.headers["X-Cache"] = "HIT"
+            record_cache_operation("hit", "scene_copypastas")
+            return SceneCopypastas(**cached_result)
+
+        record_cache_operation("miss", "scene_copypastas")
+        rows, total = select_scene_copypastas_db(days, creator_id, sort, limit, offset)
+
+        items = [
+            Copypasta(
+                message_text_id=row[0],
+                text=row[1],
+                usage_count=row[2],
+                chatter_appearances=row[3],
+                stream_count=row[4],
+                creator_count=row[5],
+                first_seen=row[6],
+                last_stream_start=row[7],
+            )
+            for row in rows
+        ]
+
+        result = SceneCopypastas(total=total, items=items)
+        cache.set(cache_key, result.model_dump(), CacheTTL.STREAM_ANALYTICS)
+        record_cache_operation("set", "scene_copypastas")
+        response.headers["X-Cache"] = "MISS"
+        return result
+    except Exception as exc:
+        logger.error(f"Error fetching scene copypastas: {exc}")
+        record_cache_operation("error", "scene_copypastas")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/stream_sniper/api/scene_models.py
+++ b/backend/stream_sniper/api/scene_models.py
@@ -1,0 +1,85 @@
+"""Response contracts for the scene endpoints (live-now, leaderboard, copypasta library)."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class LiveStreamer(BaseModel):
+    """One currently-live tracked streamer, from the latest fresh viewer sample."""
+
+    creator_id: int = Field(..., description="Creator ID", json_schema_extra={"example": 5})
+    nick: str = Field(..., description="Creator login/nick")
+    display_name: str = Field(..., description="Creator display name")
+    profile_image_url: Optional[str] = Field(None, description="Creator avatar URL, if known")
+    viewer_count: int = Field(..., description="Live viewer count at the latest sample")
+    title: Optional[str] = Field(None, description="Stream title at the latest sample, if known")
+    session_started_at: Optional[str] = Field(
+        None, description="Live session start (ISO 8601, UTC); uptime anchor, null if unknown"
+    )
+    sampled_at: str = Field(..., description="When the latest sample was taken (ISO 8601, UTC)")
+
+
+class SceneLive(BaseModel):
+    """The set of tracked streamers currently inferred to be live."""
+
+    live: List[LiveStreamer] = Field(..., description="Live streamers, sorted by viewer_count DESC")
+    live_count: int = Field(..., description="Number of live streamers")
+    last_sample_at: Optional[str] = Field(
+        None, description="Newest viewer sample overall (ISO 8601, UTC); stale => tracker down"
+    )
+
+
+class LeaderboardEntry(BaseModel):
+    """One creator's ranked row on the scene leaderboard for the window."""
+
+    rank: int = Field(..., description="1-based rank by total_messages DESC")
+    creator_id: int = Field(..., description="Creator ID", json_schema_extra={"example": 5})
+    nick: str = Field(..., description="Creator login/nick")
+    display_name: str = Field(..., description="Creator display name")
+    profile_image_url: Optional[str] = Field(None, description="Creator avatar URL, if known")
+    streams: int = Field(..., description="Streams in the window")
+    hours_streamed: Optional[float] = Field(
+        None, description="Summed hours of closed streams in the window"
+    )
+    total_messages: int = Field(..., description="Total messages across the window's streams")
+    msgs_per_min: Optional[float] = Field(
+        None, description="Duration-weighted avg msgs/min; null when no rolled-up data"
+    )
+    chatter_appearances: int = Field(
+        ..., description="Summed per-stream unique chatters (double-counts across streams)"
+    )
+    peak_viewers: Optional[int] = Field(
+        None, description="Max live viewers in the window; null when no samples"
+    )
+
+
+class SceneLeaderboard(BaseModel):
+    """Scene-wide creator leaderboard over a fixed window."""
+
+    window_days: int = Field(..., description="Window length in days (7 or 30)")
+    entries: List[LeaderboardEntry] = Field(..., description="Ranked creators, best first")
+
+
+class Copypasta(BaseModel):
+    """One deduplicated copypasta/meme message aggregated scene-wide."""
+
+    message_text_id: int = Field(..., description="Deduplicated message-text ID")
+    text: str = Field(..., description="The copypasta text")
+    usage_count: int = Field(..., description="Total times sent across all streams")
+    chatter_appearances: int = Field(
+        ..., description="Summed per-stream distinct chatters (double-counts across streams)"
+    )
+    stream_count: int = Field(..., description="Distinct streams it appeared in")
+    creator_count: int = Field(..., description="Distinct creators/channels it spread to")
+    first_seen: Optional[str] = Field(None, description="Earliest send time (ISO 8601), if known")
+    last_stream_start: Optional[str] = Field(
+        None, description="Start of the most recent stream it appeared in (ISO 8601), if known"
+    )
+
+
+class SceneCopypastas(BaseModel):
+    """A page of scene-wide copypastas matching the filter."""
+
+    total: int = Field(..., description="Total distinct copypastas matching the filter")
+    items: List[Copypasta] = Field(..., description="Copypastas for this page")

--- a/backend/stream_sniper/database/chatter_table_gateway.py
+++ b/backend/stream_sniper/database/chatter_table_gateway.py
@@ -75,14 +75,17 @@ def select_chatters_by_prefix_db(prefix: str, limit: int, cursor):
     Case-insensitive prefix search over chatter nicks for autocomplete.
     Relies on the functional index chatter_nick_lower_prefix_idx
     (lower(nick) text_pattern_ops) so the LIKE prefix scan stays fast.
+    Bots are NOT hidden here — is_bot rides along so the UI can badge them
+    (NULL = not yet classified).
     :param prefix: The nick prefix the user has typed
     :param limit: Maximum number of suggestions to return
-    :return: List of (id, nick) tuples ordered by nick
+    :return: List of (id, nick, is_bot) tuples ordered by nick
     """
     sql = """
     SELECT
         id,
-        nick
+        nick,
+        is_bot
     FROM
         chatter
     WHERE lower(nick) LIKE lower(%s) || '%%'
@@ -105,3 +108,99 @@ def select_all_chatters_db(cursor) -> dict:
     cursor.execute(sql)
 
     return {row[1]: row[0] for row in cursor.fetchall()}
+
+
+@with_cursor_connection
+def mark_bots_by_nick_db(nicks: List[str], reason: str, cursor, connection) -> int:
+    """Mark chatters whose lowercased nick is in `nicks` as bots. Returns rows updated.
+
+    Never un-marks or re-reasons an already-marked bot (is_bot IS NOT TRUE guard),
+    so the first classification reason sticks.
+    """
+    if not nicks:
+        return 0
+    cursor.execute(
+        """
+        UPDATE chatter
+        SET is_bot = TRUE, bot_reason = %s
+        WHERE lower(nick) = ANY(%s) AND is_bot IS NOT TRUE
+        """,
+        (reason, [nick.lower() for nick in nicks]),
+    )
+    connection.commit()
+    return cursor.rowcount
+
+
+@with_cursor_connection
+def mark_bots_by_ids_db(ids: List[int], reason: str, cursor, connection) -> int:
+    """Mark the given chatter IDs as bots. Returns rows updated (already-marked are skipped)."""
+    if not ids:
+        return 0
+    cursor.execute(
+        """
+        UPDATE chatter
+        SET is_bot = TRUE, bot_reason = %s
+        WHERE id = ANY(%s) AND is_bot IS NOT TRUE
+        """,
+        (reason, list(ids)),
+    )
+    connection.commit()
+    return cursor.rowcount
+
+
+@with_cursor
+def select_bot_candidates_ubiquity_db(min_channels: int, cursor):
+    """Unmarked chatters present in MORE THAN `min_channels` distinct creators' audiences.
+
+    Reads the small creator_chatter_stats rollup (never the message table).
+    :return: List of (chatter_id, channel_count) tuples, most ubiquitous first.
+    """
+    cursor.execute(
+        """
+        SELECT ccs.chatter_id, count(DISTINCT ccs.creator_id) AS channels
+        FROM creator_chatter_stats ccs
+        JOIN chatter c ON c.id = ccs.chatter_id
+        WHERE c.is_bot IS NOT TRUE
+        GROUP BY ccs.chatter_id
+        HAVING count(DISTINCT ccs.creator_id) > %s
+        ORDER BY channels DESC, ccs.chatter_id ASC
+        """,
+        (min_channels,),
+    )
+    return cursor.fetchall()
+
+
+@with_cursor
+def select_bot_candidates_rate_db(cursor, *, min_messages=200, min_rate=12.0, min_streams=3):
+    """Unmarked chatters with a superhuman sustained message rate.
+
+    A qualifying stream has message_count >= min_messages AND a sustained rate of
+    message_count / active-minutes >= min_rate; a chatter qualifies with at least
+    min_streams such streams. One SQL over the stream_chatter_stats rollup — no
+    message scan.
+    :return: List of (chatter_id, stream_count) tuples.
+    """
+    cursor.execute(
+        """
+        SELECT scs.chatter_id, count(*) AS streams
+        FROM stream_chatter_stats scs
+        JOIN chatter c ON c.id = scs.chatter_id
+        WHERE c.is_bot IS NOT TRUE
+          AND scs.message_count >= %s
+          AND scs.message_count / NULLIF(
+                EXTRACT(EPOCH FROM (scs.last_message_time - scs.first_message_time)) / 60.0, 0
+              ) >= %s
+        GROUP BY scs.chatter_id
+        HAVING count(*) >= %s
+        ORDER BY streams DESC, scs.chatter_id ASC
+        """,
+        (min_messages, min_rate, min_streams),
+    )
+    return cursor.fetchall()
+
+
+@with_cursor
+def count_bots_db(cursor) -> int:
+    """Total chatters currently marked as bots."""
+    cursor.execute("SELECT count(*) FROM chatter WHERE is_bot IS TRUE")
+    return cursor.fetchone()[0]

--- a/backend/stream_sniper/database/creator_chatter_stats_table_gateway.py
+++ b/backend/stream_sniper/database/creator_chatter_stats_table_gateway.py
@@ -12,9 +12,13 @@ _DIR = {"asc": "ASC", "desc": "DESC"}
 
 
 @with_cursor
-def select_creator_regulars_db(creator_id, min_streams, limit, cursor, *, sort="attendance", dir="desc"):
+def select_creator_regulars_db(
+    creator_id, min_streams, limit, cursor, *, sort="attendance", dir="desc", include_bots=False
+):
     col = _REGULAR_SORT.get(sort, "streams_attended")
     direction = _DIR.get(dir, "DESC")
+    # By default bots are hidden from the regulars list; include_bots=True keeps them.
+    bot_filter = "" if include_bots else "AND c.is_bot IS NOT TRUE"
     cursor.execute(
         f"""
         SELECT
@@ -27,7 +31,7 @@ def select_creator_regulars_db(creator_id, min_streams, limit, cursor, *, sort="
             ccs.total_messages
         FROM creator_chatter_stats ccs
         JOIN chatter c ON c.id = ccs.chatter_id
-        WHERE ccs.creator_id = %s AND ccs.streams_attended >= %s
+        WHERE ccs.creator_id = %s AND ccs.streams_attended >= %s {bot_filter}
         ORDER BY {col} {direction}, ccs.chatter_id ASC
         LIMIT %s
         """,

--- a/backend/stream_sniper/database/creator_overlap_table_gateway.py
+++ b/backend/stream_sniper/database/creator_overlap_table_gateway.py
@@ -35,13 +35,19 @@ def recompute_creator_overlap_db(blocking, cursor, connection):
             connection.rollback()
             return False
 
+    # Bots are excluded from the cross-channel audience/overlap layer (per-stream rollups keep
+    # them — that is the factual record). Joining chatter on the (shared) chatter_id and filtering
+    # ch.is_bot IS NOT TRUE drops bot chatters from both sides of each pair.
     cursor.execute("DELETE FROM creator_audience")
     cursor.execute(
         """
         INSERT INTO creator_audience (creator_id, chatters, regulars, computed_at)
-        SELECT creator_id, count(*), count(*) FILTER (WHERE streams_attended >= 3), now()
-        FROM creator_chatter_stats
-        GROUP BY creator_id
+        SELECT ccs.creator_id, count(*),
+               count(*) FILTER (WHERE ccs.streams_attended >= 3), now()
+        FROM creator_chatter_stats ccs
+        JOIN chatter ch ON ch.id = ccs.chatter_id
+        WHERE ch.is_bot IS NOT TRUE
+        GROUP BY ccs.creator_id
         """
     )
 
@@ -57,6 +63,8 @@ def recompute_creator_overlap_db(blocking, cursor, connection):
         FROM creator_chatter_stats a
         JOIN creator_chatter_stats b
             ON b.chatter_id = a.chatter_id AND b.creator_id > a.creator_id
+        JOIN chatter ch ON ch.id = a.chatter_id
+        WHERE ch.is_bot IS NOT TRUE
         GROUP BY a.creator_id, b.creator_id
         """
     )

--- a/backend/stream_sniper/database/message_table_gateway.py
+++ b/backend/stream_sniper/database/message_table_gateway.py
@@ -87,20 +87,24 @@ def select_moment_window_messages_db(stream_id, windows, cursor):
 
 @with_cursor
 def select_chatter_id_db(nick, cursor):
-    cursor.execute("SELECT id FROM chatter WHERE nick = %s", (nick,))
+    """Return (id, is_bot) for a nick, or None. is_bot is trailing: NULL = not yet classified."""
+    cursor.execute("SELECT id, is_bot FROM chatter WHERE nick = %s", (nick,))
     return cursor.fetchone()
 
 
 @with_cursor
 def select_chatter_stream_activity_db(chatter_id, cursor):
+    """Per-stream footprint rows for a chatter, with the chatter's is_bot flag trailing."""
     cursor.execute(
         """
-    SELECT m.stream_id, s.title, s.start, cr.id, cr.display_name, COUNT(*) AS message_count
+    SELECT m.stream_id, s.title, s.start, cr.id, cr.display_name, COUNT(*) AS message_count,
+           ch.is_bot
     FROM message m
     JOIN stream s ON s.id = m.stream_id
     JOIN creator cr ON cr.id = s.creator_id
+    JOIN chatter ch ON ch.id = m.chatter_id
     WHERE m.chatter_id = %s
-    GROUP BY m.stream_id, s.title, s.start, cr.id, cr.display_name
+    GROUP BY m.stream_id, s.title, s.start, cr.id, cr.display_name, ch.is_bot
     ORDER BY message_count DESC
     LIMIT 100
     """,

--- a/backend/stream_sniper/database/migrations/versions/0009_scene_expansion.py
+++ b/backend/stream_sniper/database/migrations/versions/0009_scene_expansion.py
@@ -1,0 +1,66 @@
+"""scene expansion: bot flag, copypasta stats, viewer sample index
+
+Adds the scene-expansion surface (bot detection, copypasta library, live-now):
+  * chatter gains is_bot / bot_reason (NULLABLE by design: NULL = "not yet
+    classified" so the UI can tell unknown apart from a confirmed human; the
+    stream-sniper-classify-bots pass writes TRUE + a reason string)
+  * stream_copypasta_stats - per-stream copypasta usage rollup (written by the
+    rollup engine, aggregated scene-wide by the /scene/copypastas endpoint)
+  * stream_viewer_sample (sampled_at DESC) index - supports the /scene/live
+    freshness scan and the leaderboard's windowed peak-viewers aggregate.
+    Plain (non-CONCURRENT) index: the table is days old and small, and this
+    revision must stay transactional/offline-capable.
+
+Ordinary transactional DDL (all IF NOT EXISTS, schema-qualified), so it runs
+online or offline (--sql).
+
+Revision ID: 0009
+Revises: 0008
+"""
+
+from alembic import op
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE stream_sniper.chatter
+            ADD COLUMN IF NOT EXISTS is_bot     boolean NULL,
+            ADD COLUMN IF NOT EXISTS bot_reason text    NULL;
+
+        CREATE TABLE IF NOT EXISTS stream_sniper.stream_copypasta_stats (
+            stream_id       int       NOT NULL,
+            message_text_id bigint    NOT NULL,
+            usage_count     int       NOT NULL,
+            chatter_count   int       NOT NULL,
+            first_seen      timestamp NULL,
+            CONSTRAINT stream_copypasta_stats_pk PRIMARY KEY (stream_id, message_text_id),
+            CONSTRAINT stream_copypasta_stats_stream_fk FOREIGN KEY (stream_id)
+                REFERENCES stream_sniper.stream (id),
+            CONSTRAINT stream_copypasta_stats_text_fk FOREIGN KEY (message_text_id)
+                REFERENCES stream_sniper.message_text (id)
+        );
+
+        CREATE INDEX IF NOT EXISTS stream_viewer_sample_sampled_at_idx
+            ON stream_sniper.stream_viewer_sample (sampled_at DESC);
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DROP INDEX IF EXISTS stream_sniper.stream_viewer_sample_sampled_at_idx;
+
+        DROP TABLE IF EXISTS stream_sniper.stream_copypasta_stats;
+
+        ALTER TABLE stream_sniper.chatter
+            DROP COLUMN IF EXISTS bot_reason,
+            DROP COLUMN IF EXISTS is_bot;
+        """
+    )

--- a/backend/stream_sniper/database/scene_table_gateway.py
+++ b/backend/stream_sniper/database/scene_table_gateway.py
@@ -1,0 +1,65 @@
+"""Database gateway for the scene-wide leaderboard.
+
+Cheap aggregates over the small `stream` + `stream_metrics` tables (one GROUP BY,
+no `message` scan). Peak viewers is a SEPARATE aggregate over stream_viewer_sample
+(creator-linked via tracked_streamers) merged in Python by creator_id, so the two
+big tables are never cross-joined.
+"""
+
+from .decorators import with_cursor
+
+
+@with_cursor
+def select_scene_leaderboard_db(days: int, cursor):
+    """Per-creator activity aggregate over the last `days` days.
+
+    Returns rows ordered by total_messages DESC:
+      (creator_id, nick, display_name, profile_image_url, streams, hours_streamed,
+       total_messages, msgs_per_min, chatter_appearances)
+
+    hours_streamed skips unclosed streams (NULL "end") via a per-row CASE. msgs_per_min
+    is NULL when there is no rolled-up duration (SUM = 0), so un-rolled creators surface
+    as unknown rather than 0 (nullable = unknown). chatter_appearances SUMs per-stream
+    unique_chatters, so it double-counts across streams — an honest "appearances" label.
+    """
+    cursor.execute(
+        """
+        SELECT s.creator_id, c.nick, c.display_name, c.profile_image_url,
+               COUNT(*) AS streams,
+               SUM(CASE WHEN s."end" IS NOT NULL
+                        THEN EXTRACT(EPOCH FROM (s."end" - s.start)) ELSE 0 END) / 3600.0 AS hours,
+               SUM(s.message_count) AS total_messages,
+               SUM(COALESCE(sm.total_messages, 0))::float
+                   / NULLIF(SUM(COALESCE(sm.duration_seconds, 0)) / 60.0, 0) AS msgs_per_min,
+               SUM(COALESCE(sm.unique_chatters, 0)) AS chatter_appearances
+        FROM stream s
+        JOIN creator c ON c.id = s.creator_id
+        LEFT JOIN stream_metrics sm ON sm.stream_id = s.id
+        WHERE s.start >= (now() AT TIME ZONE 'UTC') - (%s * interval '1 day')
+        GROUP BY s.creator_id, c.nick, c.display_name, c.profile_image_url
+        ORDER BY total_messages DESC, s.creator_id ASC
+        """,
+        (days,),
+    )
+    return cursor.fetchall()
+
+
+@with_cursor
+def select_scene_peak_viewers_db(days: int, cursor):
+    """Max live viewer_count per creator over the last `days` days.
+
+    Reads stream_viewer_sample via tracked_streamers (no stream join — sample ids live
+    in a different id space). Returns (creator_id, peak_viewers) rows; creators with no
+    samples in the window are simply absent (the caller leaves peak_viewers None).
+    """
+    cursor.execute(
+        """
+        SELECT ts.creator_id, MAX(svs.viewer_count)
+        FROM stream_viewer_sample svs
+        JOIN tracked_streamers ts ON ts.id = svs.tracked_streamer_id
+        WHERE svs.sampled_at >= now() - (%s * interval '1 day')
+        GROUP BY ts.creator_id
+        """,
+        (days,),
+    )
+    return cursor.fetchall()

--- a/backend/stream_sniper/database/stream_copypasta_stats_table_gateway.py
+++ b/backend/stream_sniper/database/stream_copypasta_stats_table_gateway.py
@@ -1,0 +1,145 @@
+"""Database gateway for the per-stream copypasta rollup (stream_copypasta_stats).
+
+Copypasta identity is the whole deduplicated message text (keyed on message_text_id),
+NOT a tokenized n-gram. The rollup engine fills this table per-stream (index-supported
+by the stream_id filter, applying junk + bot filters); the /scene/copypastas endpoint
+aggregates the SMALL rollup table scene-wide — the raw `message` table is never scanned
+on demand.
+"""
+
+from typing import List, Optional, Tuple
+
+from psycopg2.extras import execute_values
+
+from .decorators import with_cursor, with_cursor_connection
+
+# Whitelisted sort: the caller-supplied `sort` maps through this dict to a fixed ORDER BY
+# fragment, so no user string is ever interpolated into the query.
+_COPYPASTA_SORT = {
+    "usage": "usage_count DESC, message_text_id ASC",
+    "spread": "creator_count DESC, usage_count DESC, message_text_id ASC",
+    "recent": "last_stream_start DESC, message_text_id ASC",
+}
+
+
+@with_cursor
+def select_stream_copypasta_source_db(stream_id, cursor):
+    """Per-stream copypasta candidates: repeated, substantial, non-command messages from humans.
+
+    Returns (message_text_id, usage_count, chatter_count, first_seen) rows. Bots are excluded
+    (ch.is_bot IS NOT TRUE), commands (text starting '!') and short texts (< 20 chars) are
+    dropped, and a row only qualifies when it was sent by >= 2 distinct chatters OR >= 3 times.
+    """
+    cursor.execute(
+        """
+        SELECT m.message_text_id, COUNT(*), COUNT(DISTINCT m.chatter_id), MIN(m.time)
+        FROM message m
+        JOIN message_text mt ON mt.id = m.message_text_id
+        JOIN chatter ch ON ch.id = m.chatter_id
+        WHERE m.stream_id = %s AND m.chatter_id IS NOT NULL
+          AND ch.is_bot IS NOT TRUE
+          AND char_length(mt.text) >= 20
+          AND mt.text NOT LIKE '!%%'
+        GROUP BY m.message_text_id
+        HAVING COUNT(DISTINCT m.chatter_id) >= 2 OR COUNT(*) >= 3
+        """,
+        (stream_id,),
+    )
+    return cursor.fetchall()
+
+
+@with_cursor_connection
+def replace_stream_copypasta_stats_db(
+    stream_id,
+    rows: List[Tuple],
+    cursor,
+    connection,
+):
+    """Atomically replace this stream's copypasta rollup (DELETE per stream + execute_values INSERT).
+
+    rows: (message_text_id, usage_count, chatter_count, first_seen) — the shape returned by
+    select_stream_copypasta_source_db (first_seen is MIN(m.time), a datetime or None).
+    """
+    cursor.execute("DELETE FROM stream_copypasta_stats WHERE stream_id = %s", (stream_id,))
+    if rows:
+        execute_values(
+            cursor,
+            """
+            INSERT INTO stream_copypasta_stats
+                (stream_id, message_text_id, usage_count, chatter_count, first_seen)
+            VALUES %s
+            """,
+            [
+                (stream_id, message_text_id, usage_count, chatter_count, first_seen)
+                for message_text_id, usage_count, chatter_count, first_seen in rows
+            ],
+        )
+    connection.commit()
+
+
+@with_cursor
+def select_scene_copypastas_db(
+    days: Optional[int],
+    creator_id: Optional[int],
+    sort: str,
+    limit: int,
+    offset: int,
+    cursor,
+):
+    """Scene-wide copypasta aggregate over the small rollup table.
+
+    Returns (rows, total) where rows are:
+      (message_text_id, text, usage_count, chatter_appearances, stream_count, creator_count,
+       first_seen_iso, last_stream_start_iso)
+    Optional `days` window and `creator_id` filter narrow the aggregate; `sort` is whitelisted.
+    chatter_appearances SUMs per-stream chatter_count, so it double-counts across streams
+    (cross-stream distinct chatters is not reconstructable from per-stream counts).
+    """
+    order_by = _COPYPASTA_SORT.get(sort, _COPYPASTA_SORT["usage"])
+
+    where_clauses = []
+    params: list = []
+    if days is not None:
+        where_clauses.append("s.start >= (now() AT TIME ZONE 'UTC') - (%s * interval '1 day')")
+        params.append(days)
+    if creator_id is not None:
+        where_clauses.append("s.creator_id = %s")
+        params.append(creator_id)
+    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+    # Total distinct copypastas matching the filter (COUNT over the grouped subquery).
+    cursor.execute(
+        f"""
+        SELECT COUNT(*) FROM (
+            SELECT scs.message_text_id
+            FROM stream_copypasta_stats scs
+            JOIN stream s ON s.id = scs.stream_id
+            {where_sql}
+            GROUP BY scs.message_text_id
+        ) grouped
+        """,
+        tuple(params),
+    )
+    total = cursor.fetchone()[0]
+
+    cursor.execute(
+        f"""
+        SELECT scs.message_text_id, mt.text,
+               SUM(scs.usage_count) AS usage_count,
+               SUM(scs.chatter_count) AS chatter_appearances,
+               COUNT(DISTINCT scs.stream_id) AS stream_count,
+               COUNT(DISTINCT s.creator_id) AS creator_count,
+               TO_CHAR(MIN(scs.first_seen), 'YYYY-MM-DD"T"HH24:MI:SS') AS first_seen,
+               TO_CHAR(MAX(s.start), 'YYYY-MM-DD"T"HH24:MI:SS') AS last_stream_start
+        FROM stream_copypasta_stats scs
+        JOIN stream s ON s.id = scs.stream_id
+        JOIN message_text mt ON mt.id = scs.message_text_id
+        {where_sql}
+        GROUP BY scs.message_text_id, mt.text
+        ORDER BY {order_by}
+        LIMIT %s OFFSET %s
+        """,
+        tuple(params) + (limit, offset),
+    )
+    rows = cursor.fetchall()
+    return rows, total

--- a/backend/stream_sniper/database/stream_viewer_sample_table_gateway.py
+++ b/backend/stream_sniper/database/stream_viewer_sample_table_gateway.py
@@ -86,6 +86,50 @@ def select_session_viewer_samples_db(
 
 
 @with_cursor
+def select_live_now_db(cursor) -> List[Tuple]:
+    """Latest sample per tracked streamer within the last 10 minutes (i.e. currently live).
+
+    Liveness is inferred purely from sample freshness (samples are only written while live,
+    on a ~5 min cadence, so 10 min = 2 intervals). Returns one row per streamer:
+      (creator_id, nick, display_name, profile_image_url, viewer_count, title,
+       session_started_at_iso, sampled_at_iso)
+    Timestamps come out UTC-naive ISO strings. Caller sorts by viewer_count DESC.
+    """
+    cursor.execute(
+        """
+        SELECT DISTINCT ON (svs.tracked_streamer_id)
+               ts.creator_id, c.nick, c.display_name, c.profile_image_url,
+               svs.viewer_count, svs.title,
+               TO_CHAR(svs.session_started_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS'),
+               TO_CHAR(svs.sampled_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
+        FROM stream_viewer_sample svs
+        JOIN tracked_streamers ts ON ts.id = svs.tracked_streamer_id
+        JOIN creator c ON c.id = ts.creator_id
+        WHERE svs.sampled_at >= now() - interval '10 minutes'
+        ORDER BY svs.tracked_streamer_id, svs.sampled_at DESC
+        """
+    )
+    return cursor.fetchall()
+
+
+@with_cursor
+def select_latest_sample_time_db(cursor) -> Optional[str]:
+    """Newest sampled_at across all viewer samples as a UTC-naive ISO string, or None.
+
+    Surfaces tracker health: a stale value means the tracking container is down, so the UI
+    can distinguish "nobody live" from "tracking data is stale".
+    """
+    cursor.execute(
+        """
+        SELECT TO_CHAR(MAX(sampled_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS')
+        FROM stream_viewer_sample
+        """
+    )
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
+@with_cursor
 def select_stream_viewer_samples_db(stream_id, cursor) -> List[Tuple]:
     """Return viewer-count samples for a stream as (sampled_at_iso, viewer_count), oldest first.
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -61,10 +61,15 @@ SET search_path TO stream_sniper;
 
 -- Chatter table
 CREATE TABLE IF NOT EXISTS chatter (
-    id   SERIAL PRIMARY KEY,
-    nick VARCHAR(255) NOT NULL,
+    id         SERIAL PRIMARY KEY,
+    nick       VARCHAR(255) NOT NULL,
+    is_bot     boolean NULL,
+    bot_reason text    NULL,
     CONSTRAINT chatter_name_uindex UNIQUE (nick)
 );
+ALTER TABLE chatter
+    ADD COLUMN IF NOT EXISTS is_bot     boolean NULL,
+    ADD COLUMN IF NOT EXISTS bot_reason text    NULL;
 
 -- Creator table
 CREATE TABLE IF NOT EXISTS creator (

--- a/backend/tests/unit/analytics/test_bot_detection.py
+++ b/backend/tests/unit/analytics/test_bot_detection.py
@@ -1,0 +1,124 @@
+"""Unit tests for bot classification (stream_sniper.analytics.bot_detection).
+
+Gateways and the overlap recompute are patched at the bot_detection module path; no
+Postgres is touched. Covers the known-name list, the three-pass orchestrator, dry-run
+behavior, reason strings, and CLI argument handling.
+"""
+
+from unittest.mock import patch
+
+from stream_sniper.analytics import bot_detection
+from stream_sniper.analytics.bot_detection import KNOWN_BOTS, classify_bots
+
+
+class TestKnownBots:
+    """Sanity checks on the curated known-bot name set."""
+
+    def test_is_frozenset_of_lowercase_names(self):
+        assert isinstance(KNOWN_BOTS, frozenset)
+        for name in KNOWN_BOTS:
+            assert name == name.lower()
+            assert name.strip() == name
+            assert " " not in name
+
+    def test_contains_core_bots(self):
+        for expected in ("nightbot", "streamelements", "streamlabs", "moobot", "fossabot"):
+            assert expected in KNOWN_BOTS
+
+
+class TestClassifyBots:
+    """The three-pass orchestrator classify_bots()."""
+
+    @patch("stream_sniper.analytics.bot_detection.count_bots_db")
+    @patch("stream_sniper.analytics.bot_detection.select_bot_candidates_rate_db")
+    @patch("stream_sniper.analytics.bot_detection.select_bot_candidates_ubiquity_db")
+    @patch("stream_sniper.analytics.bot_detection.mark_bots_by_ids_db")
+    @patch("stream_sniper.analytics.bot_detection.mark_bots_by_nick_db")
+    def test_marks_all_three_layers(self, mock_nick, mock_ids, mock_ubiq, mock_rate, mock_count):
+        mock_nick.return_value = 3
+        mock_ubiq.return_value = [(101, 25), (102, 30)]
+        mock_rate.return_value = [(201, 5)]
+        mock_count.return_value = 6
+
+        counts = classify_bots(20)
+
+        assert counts == {"known": 3, "ubiquity": 2, "rate": 1, "total_bots": 6}
+        mock_nick.assert_called_once_with(sorted(KNOWN_BOTS), "known_bot")
+        mock_ubiq.assert_called_once_with(20)
+        mock_ids.assert_any_call([101, 102], "ubiquity:20")
+        mock_ids.assert_any_call([201], "rate")
+
+    @patch("stream_sniper.analytics.bot_detection.count_bots_db")
+    @patch("stream_sniper.analytics.bot_detection.select_bot_candidates_rate_db")
+    @patch("stream_sniper.analytics.bot_detection.select_bot_candidates_ubiquity_db")
+    @patch("stream_sniper.analytics.bot_detection.mark_bots_by_ids_db")
+    @patch("stream_sniper.analytics.bot_detection.mark_bots_by_nick_db")
+    def test_min_channels_in_reason(self, mock_nick, mock_ids, mock_ubiq, mock_rate, mock_count):
+        """The ubiquity reason string carries the configured threshold."""
+        mock_nick.return_value = 0
+        mock_ubiq.return_value = [(101, 40)]
+        mock_rate.return_value = []
+        mock_count.return_value = 1
+
+        classify_bots(35)
+
+        mock_ubiq.assert_called_once_with(35)
+        mock_ids.assert_called_once_with([101], "ubiquity:35")
+
+    @patch("stream_sniper.analytics.bot_detection.count_bots_db")
+    @patch("stream_sniper.analytics.bot_detection.select_bot_candidates_rate_db")
+    @patch("stream_sniper.analytics.bot_detection.select_bot_candidates_ubiquity_db")
+    @patch("stream_sniper.analytics.bot_detection.mark_bots_by_ids_db")
+    @patch("stream_sniper.analytics.bot_detection.mark_bots_by_nick_db")
+    def test_dry_run_writes_nothing(self, mock_nick, mock_ids, mock_ubiq, mock_rate, mock_count):
+        mock_ubiq.return_value = [(101, 25), (102, 30)]
+        mock_rate.return_value = [(201, 5)]
+        mock_count.return_value = 0
+
+        counts = classify_bots(20, dry_run=True)
+
+        mock_nick.assert_not_called()
+        mock_ids.assert_not_called()
+        assert counts["known"] == len(KNOWN_BOTS)
+        assert counts["ubiquity"] == 2
+        assert counts["rate"] == 1
+
+
+class TestMainCli:
+    """CLI argument handling in main()."""
+
+    @patch("stream_sniper.analytics.bot_detection.recompute_creator_overlap")
+    @patch("stream_sniper.analytics.bot_detection.classify_bots")
+    def test_default_run_recomputes_overlap(self, mock_classify, mock_recompute):
+        mock_classify.return_value = {"known": 1, "ubiquity": 0, "rate": 0, "total_bots": 1}
+
+        with patch("sys.argv", ["stream-sniper-classify-bots"]):
+            bot_detection.main()
+
+        mock_classify.assert_called_once_with(20, dry_run=False)
+        mock_recompute.assert_called_once_with(blocking=True)
+
+    @patch("stream_sniper.analytics.bot_detection.recompute_creator_overlap")
+    @patch("stream_sniper.analytics.bot_detection.classify_bots")
+    def test_dry_run_skips_recompute(self, mock_classify, mock_recompute):
+        mock_classify.return_value = {"known": 0, "ubiquity": 0, "rate": 0, "total_bots": 0}
+
+        with patch("sys.argv", ["stream-sniper-classify-bots", "--dry-run"]):
+            bot_detection.main()
+
+        mock_classify.assert_called_once_with(20, dry_run=True)
+        mock_recompute.assert_not_called()
+
+    @patch("stream_sniper.analytics.bot_detection.recompute_creator_overlap")
+    @patch("stream_sniper.analytics.bot_detection.classify_bots")
+    def test_min_channels_and_skip_flag(self, mock_classify, mock_recompute):
+        mock_classify.return_value = {"known": 0, "ubiquity": 0, "rate": 0, "total_bots": 0}
+
+        with patch(
+            "sys.argv",
+            ["stream-sniper-classify-bots", "--min-channels", "40", "--skip-overlap-recompute"],
+        ):
+            bot_detection.main()
+
+        mock_classify.assert_called_once_with(40, dry_run=False)
+        mock_recompute.assert_not_called()

--- a/backend/tests/unit/api/test_creator_analytics.py
+++ b/backend/tests/unit/api/test_creator_analytics.py
@@ -153,7 +153,7 @@ class TestCreatorRegularsEndpoint:
         assert first["message_count"] == 1250
         assert data["regulars"][1]["attendance_rate"] == round(3 / 8, 4)
         mock_count.assert_called_once_with(5)
-        mock_regulars.assert_called_once_with(5, 1, 50, sort="attendance", dir="desc")
+        mock_regulars.assert_called_once_with(5, 1, 50, sort="attendance", dir="desc", include_bots=False)
 
     @patch("stream_sniper.api.analytics_endpoints.get_cache")
     @patch("stream_sniper.api.analytics_endpoints.select_all_stream_count_db")
@@ -187,7 +187,48 @@ class TestCreatorRegularsEndpoint:
             response = client.get("/creator/5/regulars?sort=last_seen&dir=asc&min_streams=4&limit=25")
 
         assert response.status_code == 200
-        mock_regulars.assert_called_once_with(5, 4, 25, sort="last_seen", dir="asc")
+        mock_regulars.assert_called_once_with(5, 4, 25, sort="last_seen", dir="asc", include_bots=False)
+
+    @patch("stream_sniper.api.analytics_endpoints.get_cache")
+    @patch("stream_sniper.api.analytics_endpoints.select_all_stream_count_db")
+    @patch("stream_sniper.api.analytics_endpoints.select_creator_regulars_db")
+    def test_regulars_include_bots_forwarded(self, mock_regulars, mock_count, mock_get_cache):
+        """include_bots=true is forwarded to the gateway and folded into the cache key."""
+        cache = _miss_cache()
+        mock_get_cache.return_value = cache
+        mock_count.return_value = 10
+        mock_regulars.return_value = []
+
+        with TestClient(app) as client:
+            response = client.get("/creator/5/regulars?include_bots=true")
+
+        assert response.status_code == 200
+        mock_regulars.assert_called_once_with(5, 2, 50, sort="attendance", dir="desc", include_bots=True)
+        # include_bots participates in the regulars cache key (True suffix).
+        assert any(
+            call.args and call.args[0] == "creator_regulars" and call.args[-1] is True
+            for call in cache._generate_key.call_args_list
+        )
+
+    @patch("stream_sniper.api.analytics_endpoints.get_cache")
+    @patch("stream_sniper.api.analytics_endpoints.select_all_stream_count_db")
+    @patch("stream_sniper.api.analytics_endpoints.select_creator_regulars_db")
+    def test_regulars_include_bots_defaults_false(self, mock_regulars, mock_count, mock_get_cache):
+        """The default forwards include_bots=False and keys the cache with False."""
+        cache = _miss_cache()
+        mock_get_cache.return_value = cache
+        mock_count.return_value = 10
+        mock_regulars.return_value = []
+
+        with TestClient(app) as client:
+            response = client.get("/creator/5/regulars")
+
+        assert response.status_code == 200
+        mock_regulars.assert_called_once_with(5, 2, 50, sort="attendance", dir="desc", include_bots=False)
+        assert any(
+            call.args and call.args[0] == "creator_regulars" and call.args[-1] is False
+            for call in cache._generate_key.call_args_list
+        )
 
     def test_regulars_bogus_sort_422(self):
         """A sort value outside the whitelist is rejected before the gateway."""

--- a/backend/tests/unit/api/test_scene_endpoints.py
+++ b/backend/tests/unit/api/test_scene_endpoints.py
@@ -1,0 +1,274 @@
+"""Unit tests for the scene endpoints (live-now, leaderboard, copypasta library).
+
+The scene router is mounted onto a dedicated test app with the real limiter, and every
+gateway is patched at the endpoint module's import path. Postgres is never touched.
+"""
+
+from unittest.mock import Mock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stream_sniper.api.rate_limiter import setup_rate_limiting
+from stream_sniper.api.scene_endpoints import router
+
+
+def _build_app():
+    app = FastAPI()
+    setup_rate_limiting(app)
+    app.include_router(router)
+    return app
+
+
+app = _build_app()
+
+
+def _miss_cache():
+    """A mock cache that always misses, so endpoint tests don't depend on cache state."""
+    cache = Mock()
+    cache._generate_key = Mock(side_effect=lambda *args: "-".join(str(a) for a in args))
+    cache.get = Mock(return_value=None)
+    cache.set = Mock(return_value=True)
+    return cache
+
+
+def _hit_cache(payload):
+    """A mock cache that returns `payload` on get (cache HIT)."""
+    cache = Mock()
+    cache._generate_key = Mock(side_effect=lambda *args: "-".join(str(a) for a in args))
+    cache.get = Mock(return_value=payload)
+    cache.set = Mock(return_value=True)
+    return cache
+
+
+class TestSceneLiveEndpoint:
+    """GET /scene/live."""
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_latest_sample_time_db")
+    @patch("stream_sniper.api.scene_endpoints.select_live_now_db")
+    def test_live_sorted_by_viewer_count_desc(self, mock_live, mock_latest, mock_get_cache):
+        """Live streamers are sorted by viewer_count DESC regardless of gateway order."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_live.return_value = [
+            (1, "small", "Small", "http://a", 50, "hi", "2024-01-01T18:00:00", "2024-01-01T20:00:00"),
+            (2, "big", "Big", None, 5000, "yo", "2024-01-01T17:00:00", "2024-01-01T20:01:00"),
+        ]
+        mock_latest.return_value = "2024-01-01T20:01:00"
+
+        response = TestClient(app).get("/scene/live")
+
+        assert response.status_code == 200
+        assert response.headers["X-Cache"] == "MISS"
+        data = response.json()
+        assert data["live_count"] == 2
+        assert data["last_sample_at"] == "2024-01-01T20:01:00"
+        assert [s["creator_id"] for s in data["live"]] == [2, 1]
+        assert data["live"][0]["viewer_count"] == 5000
+        assert data["live"][0]["profile_image_url"] is None
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_latest_sample_time_db")
+    @patch("stream_sniper.api.scene_endpoints.select_live_now_db")
+    def test_live_empty_returns_200(self, mock_live, mock_latest, mock_get_cache):
+        """Nobody live is a valid 200 with an empty list and null last_sample_at."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_live.return_value = []
+        mock_latest.return_value = None
+
+        response = TestClient(app).get("/scene/live")
+
+        assert response.status_code == 200
+        assert response.json() == {"live": [], "live_count": 0, "last_sample_at": None}
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_live_now_db")
+    def test_live_cache_hit_skips_gateway(self, mock_live, mock_get_cache):
+        """A cache HIT returns the cached payload and never calls the gateway."""
+        mock_get_cache.return_value = _hit_cache(
+            {"live": [], "live_count": 0, "last_sample_at": None}
+        )
+
+        response = TestClient(app).get("/scene/live")
+
+        assert response.status_code == 200
+        assert response.headers["X-Cache"] == "HIT"
+        mock_live.assert_not_called()
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_latest_sample_time_db")
+    @patch("stream_sniper.api.scene_endpoints.select_live_now_db")
+    def test_live_server_error(self, mock_live, mock_latest, mock_get_cache):
+        """A gateway error surfaces as a 500."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_live.side_effect = Exception("boom")
+
+        response = TestClient(app).get("/scene/live")
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Internal server error"
+
+
+class TestSceneLeaderboardEndpoint:
+    """GET /scene/leaderboard."""
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_peak_viewers_db")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_leaderboard_db")
+    def test_leaderboard_rank_and_nulls(self, mock_board, mock_peak, mock_get_cache):
+        """Rank is assigned in order; missing msgs_per_min / peak_viewers stay null."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_board.return_value = [
+            (5, "top", "Top", "http://a", 10, 42.5, 100000, 33.3, 900),
+            (8, "second", "Second", None, 4, 2.0, 5000, None, 120),
+        ]
+        mock_peak.return_value = [(5, 8000)]
+
+        response = TestClient(app).get("/scene/leaderboard?window=30")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["window_days"] == 30
+        assert data["entries"][0]["rank"] == 1
+        assert data["entries"][0]["creator_id"] == 5
+        assert data["entries"][0]["peak_viewers"] == 8000
+        assert data["entries"][0]["msgs_per_min"] == 33.3
+        assert data["entries"][1]["rank"] == 2
+        assert data["entries"][1]["msgs_per_min"] is None
+        assert data["entries"][1]["peak_viewers"] is None
+        mock_board.assert_called_once_with(30)
+        mock_peak.assert_called_once_with(30)
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_peak_viewers_db")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_leaderboard_db")
+    def test_leaderboard_default_window_7(self, mock_board, mock_peak, mock_get_cache):
+        """The default window is 7 days."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_board.return_value = []
+        mock_peak.return_value = []
+
+        response = TestClient(app).get("/scene/leaderboard")
+
+        assert response.status_code == 200
+        assert response.json() == {"window_days": 7, "entries": []}
+        mock_board.assert_called_once_with(7)
+
+    def test_leaderboard_invalid_window_422(self):
+        """A window other than 7 or 30 is rejected before the gateway."""
+        response = TestClient(app).get("/scene/leaderboard?window=5")
+        assert response.status_code == 422
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_leaderboard_db")
+    def test_leaderboard_cache_hit(self, mock_board, mock_get_cache):
+        """A cache HIT skips the gateway."""
+        mock_get_cache.return_value = _hit_cache({"window_days": 7, "entries": []})
+
+        response = TestClient(app).get("/scene/leaderboard")
+
+        assert response.status_code == 200
+        assert response.headers["X-Cache"] == "HIT"
+        mock_board.assert_not_called()
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_peak_viewers_db")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_leaderboard_db")
+    def test_leaderboard_server_error(self, mock_board, mock_peak, mock_get_cache):
+        """A gateway error surfaces as a 500."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_board.side_effect = Exception("boom")
+
+        response = TestClient(app).get("/scene/leaderboard")
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Internal server error"
+
+
+class TestSceneCopypastasEndpoint:
+    """GET /scene/copypastas."""
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_copypastas_db")
+    def test_copypastas_success_shape(self, mock_gw, mock_get_cache):
+        """Rows map to the Copypasta contract and total is echoed."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_gw.return_value = (
+            [
+                (7, "same message every time", 120, 45, 9, 4, "2024-01-01T20:00:00", "2024-02-01T20:00:00"),
+            ],
+            1,
+        )
+
+        response = TestClient(app).get("/scene/copypastas")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        item = data["items"][0]
+        assert item["message_text_id"] == 7
+        assert item["text"] == "same message every time"
+        assert item["usage_count"] == 120
+        assert item["creator_count"] == 4
+        # default: days=None, creator_id=None, sort=usage, limit=25, offset=0
+        mock_gw.assert_called_once_with(None, None, "usage", 25, 0)
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_copypastas_db")
+    def test_copypastas_empty_returns_200(self, mock_gw, mock_get_cache):
+        """An empty rollup table yields 200 with total 0 and no items."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_gw.return_value = ([], 0)
+
+        response = TestClient(app).get("/scene/copypastas")
+
+        assert response.status_code == 200
+        assert response.json() == {"total": 0, "items": []}
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_copypastas_db")
+    def test_copypastas_filters_forwarded(self, mock_gw, mock_get_cache):
+        """days / creator_id / sort / limit / offset are forwarded to the gateway."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_gw.return_value = ([], 0)
+
+        response = TestClient(app).get(
+            "/scene/copypastas?days=30&creator_id=5&sort=spread&limit=10&offset=20"
+        )
+
+        assert response.status_code == 200
+        mock_gw.assert_called_once_with(30, 5, "spread", 10, 20)
+
+    def test_copypastas_bad_sort_422(self):
+        """A sort outside the whitelist is rejected before the gateway."""
+        response = TestClient(app).get("/scene/copypastas?sort=bogus")
+        assert response.status_code == 422
+
+    def test_copypastas_limit_over_max_422(self):
+        """limit above 100 is rejected."""
+        response = TestClient(app).get("/scene/copypastas?limit=101")
+        assert response.status_code == 422
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_copypastas_db")
+    def test_copypastas_cache_hit(self, mock_gw, mock_get_cache):
+        """A cache HIT skips the gateway."""
+        mock_get_cache.return_value = _hit_cache({"total": 0, "items": []})
+
+        response = TestClient(app).get("/scene/copypastas")
+
+        assert response.status_code == 200
+        assert response.headers["X-Cache"] == "HIT"
+        mock_gw.assert_not_called()
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_scene_copypastas_db")
+    def test_copypastas_server_error(self, mock_gw, mock_get_cache):
+        """A gateway error surfaces as a 500."""
+        mock_get_cache.return_value = _miss_cache()
+        mock_gw.side_effect = Exception("boom")
+
+        response = TestClient(app).get("/scene/copypastas")
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Internal server error"

--- a/backend/tests/unit/database/test_analytics_expansion_gateways.py
+++ b/backend/tests/unit/database/test_analytics_expansion_gateways.py
@@ -330,6 +330,28 @@ class TestCreatorOverlapGateway:
         analytics_db.execute("SELECT count(*) FROM creator_overlap")
         assert analytics_db.fetchone()[0] == 2
 
+    def test_recompute_excludes_bots(self, overlap_seed, analytics_db):
+        """A chatter flagged is_bot is dropped from both audience and overlap counts."""
+        c1, c2 = overlap_seed["c1"], overlap_seed["c2"]
+        # chB is shared by c1 (2 streams) and c2 (1 stream); mark it a bot.
+        analytics_db.execute(
+            "UPDATE chatter SET is_bot = TRUE, bot_reason = 'known_bot' WHERE nick = 'chB'"
+        )
+        analytics_db.connection.commit()
+
+        assert recompute_creator_overlap_db(True) is True
+
+        analytics_db.execute("SELECT creator_id, chatters FROM creator_audience ORDER BY creator_id")
+        aud = {r[0]: r[1] for r in analytics_db.fetchall()}
+        assert aud[c1] == 2  # chA, chC (chB excluded)
+        assert aud[c2] == 1  # chA only (chB excluded)
+
+        analytics_db.execute(
+            "SELECT shared_chatters FROM creator_overlap WHERE creator_a = %s AND creator_b = %s",
+            (min(c1, c2), max(c1, c2)),
+        )
+        assert analytics_db.fetchone()[0] == 1  # only chA shared now
+
     def test_select_overlap_top_n(self, overlap_seed, analytics_db):
         recompute_creator_overlap_db(True)
         c1, c2 = overlap_seed["c1"], overlap_seed["c2"]

--- a/backend/tests/unit/database/test_scene_copypasta_gateway.py
+++ b/backend/tests/unit/database/test_scene_copypasta_gateway.py
@@ -1,0 +1,188 @@
+"""Gateway tests for the scene copypasta rollup (migration 0009).
+
+DB-backed (real Postgres via the session fixtures, same as the other gateway tests). The base
+``db_cursor`` fixture only provisions the baseline tables, so ``copypasta_db`` self-provisions
+``stream_copypasta_stats`` with CREATE ... IF NOT EXISTS and truncates it per test. Runs in CI
+(and any throwaway Postgres), never on the source-less dev host.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from stream_sniper.database.stream_copypasta_stats_table_gateway import (
+    replace_stream_copypasta_stats_db,
+    select_scene_copypastas_db,
+    select_stream_copypasta_source_db,
+)
+from tests.conftest import create_test_chatter, create_test_creator, create_test_message_text, create_test_stream
+
+_COPYPASTA_DDL = """
+SET search_path TO stream_sniper;
+
+CREATE TABLE IF NOT EXISTS stream_copypasta_stats (
+    stream_id       int    NOT NULL,
+    message_text_id bigint NOT NULL,
+    usage_count     int    NOT NULL,
+    chatter_count   int    NOT NULL,
+    first_seen      timestamp NULL,
+    CONSTRAINT stream_copypasta_stats_pk PRIMARY KEY (stream_id, message_text_id)
+);
+"""
+
+
+@pytest.fixture
+def copypasta_db(db_cursor):
+    db_cursor.execute(_COPYPASTA_DDL)
+    db_cursor.execute("TRUNCATE stream_copypasta_stats RESTART IDENTITY CASCADE")
+    db_cursor.connection.commit()
+    return db_cursor
+
+
+def _msg(cursor, stream_id, chatter_id, text_id, when):
+    cursor.execute(
+        "INSERT INTO message (chatter_id, stream_id, message_text_id, time) VALUES (%s, %s, %s, %s)",
+        (chatter_id, stream_id, text_id, when),
+    )
+
+
+class TestStreamCopypastaSource:
+    """select_stream_copypasta_source_db + replace_stream_copypasta_stats_db."""
+
+    def test_source_applies_junk_and_bot_filters(self, copypasta_db):
+        creator = create_test_creator(
+            copypasta_db,
+            {"nick": "c", "display_name": "C", "profile_image_url": "u", "twitch_id": "s1"},
+        )
+        stream = create_test_stream(copypasta_db, {"twitch_id": "st1", "title": "S", "start": datetime(2024, 1, 1)}, creator)
+        u1 = create_test_chatter(copypasta_db, "u1")
+        u2 = create_test_chatter(copypasta_db, "u2")
+        bot = create_test_chatter(copypasta_db, "botz")
+        copypasta_db.execute("UPDATE chatter SET is_bot = TRUE WHERE id = %s", (bot,))
+
+        # Qualifies via 2 distinct chatters.
+        t_pasta = create_test_message_text(copypasta_db, "this is a real copypasta yes")
+        # Qualifies via >= 3 uses by one chatter.
+        t_spam = create_test_message_text(copypasta_db, "kappa kappa kappa kappa kap")
+        # Too short (< 20 chars) -> excluded.
+        t_short = create_test_message_text(copypasta_db, "short one")
+        # Command (starts '!') -> excluded even though long + repeated.
+        t_cmd = create_test_message_text(copypasta_db, "!drop this longwinded command")
+        # Bot-only -> excluded.
+        t_bot = create_test_message_text(copypasta_db, "beep boop bot pasta here now")
+
+        base = datetime(2024, 1, 1, 20, 0, 0)
+        _msg(copypasta_db, stream, u1, t_pasta, base)
+        _msg(copypasta_db, stream, u2, t_pasta, base + timedelta(minutes=1))
+        _msg(copypasta_db, stream, u1, t_spam, base)
+        _msg(copypasta_db, stream, u1, t_spam, base + timedelta(seconds=10))
+        _msg(copypasta_db, stream, u1, t_spam, base + timedelta(seconds=20))
+        _msg(copypasta_db, stream, u1, t_short, base)
+        _msg(copypasta_db, stream, u2, t_short, base)
+        _msg(copypasta_db, stream, u1, t_cmd, base)
+        _msg(copypasta_db, stream, u2, t_cmd, base)
+        _msg(copypasta_db, stream, bot, t_bot, base)
+        _msg(copypasta_db, stream, bot, t_bot, base + timedelta(seconds=5))
+        _msg(copypasta_db, stream, bot, t_bot, base + timedelta(seconds=9))
+        copypasta_db.connection.commit()
+
+        rows = select_stream_copypasta_source_db(stream)
+        by_text = {r[0]: (r[1], r[2]) for r in rows}  # message_text_id -> (usage, chatters)
+
+        assert set(by_text) == {t_pasta, t_spam}
+        assert by_text[t_pasta] == (2, 2)
+        assert by_text[t_spam] == (3, 1)
+
+    def test_replace_round_trip(self, copypasta_db):
+        creator = create_test_creator(
+            copypasta_db,
+            {"nick": "c", "display_name": "C", "profile_image_url": "u", "twitch_id": "s1"},
+        )
+        stream = create_test_stream(copypasta_db, {"twitch_id": "st1", "title": "S", "start": datetime(2024, 1, 1)}, creator)
+        t1 = create_test_message_text(copypasta_db, "pasta one text goes here now")
+        t2 = create_test_message_text(copypasta_db, "pasta two text goes here now")
+
+        replace_stream_copypasta_stats_db(
+            stream,
+            [(t1, 5, 3, datetime(2024, 1, 1, 20, 0, 0)), (t2, 9, 4, datetime(2024, 1, 1, 21, 0, 0))],
+        )
+        # Replacing again fully overwrites (idempotent DELETE + insert).
+        replace_stream_copypasta_stats_db(stream, [(t1, 7, 2, datetime(2024, 1, 1, 20, 0, 0))])
+
+        copypasta_db.execute(
+            "SELECT message_text_id, usage_count, chatter_count FROM stream_copypasta_stats "
+            "WHERE stream_id = %s ORDER BY message_text_id",
+            (stream,),
+        )
+        rows = copypasta_db.fetchall()
+        assert rows == [(t1, 7, 2)]
+
+
+class TestSceneCopypastasAggregate:
+    """select_scene_copypastas_db aggregates the small rollup table scene-wide."""
+
+    @pytest.fixture
+    def seeded(self, copypasta_db):
+        now = datetime.now()
+        c1 = create_test_creator(
+            copypasta_db,
+            {"nick": "c1", "display_name": "C1", "profile_image_url": "u", "twitch_id": "1"},
+        )
+        c2 = create_test_creator(
+            copypasta_db,
+            {"nick": "c2", "display_name": "C2", "profile_image_url": "u", "twitch_id": "2"},
+        )
+        s_recent_c1 = create_test_stream(
+            copypasta_db, {"twitch_id": "r1", "title": "R1", "start": now - timedelta(days=1)}, c1
+        )
+        s_recent_c2 = create_test_stream(
+            copypasta_db, {"twitch_id": "r2", "title": "R2", "start": now - timedelta(days=2)}, c2
+        )
+        s_old_c1 = create_test_stream(
+            copypasta_db, {"twitch_id": "o1", "title": "O1", "start": now - timedelta(days=40)}, c1
+        )
+        t_wide = create_test_message_text(copypasta_db, "spreads across both channels ok")
+        t_narrow = create_test_message_text(copypasta_db, "only in one single channel ok")
+
+        # t_wide spreads across both channels; t_narrow lives only in c1's recent stream.
+        replace_stream_copypasta_stats_db(
+            s_recent_c1,
+            [(t_wide, 10, 3, now - timedelta(days=1)), (t_narrow, 40, 6, now - timedelta(days=1))],
+        )
+        replace_stream_copypasta_stats_db(s_recent_c2, [(t_wide, 5, 2, now - timedelta(days=2))])
+        replace_stream_copypasta_stats_db(s_old_c1, [(t_wide, 100, 9, now - timedelta(days=40))])
+        copypasta_db.connection.commit()
+        return {"c1": c1, "c2": c2, "t_wide": t_wide, "t_narrow": t_narrow}
+
+    def test_all_time_usage_sort(self, seeded, copypasta_db):
+        rows, total = select_scene_copypastas_db(None, None, "usage", 25, 0)
+        assert total == 2
+        by_text = {r[0]: r for r in rows}
+        # t_wide total usage = 10 + 5 + 100 = 115 across 3 streams / 2 creators.
+        wide = by_text[seeded["t_wide"]]
+        assert wide[2] == 115  # usage_count
+        assert wide[4] == 3  # stream_count
+        assert wide[5] == 2  # creator_count
+        # usage sort: t_wide (115) before t_narrow (40).
+        assert rows[0][0] == seeded["t_wide"]
+
+    def test_window_excludes_old_streams(self, seeded, copypasta_db):
+        rows, total = select_scene_copypastas_db(7, None, "usage", 25, 0)
+        by_text = {r[0]: r for r in rows}
+        # 7-day window drops the 40-day-old stream: t_wide usage = 10 + 5 = 15, 2 streams, 2 creators.
+        wide = by_text[seeded["t_wide"]]
+        assert wide[2] == 15
+        assert wide[4] == 2
+        assert wide[5] == 2
+
+    def test_creator_filter(self, seeded, copypasta_db):
+        rows, total = select_scene_copypastas_db(None, seeded["c2"], "usage", 25, 0)
+        # Only c2's recent stream has t_wide.
+        assert total == 1
+        assert rows[0][0] == seeded["t_wide"]
+        assert rows[0][2] == 5  # only c2's usage
+
+    def test_spread_sort_prefers_wider_reach(self, seeded, copypasta_db):
+        rows, _ = select_scene_copypastas_db(None, None, "spread", 25, 0)
+        # t_wide (2 creators) ranks above t_narrow (1 creator).
+        assert rows[0][0] == seeded["t_wide"]

--- a/frontend/app/(app)/copypasta/page.tsx
+++ b/frontend/app/(app)/copypasta/page.tsx
@@ -1,0 +1,6 @@
+'use client'
+import Copypasta from '@/views/Copypasta'
+
+export default function CopypastaPage() {
+  return <Copypasta />
+}

--- a/frontend/app/(app)/live/page.tsx
+++ b/frontend/app/(app)/live/page.tsx
@@ -1,0 +1,6 @@
+'use client'
+import LiveNow from '@/views/LiveNow'
+
+export default function LivePage() {
+  return <LiveNow />
+}

--- a/frontend/app/(app)/scene/page.tsx
+++ b/frontend/app/(app)/scene/page.tsx
@@ -1,0 +1,6 @@
+'use client'
+import Scene from '@/views/Scene'
+
+export default function ScenePage() {
+  return <Scene />
+}

--- a/frontend/components/layout/Sidebar.jsx
+++ b/frontend/components/layout/Sidebar.jsx
@@ -15,6 +15,11 @@ const navigation = [
         icon: 'bi bi-collection-play',
     },
     {
+        title: 'Live',
+        href: '/live',
+        icon: 'bi bi-broadcast',
+    },
+    {
         title: 'Chatter explorer',
         href: '/chatter',
         icon: 'bi bi-fingerprint',
@@ -28,6 +33,16 @@ const navigation = [
         title: 'Community',
         href: '/community',
         icon: 'bi bi-diagram-3',
+    },
+    {
+        title: 'Scene',
+        href: '/scene',
+        icon: 'bi bi-trophy',
+    },
+    {
+        title: 'Copypasta',
+        href: '/copypasta',
+        icon: 'bi bi-chat-quote',
     },
     {
         title: 'Highlights',

--- a/frontend/components/scene/CopypastaCard.jsx
+++ b/frontend/components/scene/CopypastaCard.jsx
@@ -1,0 +1,74 @@
+'use client'
+import { useState } from 'react'
+
+/** Naive UTC "YYYY-MM-DDTHH:MM:SS" -> "YYYY-MM-DD" date slice (no TZ drift). */
+const dateOnly = ts => (typeof ts === 'string' && ts.length >= 10 ? ts.slice(0, 10) : null)
+
+// Texts longer than this are clamped with an expand toggle.
+const CLAMP_CHARS = 240
+
+/**
+ * One copypasta row: the verbatim message text in a monospace block plus spread
+ * chips (usage, channels, streams, first seen). Long pastas clamp to a preview
+ * with an expand-on-click toggle. Nullable dates are omitted, never faked.
+ *
+ * @param {object} props
+ * @param {object} props.pasta mapped copypasta item from useSceneCopypastas
+ */
+const CopypastaCard = ({ pasta }) => {
+    const {
+        text,
+        usageCount,
+        streamCount,
+        creatorCount,
+        firstSeen,
+    } = pasta
+
+    const [
+        expanded,
+        setExpanded,
+    ] = useState(false)
+
+    const isLong = typeof text === 'string' && text.length > CLAMP_CHARS
+    const firstSeenDate = dateOnly(firstSeen)
+
+    return (
+        <article className="pasta-card">
+            <div className={`pasta-text mono${isLong && !expanded ? ' is-clamped' : ''}`}>
+                {text}
+            </div>
+
+            {isLong ? (
+                <button
+                    type="button"
+                    className="pasta-expand"
+                    aria-expanded={expanded}
+                    onClick={() => setExpanded(prev => !prev)}>
+                    {expanded ? 'Show less' : 'Show more'}
+                </button>
+            ) : null}
+
+            <div className="pasta-chips">
+                <span className="pasta-chip mono">
+                    {(usageCount ?? 0).toLocaleString()}
+                    <span className="pasta-chip-unit"> uses</span>
+                </span>
+                <span className="pasta-chip mono">
+                    {(creatorCount ?? 0).toLocaleString()}
+                    <span className="pasta-chip-unit"> channels</span>
+                </span>
+                <span className="pasta-chip mono">
+                    {(streamCount ?? 0).toLocaleString()}
+                    <span className="pasta-chip-unit"> streams</span>
+                </span>
+                {firstSeenDate ? (
+                    <span className="pasta-chip pasta-chip-muted mono">
+                        first seen {firstSeenDate}
+                    </span>
+                ) : null}
+            </div>
+        </article>
+    )
+}
+
+export default CopypastaCard

--- a/frontend/hooks/useApiQuery.js
+++ b/frontend/hooks/useApiQuery.js
@@ -56,6 +56,13 @@ export {
 } from './useMomentsQueries'
 
 export {
+    sceneKeys,
+    useSceneCopypastas,
+    useSceneLeaderboard,
+    useSceneLive,
+} from './useSceneQueries'
+
+export {
     useChatters,
     useCreators,
     useChatterId,

--- a/frontend/hooks/useChattersQuery.js
+++ b/frontend/hooks/useChattersQuery.js
@@ -86,16 +86,31 @@ export const useCreators = (options = {}) => useQuery({
 
 /**
  * Custom hook for fetching chatter ID by nickname using TanStack Query
+ *
+ * The backend returns a positional row with is_bot appended as the trailing
+ * element ([id, is_bot]); null is preserved (`?? null` — unknown, not false)
+ * per the nullable = unknown contract.
+ *
  * @param {string} nick - The chatter nickname
  * @param {boolean} enabled - Whether to execute the request (default: false)
  * @param {object} options - Additional query options
- * @returns {object} useQuery result with data, isLoading, error, etc.
+ * @returns {object} useQuery result; data = {chatterId, isBot}
  */
 export const useChatterId = (nick, enabled = false, options = {}) => useQuery({
     queryKey: chattersKeys.chatterId(nick),
     queryFn: async () => {
         const response = await retrieveChatterId(nick)
-        return response.data
+        const data = response.data
+        if (Array.isArray(data)) {
+            return {
+                chatterId: data[0] ?? null,
+                isBot: data[1] ?? null,
+            }
+        }
+        return {
+            chatterId: data ?? null,
+            isBot: null,
+        }
     },
     enabled: Boolean(nick) && enabled, // Only enabled when nick is provided and enabled is true
     ...options,

--- a/frontend/hooks/useSceneQueries.js
+++ b/frontend/hooks/useSceneQueries.js
@@ -1,0 +1,155 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+    retrieveSceneCopypastas,
+    retrieveSceneLeaderboard,
+    retrieveSceneLive,
+} from '@/lib/api'
+
+/**
+ * Query key factory for scene-wide queries (live now, leaderboard, copypastas)
+ */
+export const sceneKeys = {
+    all: [
+        'scene',
+    ],
+    live: () => [
+        ...sceneKeys.all,
+        'live',
+    ],
+    leaderboard: windowDays => [
+        ...sceneKeys.all,
+        'leaderboard',
+        { windowDays },
+    ],
+    copypastas: filters => [
+        ...sceneKeys.all,
+        'copypastas',
+        filters,
+    ],
+}
+
+/**
+ * Custom hook for currently-live tracked streamers, mapped to camelCase.
+ *
+ * Liveness is inferred from viewer-sample freshness (samples only exist while
+ * live), so `lastSampleAt` is surfaced for tracker-health: a stale value means
+ * the tracker is down, not that nobody is live. Polls every 30s by default.
+ *
+ * Nullable = unknown contract: title/sessionStartedAt/profileImageUrl may be
+ * null — preserved via `?? null`, never defaulted.
+ *
+ * @param {object} options - Additional query options
+ * @returns {object} useQuery result; data = {live: [{creatorId, nick, displayName,
+ *   profileImageUrl, viewerCount, title, sessionStartedAt, sampledAt}],
+ *   liveCount, lastSampleAt}
+ */
+export const useSceneLive = (options = {}) => useQuery({
+    queryKey: sceneKeys.live(),
+    queryFn: async () => {
+        const response = await retrieveSceneLive()
+        const data = response.data || {
+        }
+        return {
+            live: (data.live || []).map(s => ({
+                creatorId: s.creator_id,
+                nick: s.nick,
+                displayName: s.display_name ?? null,
+                profileImageUrl: s.profile_image_url ?? null,
+                viewerCount: s.viewer_count ?? null,
+                title: s.title ?? null,
+                sessionStartedAt: s.session_started_at ?? null,
+                sampledAt: s.sampled_at ?? null,
+            })),
+            liveCount: data.live_count ?? 0,
+            lastSampleAt: data.last_sample_at ?? null,
+        }
+    },
+    refetchInterval: 30000,
+    ...options,
+})
+
+/**
+ * Custom hook for the scene-wide creator leaderboard, mapped to camelCase.
+ *
+ * Nullable = unknown contract: hoursStreamed is null when no closed streams,
+ * msgsPerMin is null when no rolled-up metrics exist in the window, and
+ * peakViewers is null when the creator has no viewer samples — all preserved
+ * via `?? null` and rendered as '--' (never 0).
+ *
+ * @param {7|30} windowDays - Leaderboard window in days
+ * @param {object} options - Additional query options
+ * @returns {object} useQuery result; data = {windowDays, computedAt,
+ *   entries: [{rank, creatorId, nick, displayName, profileImageUrl, streams,
+ *   hoursStreamed, totalMessages, msgsPerMin, chatterAppearances, peakViewers}]}
+ */
+export const useSceneLeaderboard = (windowDays, options = {}) => useQuery({
+    queryKey: sceneKeys.leaderboard(windowDays),
+    queryFn: async () => {
+        const response = await retrieveSceneLeaderboard(windowDays)
+        const data = response.data || {
+        }
+        return {
+            windowDays: data.window_days,
+            computedAt: data.computed_at ?? null,
+            entries: (data.entries || []).map(e => ({
+                rank: e.rank,
+                creatorId: e.creator_id,
+                nick: e.nick,
+                displayName: e.display_name ?? null,
+                profileImageUrl: e.profile_image_url ?? null,
+                streams: e.streams,
+                hoursStreamed: e.hours_streamed ?? null,
+                totalMessages: e.total_messages,
+                msgsPerMin: e.msgs_per_min ?? null,
+                chatterAppearances: e.chatter_appearances,
+                peakViewers: e.peak_viewers ?? null,
+            })),
+        }
+    },
+    enabled: Boolean(windowDays),
+    ...options,
+})
+
+/**
+ * Custom hook for the scene-wide copypasta library, mapped to camelCase.
+ * Mirrors useMomentsQueue: filterable, offset-paginated (rows, total).
+ *
+ * @param {object} filters
+ * @param {number} [filters.days] - Window in days (omitted = all-time)
+ * @param {number} [filters.creatorId] - Restrict to one creator
+ * @param {('usage'|'spread'|'recent')} [filters.sort] - Sort mode
+ * @param {number} [filters.limit] - Page size
+ * @param {number} [filters.offset] - Row offset
+ * @param {object} options - Additional query options
+ * @returns {object} useQuery result; data = {total, items: [{messageTextId,
+ *   text, usageCount, chatterAppearances, streamCount, creatorCount,
+ *   firstSeen, lastStreamStart}]}
+ */
+export const useSceneCopypastas = ({
+    days, creatorId, sort, limit, offset,
+} = {}, options = {}) => useQuery({
+    queryKey: sceneKeys.copypastas({
+        days, creatorId, sort, limit, offset,
+    }),
+    queryFn: async () => {
+        const response = await retrieveSceneCopypastas({
+            days, creatorId, sort, limit, offset,
+        })
+        const data = response.data || {
+        }
+        return {
+            total: data.total ?? 0,
+            items: (data.items || []).map(p => ({
+                messageTextId: p.message_text_id,
+                text: p.text,
+                usageCount: p.usage_count,
+                chatterAppearances: p.chatter_appearances,
+                streamCount: p.stream_count,
+                creatorCount: p.creator_count,
+                firstSeen: p.first_seen ?? null,
+                lastStreamStart: p.last_stream_start ?? null,
+            })),
+        }
+    },
+    ...options,
+})

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -111,6 +111,15 @@ export const downloadStreamExport = (streamId: number, format: 'ndjson' | 'csv' 
 export const downloadStreamInsightCsv = (streamId: number, kind: 'emotes' | 'phrases' | 'mentions') =>
   api.get(`/stream/${streamId}/${kind}?format=csv`, { responseType: 'blob', timeout: 0 })
 
+// W9 — scene expansion (live now, leaderboard, copypasta library)
+export const retrieveSceneLive = () => api.get('/scene/live')
+export const retrieveSceneLeaderboard = (windowDays: 7 | 30 = 7) => api.get(`/scene/leaderboard?${qs({ window: windowDays })}`)
+export const retrieveSceneCopypastas = (p: {
+  days?: number, creatorId?: number, sort?: 'usage' | 'spread' | 'recent', limit?: number, offset?: number,
+} = {}) => api.get(`/scene/copypastas?${qs({
+  days: p.days, creator_id: p.creatorId, sort: p.sort, limit: p.limit, offset: p.offset,
+})}`)
+
 export const retrieveStreamComprehensive = (streamId: string | number) => api.get(`/stream/${streamId}`)
 export const retrieveAllCreators = () => api.get('/creators')
 export const retrieveChatterStreamActivity = (chatterId: string | number) => api.get(`/chatter/${chatterId}/stream-activity`)

--- a/frontend/styles/_scene.scss
+++ b/frontend/styles/_scene.scss
@@ -1,0 +1,230 @@
+// Scene expansion: live-now card grid, scene leaderboard table trimmings, and
+// the copypasta library card list. Night-ops tokens throughout.
+
+/* ---------- Live now ---------- */
+.live-stale-note {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-bottom: 0.85rem;
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+}
+
+.live-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1rem;
+}
+
+.live-card {
+    height: 100%;
+
+    .card-body {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+}
+
+.live-card-head {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.live-avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 1px solid $hairline;
+    flex-shrink: 0;
+}
+
+.live-avatar-empty {
+    display: inline-block;
+    background: $bg-raised;
+}
+
+.live-identity {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    min-width: 0;
+}
+
+.live-name {
+    font-weight: 600;
+    color: $gray-100;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.live-chip {
+    align-self: flex-start;
+}
+
+.live-metrics {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.live-viewers {
+    font-size: 1.05rem;
+    color: $phosphor;
+
+    .live-viewers-unit {
+        font-size: 0.66rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: $gray-500;
+    }
+}
+
+.live-uptime {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.72rem;
+    color: $gray-300;
+}
+
+.live-title {
+    margin: 0;
+    font-size: 0.82rem;
+    color: $gray-200;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+/* ---------- Scene leaderboard ---------- */
+.scene-toolbar {
+    flex-wrap: wrap;
+    row-gap: 0.6rem;
+}
+
+.scene-streamer {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    min-width: 0;
+}
+
+.scene-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 1px solid $hairline;
+    flex-shrink: 0;
+}
+
+.scene-avatar-empty {
+    display: inline-block;
+    background: $bg-raised;
+}
+
+.scene-streamer-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ---------- Copypasta library ---------- */
+.pasta-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    transition: opacity 0.2s ease;
+
+    // Hold the previous page at reduced opacity while refetching (keepPreviousData).
+    &.is-refetching {
+        opacity: 0.55;
+    }
+}
+
+.pasta-card {
+    background: $bg-surface;
+    border: 1px solid $hairline;
+    border-radius: 6px;
+    padding: 1rem 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.pasta-text {
+    margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: $gray-100;
+    white-space: pre-wrap;
+    word-break: break-word;
+
+    &.is-clamped {
+        display: -webkit-box;
+        -webkit-line-clamp: 4;
+        line-clamp: 4;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+}
+
+.pasta-expand {
+    align-self: flex-start;
+    background: none;
+    border: none;
+    padding: 0;
+    font-family: $font-family-monospace;
+    font-size: 0.66rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: $phosphor;
+    cursor: pointer;
+
+    &:hover {
+        color: $teal;
+    }
+}
+
+.pasta-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.pasta-chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.3rem;
+    padding: 0.2rem 0.55rem;
+    border: 1px solid $hairline;
+    border-radius: 4px;
+    background: $bg-raised;
+    font-size: 0.72rem;
+    color: $gray-100;
+
+    .pasta-chip-unit {
+        font-size: 0.6rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: $gray-500;
+    }
+
+    &.pasta-chip-muted {
+        color: $gray-300;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pasta-list {
+        transition: none;
+    }
+}

--- a/frontend/styles/style.scss
+++ b/frontend/styles/style.scss
@@ -15,3 +15,4 @@
 @import "moments-queue";
 @import "stream-insights";
 @import "stream-report";
+@import "scene";

--- a/frontend/views/ChatterExplorer.jsx
+++ b/frontend/views/ChatterExplorer.jsx
@@ -41,9 +41,11 @@ const ChatterExplorer = ({ initialView = 'footprint' }) => {
 
     /**
      * Prefix-search chatter nicks for the autocomplete dropdown.
-     * The backend returns [[id, nick], ...]; map to react-select options.
+     * The backend returns [[id, nick, is_bot], ...]; map to react-select options,
+     * preserving is_bot (null = unclassified, unknown — never coerced to false)
+     * so a selected bot can be badged.
      * @param {string} query
-     * @returns {Promise<Array<{value: number, label: string}>>}
+     * @returns {Promise<Array<{value: number, label: string, isBot: boolean|null}>>}
      */
     const loadChatterOptions = useCallback(async query => {
         const trimmed = query.trim()
@@ -55,9 +57,11 @@ const ChatterExplorer = ({ initialView = 'footprint' }) => {
             return (data || []).map(([
                 id,
                 nick,
+                isBot,
             ]) => ({
                 value: id,
                 label: nick,
+                isBot: isBot ?? null,
             }))
         } catch {
             return []
@@ -109,6 +113,13 @@ const ChatterExplorer = ({ initialView = 'footprint' }) => {
                         aria-label="Chatter nickname"
                     />
                 </div>
+                {selectedChatter?.isBot === true && (
+                    <span
+                        className="status-chip is-warn"
+                        aria-label="This chatter is flagged as a bot">
+                        BOT
+                    </span>
+                )}
             </div>
 
             <div

--- a/frontend/views/Copypasta.jsx
+++ b/frontend/views/Copypasta.jsx
@@ -1,0 +1,215 @@
+'use client'
+import {
+    useCallback,
+    useMemo,
+    useState,
+} from 'react'
+import Select from 'react-select'
+import { keepPreviousData } from '@tanstack/react-query'
+import {
+    useCreators,
+    useSceneCopypastas,
+} from '@/hooks/useApiQuery'
+import CopypastaCard from '@/components/scene/CopypastaCard'
+import PaginationComponent from '@/components/streams/PaginationComponent'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorAlert from '@/components/ErrorAlert'
+
+// Copypasta pages are their own size (independent of the stream-grid page size).
+const LIMIT = 25
+
+const SORT_OPTIONS = [
+    {
+        value: 'usage',
+        label: 'Most used',
+    },
+    {
+        value: 'spread',
+        label: 'Widest spread',
+    },
+    {
+        value: 'recent',
+        label: 'Recent',
+    },
+]
+
+/**
+ * Copypasta library: the most-repeated chat lines across all captured streams,
+ * filterable by creator and sortable by usage / spread / recency. Offset
+ * paginated against the total. On refetch the previous page is held at reduced
+ * opacity (keepPreviousData) rather than flashing a skeleton.
+ */
+const Copypasta = () => {
+    const [
+        selectedCreator,
+        setSelectedCreator,
+    ] = useState(null)
+    const [
+        selectedSort,
+        setSelectedSort,
+    ] = useState(SORT_OPTIONS[0])
+    const [
+        page,
+        setPage,
+    ] = useState(0)
+
+    const creatorId = selectedCreator?.value || undefined
+    const sort = selectedSort?.value || 'usage'
+
+    const {
+        data: creatorsData,
+        error: creatorsError,
+        refetch: refetchCreators,
+    } = useCreators()
+
+    const creators = useMemo(() => creatorsData?.map(creator => ({
+        label: creator[1],
+        value: creator[0],
+    })) || [
+    ], [
+        creatorsData,
+    ])
+
+    const {
+        data,
+        isLoading,
+        isPlaceholderData,
+        error,
+        refetch,
+    } = useSceneCopypastas(
+        {
+            creatorId,
+            sort,
+            limit: LIMIT,
+            offset: page * LIMIT,
+        },
+        { placeholderData: keepPreviousData },
+    )
+
+    const handleCreatorChange = useCallback(option => {
+        setSelectedCreator(option)
+        setPage(0)
+    }, [
+    ])
+
+    const handleSortChange = useCallback(option => {
+        setSelectedSort(option || SORT_OPTIONS[0])
+        setPage(0)
+    }, [
+    ])
+
+    const items = data?.items || [
+    ]
+    const total = data?.total || 0
+    const pagesCount = Math.ceil(total / LIMIT)
+
+    return (
+        <>
+            <div className="page-head">
+                <div>
+                    <h1 className="page-title">Copypasta</h1>
+                    <p className="page-sub">The scene&apos;s most-repeated chat lines</p>
+                </div>
+            </div>
+
+            {creatorsError && (
+                <ErrorAlert
+                    error={creatorsError}
+                    title="Failed to load creators"
+                    onRetry={refetchCreators}
+                    showDetails={process.env.NODE_ENV === 'development'}
+                />
+            )}
+
+            <div
+                className="toolbar copypasta-toolbar"
+                role="search"
+                aria-label="Copypasta filters">
+                <div className="toolbar-field copypasta-creator-field">
+                    <label
+                        htmlFor="copypasta-creator-select"
+                        className="visually-hidden">
+                        Filter by creator
+                    </label>
+                    <Select
+                        classNamePrefix="rs"
+                        instanceId="copypasta-creator-select"
+                        inputId="copypasta-creator-select"
+                        options={creators}
+                        value={selectedCreator}
+                        onChange={handleCreatorChange}
+                        placeholder="All creators..."
+                        isClearable
+                        aria-label="Filter by creator"
+                    />
+                </div>
+                <div className="toolbar-field copypasta-sort-field">
+                    <label
+                        htmlFor="copypasta-sort-select"
+                        className="visually-hidden">
+                        Sort order
+                    </label>
+                    <Select
+                        classNamePrefix="rs"
+                        instanceId="copypasta-sort-select"
+                        inputId="copypasta-sort-select"
+                        options={SORT_OPTIONS}
+                        value={selectedSort}
+                        onChange={handleSortChange}
+                        isSearchable={false}
+                        aria-label="Sort order"
+                    />
+                </div>
+            </div>
+
+            {error ? (
+                <ErrorAlert
+                    error={error}
+                    title="Failed to load copypasta library"
+                    onRetry={refetch}
+                    showDetails={process.env.NODE_ENV === 'development'}
+                />
+            ) : isLoading ? (
+                <LoadingSpinner
+                    text="Loading copypasta..."
+                    centered
+                />
+            ) : items.length === 0 ? (
+                <div className="empty-state">
+                    <span
+                        className="empty-scope"
+                        aria-hidden="true" />
+                    <p className="empty-title">No copypasta yet</p>
+                    <p className="empty-hint">
+                        Nothing has been rolled up for this filter yet. Run
+                        {' '}
+                        <span className="mono">stream-sniper-rollup --all --force</span>
+                        {' '}
+                        to populate the library.
+                    </p>
+                </div>
+            ) : (
+                <>
+                    <div
+                        className={`pasta-list${isPlaceholderData ? ' is-refetching' : ''}`}
+                        aria-busy={isPlaceholderData}>
+                        {items.map(pasta => (
+                            <CopypastaCard
+                                key={pasta.messageTextId}
+                                pasta={pasta}
+                            />
+                        ))}
+                    </div>
+
+                    <PaginationComponent
+                        pagesCount={pagesCount}
+                        offset={page}
+                        updateOffset={setPage}
+                    />
+                </>
+            )}
+        </>
+    )
+}
+
+export default Copypasta

--- a/frontend/views/LiveNow.jsx
+++ b/frontend/views/LiveNow.jsx
@@ -1,0 +1,221 @@
+'use client'
+import { useMemo } from 'react'
+import { Card } from 'react-bootstrap'
+import { useSceneLive } from '@/hooks/useApiQuery'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorAlert from '@/components/ErrorAlert'
+
+// Freshness horizon for the "tracker stale" warning. Samples land every ~5 min;
+// if the newest sample overall is older than this, the tracker is likely down,
+// which reads as "nobody live" — surface that instead of a false empty state.
+const STALE_MS = 15 * 60 * 1000
+
+/**
+ * Parse a naive UTC timestamp ("YYYY-MM-DDTHH:MM:SS", no zone) as UTC by
+ * appending 'Z' — the backend formats AT TIME ZONE 'UTC' without an offset.
+ * @param {string|null} ts
+ * @returns {number|null} epoch ms, or null when unparseable
+ */
+const utcEpoch = ts => {
+    if (typeof ts !== 'string' || ts.length < 16) {
+        return null
+    }
+    const ms = new Date(`${ts}Z`).getTime()
+    return Number.isNaN(ms) ? null : ms
+}
+
+/**
+ * Human uptime "2h 14m" / "43m" from a live session start, or null when unknown
+ * or the clock is skewed (negative elapsed).
+ * @param {string|null} startedAt
+ * @returns {string|null}
+ */
+const uptimeLabel = startedAt => {
+    const start = utcEpoch(startedAt)
+    if (start === null) {
+        return null
+    }
+    const totalMin = Math.floor((Date.now() - start) / 60000)
+    if (totalMin < 0) {
+        return null
+    }
+    const hours = Math.floor(totalMin / 60)
+    const minutes = totalMin % 60
+    return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`
+}
+
+/**
+ * One live streamer card: avatar, identity, LIVE chip, viewer count, title,
+ * uptime. Nullable fields (title/profileImageUrl/sessionStartedAt) are hidden
+ * rather than faked per the nullable = unknown contract.
+ *
+ * @param {object} props
+ * @param {object} props.streamer mapped live entry from useSceneLive
+ */
+const LiveCard = ({ streamer }) => {
+    const {
+        nick,
+        displayName,
+        profileImageUrl,
+        viewerCount,
+        title,
+        sessionStartedAt,
+    } = streamer
+
+    const name = displayName || nick
+    const uptime = uptimeLabel(sessionStartedAt)
+
+    return (
+        <Card className="live-card">
+            <Card.Body>
+                <div className="live-card-head">
+                    {profileImageUrl
+                        ? (
+                            <img
+                                className="live-avatar"
+                                src={profileImageUrl}
+                                alt=""
+                                width={48}
+                                height={48}
+                                loading="lazy"
+                            />
+                        )
+                        : (
+                            <span
+                                className="live-avatar live-avatar-empty"
+                                aria-hidden="true" />
+                        )}
+                    <div className="live-identity">
+                        <span className="live-name">{name}</span>
+                        <span
+                            className="status-chip is-ok live-chip"
+                            aria-label="Live now">
+                            LIVE
+                        </span>
+                    </div>
+                </div>
+
+                <div className="live-metrics">
+                    <span className="live-viewers mono">
+                        {viewerCount == null ? '--' : viewerCount.toLocaleString()}
+                        <span className="live-viewers-unit"> viewers</span>
+                    </span>
+                    {uptime ? (
+                        <span className="live-uptime mono">
+                            <i
+                                className="bi bi-clock"
+                                aria-hidden="true" />
+                            {uptime}
+                        </span>
+                    ) : null}
+                </div>
+
+                {title ? (
+                    <p
+                        className="live-title"
+                        title={title}>
+                        {title}
+                    </p>
+                ) : null}
+            </Card.Body>
+        </Card>
+    )
+}
+
+/**
+ * Live-now dashboard: every tracked streamer whose viewer samples are fresh.
+ * Liveness is inferred from sample freshness, so a dead tracker looks like an
+ * empty scene — `lastSampleAt` drives a staleness warning to disambiguate.
+ * Polls every 30s via the hook's refetchInterval.
+ */
+const LiveNow = () => {
+    const {
+        data,
+        isLoading,
+        error,
+        refetch,
+    } = useSceneLive()
+
+    const live = useMemo(() => data?.live || [
+    ], [
+        data?.live,
+    ])
+
+    const lastSampleAt = data?.lastSampleAt ?? null
+
+    const isStale = useMemo(() => {
+        const last = utcEpoch(lastSampleAt)
+        return last !== null && Date.now() - last > STALE_MS
+    }, [
+        lastSampleAt,
+    ])
+
+    return (
+        <>
+            <div className="page-head">
+                <div>
+                    <h1 className="page-title">Live now</h1>
+                    <p className="page-sub">Tracked streamers broadcasting right now</p>
+                </div>
+                {live.length > 0 && (
+                    <span className="toolbar-readout">
+                        <strong>{live.length}</strong> live
+                    </span>
+                )}
+            </div>
+
+            {error ? (
+                <ErrorAlert
+                    error={error}
+                    title="Failed to load live streamers"
+                    onRetry={refetch}
+                    showDetails={process.env.NODE_ENV === 'development'}
+                />
+            ) : isLoading ? (
+                <LoadingSpinner
+                    text="Checking who's live..."
+                    centered
+                />
+            ) : live.length === 0 ? (
+                <div className="empty-state">
+                    <span
+                        className="empty-scope"
+                        aria-hidden="true" />
+                    <p className="empty-title">Nobody live right now</p>
+                    {isStale ? (
+                        <p className="empty-hint text-warning">
+                            Tracking data is stale — the newest viewer sample is over 15 minutes old,
+                            so the tracker may be down rather than the scene being quiet.
+                        </p>
+                    ) : (
+                        <p className="empty-hint">
+                            No tracked streamer is broadcasting. This refreshes automatically every 30 seconds.
+                        </p>
+                    )}
+                </div>
+            ) : (
+                <>
+                    {isStale && (
+                        <p className="live-stale-note text-warning mono">
+                            <i
+                                className="bi bi-exclamation-triangle"
+                                aria-hidden="true" />
+                            {' '}
+                            Latest sample is over 15 minutes old — this list may be incomplete.
+                        </p>
+                    )}
+                    <div className="live-grid">
+                        {live.map(streamer => (
+                            <LiveCard
+                                key={streamer.creatorId}
+                                streamer={streamer}
+                            />
+                        ))}
+                    </div>
+                </>
+            )}
+        </>
+    )
+}
+
+export default LiveNow

--- a/frontend/views/Scene.jsx
+++ b/frontend/views/Scene.jsx
@@ -1,0 +1,321 @@
+'use client'
+import {
+    useCallback,
+    useMemo,
+    useState,
+} from 'react'
+import { Card, Table } from 'react-bootstrap'
+import { useSceneLeaderboard } from '@/hooks/useApiQuery'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import ErrorAlert from '@/components/ErrorAlert'
+
+// Window toggle (days). Backend accepts only 7 or 30.
+const WINDOW_TABS = [
+    {
+        key: 7,
+        label: '7 days',
+    },
+    {
+        key: 30,
+        label: '30 days',
+    },
+]
+
+// Sortable columns. `numeric` columns right-align and sink null values to the
+// bottom in both sort directions; `nullable` marks the fields that may be null
+// (unknown) per the nullable = unknown contract and render '--'.
+const COLUMNS = [
+    {
+        key: 'rank',
+        label: '#',
+        align: 'start',
+    },
+    {
+        key: 'name',
+        label: 'Streamer',
+        align: 'start',
+    },
+    {
+        key: 'streams',
+        label: 'Streams',
+        align: 'end',
+        numeric: true,
+    },
+    {
+        key: 'hoursStreamed',
+        label: 'Hours',
+        align: 'end',
+        numeric: true,
+        nullable: true,
+    },
+    {
+        key: 'totalMessages',
+        label: 'Messages',
+        align: 'end',
+        numeric: true,
+    },
+    {
+        key: 'msgsPerMin',
+        label: 'Msgs/min',
+        align: 'end',
+        numeric: true,
+        nullable: true,
+    },
+    {
+        key: 'chatterAppearances',
+        label: 'Chatter appearances',
+        align: 'end',
+        numeric: true,
+    },
+    {
+        key: 'peakViewers',
+        label: 'Peak viewers',
+        align: 'end',
+        numeric: true,
+        nullable: true,
+    },
+]
+
+const SortHeader = ({
+    column, sort, dir, onSort,
+}) => {
+    const active = sort === column.key
+    return (
+        <th
+            scope="col"
+            className={column.align === 'end' ? 'text-end' : undefined}
+            aria-sort={active ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+        >
+            <button
+                type="button"
+                className={active ? 'th-sort active' : 'th-sort'}
+                onClick={() => onSort(column.key)}
+            >
+                {column.label}
+                <span
+                    className="th-sort-caret"
+                    aria-hidden="true"
+                >
+                    {active ? (dir === 'asc' ? '▲' : '▼') : ''}
+                </span>
+            </button>
+        </th>
+    )
+}
+
+/** '--' for unknown (null) numbers; formatted otherwise. */
+const numCell = (value, digits = 0) => {
+    if (value == null) {
+        return '--'
+    }
+    return digits > 0 ? value.toFixed(digits) : value.toLocaleString()
+}
+
+/**
+ * Scene leaderboard: creators ranked by total messages over a 7- or 30-day
+ * window, with a client-side sortable table. Rank comes from the backend
+ * (total_messages DESC); nullable columns (hours, msgs/min, peak viewers)
+ * render '--' and always sort to the bottom.
+ */
+const Scene = () => {
+    const [
+        windowDays,
+        setWindowDays,
+    ] = useState(7)
+    const [
+        sort,
+        setSort,
+    ] = useState('rank')
+    const [
+        dir,
+        setDir,
+    ] = useState('asc')
+
+    const {
+        data,
+        isLoading,
+        error,
+        refetch,
+    } = useSceneLeaderboard(windowDays)
+
+    const entries = useMemo(() => data?.entries || [
+    ], [
+        data?.entries,
+    ])
+
+    const sortedEntries = useMemo(() => {
+        const factor = dir === 'asc' ? 1 : -1
+        const value = row => {
+            if (sort === 'name') {
+                return (row.displayName || row.nick || '').toLowerCase()
+            }
+            return row[sort]
+        }
+        return [
+            ...entries,
+        ].sort((r1, r2) => {
+            const v1 = value(r1)
+            const v2 = value(r2)
+            // Unknown (null) numeric fields always sink to the bottom.
+            if (v1 == null && v2 == null) {
+                return 0
+            }
+            if (v1 == null) {
+                return 1
+            }
+            if (v2 == null) {
+                return -1
+            }
+            if (v1 < v2) {
+                return -1 * factor
+            }
+            if (v1 > v2) {
+                return 1 * factor
+            }
+            return 0
+        })
+    }, [
+        entries,
+        sort,
+        dir,
+    ])
+
+    const handleSort = useCallback(key => {
+        if (sort === key) {
+            setDir(prev => (prev === 'asc' ? 'desc' : 'asc'))
+        } else {
+            setSort(key)
+            // Names ascend; ranks ascend (1 first); every other metric descends.
+            setDir(key === 'name' || key === 'rank' ? 'asc' : 'desc')
+        }
+    }, [
+        sort,
+    ])
+
+    const handleWindowChange = useCallback(key => {
+        setWindowDays(key)
+    }, [
+    ])
+
+    return (
+        <>
+            <div className="page-head">
+                <div>
+                    <h1 className="page-title">Scene leaderboard</h1>
+                    <p className="page-sub">Creators ranked by chat activity</p>
+                </div>
+            </div>
+
+            <div
+                className="toolbar scene-toolbar"
+                role="search"
+                aria-label="Leaderboard window">
+                <div
+                    className="chatter-tabs"
+                    role="tablist"
+                    aria-label="Window">
+                    {WINDOW_TABS.map(tab => (
+                        <button
+                            key={tab.key}
+                            type="button"
+                            role="tab"
+                            aria-selected={windowDays === tab.key}
+                            className={windowDays === tab.key ? 'chatter-tab active' : 'chatter-tab'}
+                            onClick={() => handleWindowChange(tab.key)}>
+                            {tab.label}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {error ? (
+                <ErrorAlert
+                    error={error}
+                    title="Failed to load leaderboard"
+                    onRetry={refetch}
+                    showDetails={process.env.NODE_ENV === 'development'}
+                />
+            ) : isLoading ? (
+                <LoadingSpinner
+                    text="Ranking the scene..."
+                    centered
+                />
+            ) : entries.length === 0 ? (
+                <div className="empty-state">
+                    <span
+                        className="empty-scope"
+                        aria-hidden="true" />
+                    <p className="empty-title">No streams in window</p>
+                    <p className="empty-hint">
+                        No captured streams fall inside the last {windowDays} days.
+                    </p>
+                </div>
+            ) : (
+                <Card>
+                    <Card.Body className="p-0">
+                        <div
+                            role="region"
+                            aria-label="Scene leaderboard">
+                            <Table
+                                hover
+                                responsive
+                                className="mb-0">
+                                <thead>
+                                    <tr>
+                                        {COLUMNS.map(column => (
+                                            <SortHeader
+                                                key={column.key}
+                                                column={column}
+                                                sort={sort}
+                                                dir={dir}
+                                                onSort={handleSort}
+                                            />
+                                        ))}
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {sortedEntries.map(entry => (
+                                        <tr key={entry.creatorId}>
+                                            <td className="rank-num">{String(entry.rank).padStart(2, '0')}</td>
+                                            <td>
+                                                <span className="scene-streamer">
+                                                    {entry.profileImageUrl
+                                                        ? (
+                                                            <img
+                                                                className="scene-avatar"
+                                                                src={entry.profileImageUrl}
+                                                                alt=""
+                                                                width={28}
+                                                                height={28}
+                                                                loading="lazy"
+                                                            />
+                                                        )
+                                                        : (
+                                                            <span
+                                                                className="scene-avatar scene-avatar-empty"
+                                                                aria-hidden="true" />
+                                                        )}
+                                                    <span className="scene-streamer-name">
+                                                        {entry.displayName || entry.nick}
+                                                    </span>
+                                                </span>
+                                            </td>
+                                            <td className="mono text-end">{numCell(entry.streams)}</td>
+                                            <td className="mono text-end">{numCell(entry.hoursStreamed, 1)}</td>
+                                            <td className="mono text-end">{numCell(entry.totalMessages)}</td>
+                                            <td className="mono text-end">{numCell(entry.msgsPerMin, 1)}</td>
+                                            <td className="mono text-end">{numCell(entry.chatterAppearances)}</td>
+                                            <td className="mono text-end">{numCell(entry.peakViewers)}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+                        </div>
+                    </Card.Body>
+                </Card>
+            )}
+        </>
+    )
+}
+
+export default Scene


### PR DESCRIPTION
Four scene-wide features (roadmap items decided by the earlier ideation panel), built as one bundle since they share nav, routers, and a single migration. Follows PR #38 (report card), which is already merged and deployed.

## Features

**Live-now** — `GET /scene/live`, `/live` page. Infers which of the 39 tracked streamers are live right now from `stream_viewer_sample` freshness (samples are written only while live, ~5-min cadence): viewer count, title, uptime. Polls every 30s. Surfaces `last_sample_at` so if the tracking container is down the page says "data is stale" rather than falsely "nobody live".

**Scene leaderboard** — `GET /scene/leaderboard?window=7|30`, `/scene` page. Ranks creators over the window by streams, hours, total messages, duration-weighted msgs/min, chatter appearances, and peak viewers. One `GROUP BY` over `stream` + `stream_metrics` (LEFT JOIN + COALESCE so un-rolled streams still count); peak viewers computed separately from the viewer-sample table and merged in Python (avoids a big-table cross join). Sortable table, 7d/30d toggle.

**Copypasta library** — `GET /scene/copypastas`, `/copypasta` page. Surfaces message texts that many different chatters repeated, with usage count, channel/stream spread, and first-seen. Backed by a **new per-stream `stream_copypasta_stats` rollup** filled at rollup time — so `stream-sniper-rollup --all --force` backfills it, and the scene view aggregates that small table instead of ever scanning `message` on demand (the RPI can't afford a global message scan). Creator filter, sort, offset pagination.

**Bot detection** — `stream-sniper-classify-bots` CLI. Flags chatters via (1) a known-bot name list, (2) cross-channel ubiquity, (3) message-rate heuristics — all computed from the small derived tables (`creator_chatter_stats`, `stream_chatter_stats`), never a full `message` scan. `chatter.is_bot` is then excluded from community overlap and, by default, streamer regulars and copypasta. Per-stream rollups are deliberately left intact (a bot's messages genuinely happened; re-excluding would force a full-history recompute). A BOT badge shows in the chatter explorer.

## Design notes

- **Migration 0009** (transactional, offline-capable, no `CONCURRENTLY`): `chatter.is_bot`/`bot_reason`, the `stream_copypasta_stats` table, and a `stream_viewer_sample(sampled_at DESC)` index for the live/leaderboard scans.
- Scene window filters use `now() AT TIME ZONE 'UTC'` so naive `stream.start` timestamps don't drift by the RPI's DB session offset (caught in adversarial review).
- nullable = unknown throughout: hours/msgs-per-min/peak-viewers/first-seen render as `--` or are omitted, never 0.
- `chatter_appearances` is honestly named (it sums per-stream unique chatters, which double-counts across streams) rather than implying a true distinct count.

## How it was built

Design scouts mapped each feature against the real schema, a locked contract drove two parallel implementers, and a 3-reviewer adversarial pass over SQL / bot logic / integration found and fixed 2 timezone-boundary bugs.

## Verification

- `uv run ruff check .` clean; `uv run pytest tests/unit/api tests/unit/analytics tests/unit/utils` — **272 passed** (3 pre-existing `TestMomentQueueGateway` errors need Postgres, unchanged from main).
- `npm run typecheck` + `npm run build` clean; `/live`, `/scene`, `/copypasta` routes present.
- New tests: scene endpoints (shapes, empty, validation 422, cache hit, 500), bot detection (known list, passes, dry-run), regulars `include_bots`, plus CI-only DB-backed tests for the copypasta gateway and overlap bot-exclusion.

## ⚠️ After merge — migration required

Unlike PR #38, this needs a migration. After the deploy:
```
docker exec stream-sniper-api stream-sniper-migrate upgrade head
```
Then to populate the copypasta library and bot flags on existing data:
```
docker exec stream-sniper-api stream-sniper-rollup --all --force
docker exec stream-sniper-api stream-sniper-classify-bots
```

https://claude.ai/code/session_01EXfaau3UEsTSdpFmxZKKnc