### PR TITLE
Add scene intelligence platform

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,17 @@ MONITORING_REQUEST_METRICS=true
 MONITORING_CACHE_METRICS=true
 MONITORING_RATE_LIMIT_METRICS=true
 MONITORING_RETENTION_HOURS=24
+
+# Twitch live chat capture (optional standalone service)
+# Dedicated bot account refresh token with the chat:read scope.
+TWITCH_BOT_REFRESH_TOKEN=
+# Optional writable file; refreshed credentials are persisted here for restarts.
+TWITCH_BOT_TOKEN_FILE=
+LIVE_CHANNELS=
+# Also keep rooms synchronized with active tracked_streamers (recommended).
+LIVE_TRACKED_CHANNELS=true
+LIVE_FLUSH_INTERVAL=5
+LIVE_BUFFER_SIZE=1000
+
+# Optional Discord destination for the scene digest CLI.
+SCENE_DIGEST_WEBHOOK_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ pip-selfcheck.json
 testing.py
 # Backend runtime logs (logger fallback during local runs)
 backend/logs/
+.live-refresh-token

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -67,6 +67,8 @@ stream-sniper-tracking = "stream_sniper.tracking_service:run_tracking_service"
 stream-sniper-migrate = "stream_sniper.database.migrate:main"
 stream-sniper-rollup = "stream_sniper.analytics.backfill:main"
 stream-sniper-classify-bots = "stream_sniper.analytics.bot_detection:main"
+stream-sniper-digest = "stream_sniper.analytics.digest:main"
+stream-sniper-live = "stream_sniper.live_service:run_live_service"
 
 [project.urls]
 Homepage = "https://github.com/slanycukr/stream-sniper"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -69,6 +69,7 @@ stream-sniper-rollup = "stream_sniper.analytics.backfill:main"
 stream-sniper-classify-bots = "stream_sniper.analytics.bot_detection:main"
 stream-sniper-digest = "stream_sniper.analytics.digest:main"
 stream-sniper-live = "stream_sniper.live_service:run_live_service"
+stream-sniper-live-auth = "stream_sniper.live_auth_cli:main"
 
 [project.urls]
 Homepage = "https://github.com/slanycukr/stream-sniper"

--- a/backend/stream_sniper/analytics/digest.py
+++ b/backend/stream_sniper/analytics/digest.py
@@ -1,0 +1,53 @@
+"""Build and optionally deliver a deterministic scene digest to a Discord webhook."""
+
+import argparse
+import os
+import sys
+
+import requests
+from dotenv import load_dotenv
+
+from ..database.scene_event_table_gateway import select_scene_events_db
+
+
+def format_digest(rows, days: int) -> str:
+    lines = [f"## Stream Sniper · {days}-day scene pulse"]
+    if not rows:
+        return "\n".join([*lines, "No notable captured events in this window."])
+    for row in rows:
+        creator = row[5] or row[4] or "Scene"
+        lines.append(f"- **{row[8]}** — {row[9]} ({creator}, {row[2][:10]})")
+    return "\n".join(lines)
+
+
+def build_digest(days: int = 7, limit: int = 20) -> str:
+    rows, _ = select_scene_events_db(days, None, None, limit, 0)
+    return format_digest(rows, days)
+
+
+def deliver_discord(markdown: str, webhook_url: str) -> None:
+    response = requests.post(webhook_url, json={"content": markdown[:2000]}, timeout=15)
+    response.raise_for_status()
+
+
+def main() -> None:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description="Preview or deliver the Stream Sniper scene digest")
+    parser.add_argument("--days", type=int, default=7, choices=range(1, 31))
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--send", action="store_true", help="Deliver to SCENE_DIGEST_WEBHOOK_URL")
+    args = parser.parse_args()
+    digest = build_digest(args.days, max(1, min(args.limit, 50)))
+    if not args.send:
+        print(digest)
+        return
+    webhook = os.getenv("SCENE_DIGEST_WEBHOOK_URL")
+    if not webhook:
+        print("SCENE_DIGEST_WEBHOOK_URL is required with --send", file=sys.stderr)
+        raise SystemExit(2)
+    deliver_discord(digest, webhook)
+    print("Scene digest delivered.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/stream_sniper/analytics/rollup_engine.py
+++ b/backend/stream_sniper/analytics/rollup_engine.py
@@ -17,6 +17,7 @@ from ..logging_config import get_logger
 from . import community, text_stats
 from .emote_seed import ensure_emote_dictionary_seeded
 from .moment_enrichment import enrich_moments
+from .scene_events import refresh_stream_events
 
 logger = get_logger(__name__)
 
@@ -70,6 +71,11 @@ def compute_stream_rollup(stream_id: int, *, refresh_overlap: bool = True) -> No
         logger.error(
             f"compute_stream_rollup: copypasta rollup failed for stream {stream_id}: {e}", exc_info=True
         )
+
+    try:
+        refresh_stream_events(stream_id)
+    except Exception as e:
+        logger.error(f"compute_stream_rollup: scene events failed for stream {stream_id}: {e}", exc_info=True)
 
     if refresh_overlap:
         try:

--- a/backend/stream_sniper/analytics/scene_events.py
+++ b/backend/stream_sniper/analytics/scene_events.py
@@ -1,0 +1,61 @@
+"""Derive human-readable, deterministic events from one stream's rollups."""
+
+from ..database.scene_event_table_gateway import (
+    replace_stream_scene_events_db,
+    select_stream_event_signals_db,
+)
+
+
+def _record_event(stream_id, creator_id, creator, occurred_at, kind, label, value):
+    return {
+        "event_type": "personal_record",
+        "occurred_at": occurred_at,
+        "creator_id": creator_id,
+        "title": f"{creator} set a {label} record",
+        "summary": f"{value:,.1f}" if isinstance(value, float) else f"{value:,}",
+        "metadata": {"metric": kind, "value": value},
+        "dedupe_key": f"stream:{stream_id}:record:{kind}",
+    }
+
+
+def refresh_stream_events(stream_id: int) -> int:
+    header, moment, copypastas = select_stream_event_signals_db(stream_id)
+    if header is None or header[5] is None:
+        replace_stream_scene_events_db(stream_id, [])
+        return 0
+    _, creator_id, creator, stream_title, occurred_at, messages, unique, rate, prev_messages, prev_unique, prev_rate = header
+    events = [{
+        "event_type": "stream_report",
+        "occurred_at": occurred_at,
+        "creator_id": creator_id,
+        "title": f"{creator} finished a stream",
+        "summary": f"{messages:,} messages from {unique:,} chatters · {stream_title}",
+        "metadata": {"total_messages": messages, "unique_chatters": unique, "messages_per_minute": rate},
+        "dedupe_key": f"stream:{stream_id}:report",
+    }]
+    for kind, label, value, previous in (
+        ("messages", "message", messages, prev_messages),
+        ("chatters", "chatter", unique, prev_unique),
+        ("rate", "chat-speed", rate, prev_rate),
+    ):
+        if value is not None and previous is not None and value > previous:
+            events.append(_record_event(stream_id, creator_id, creator, occurred_at, kind, label, value))
+    if moment and moment[1] is not None and moment[1] >= 5:
+        events.append({
+            "event_type": "standout_moment", "occurred_at": moment[0], "creator_id": creator_id,
+            "title": f"A {moment[1]:.1f}× chat spike on {creator}",
+            "summary": f"{moment[2]:,} messages in one minute",
+            "metadata": {"ratio": moment[1], "message_count": moment[2]},
+            "dedupe_key": f"stream:{stream_id}:moment:{moment[0]}",
+        })
+    for message_text_id, text, usage_count, creator_count in copypastas:
+        events.append({
+            "event_type": "copypasta_spread", "occurred_at": occurred_at, "creator_id": creator_id,
+            "message_text_id": message_text_id,
+            "title": f"A copypasta reached {creator}",
+            "summary": text[:180],
+            "metadata": {"usage_count": usage_count, "creator_count": creator_count},
+            "dedupe_key": f"stream:{stream_id}:copypasta:{message_text_id}",
+        })
+    replace_stream_scene_events_db(stream_id, events)
+    return len(events)

--- a/backend/stream_sniper/api/analytics_endpoints.py
+++ b/backend/stream_sniper/api/analytics_endpoints.py
@@ -3,10 +3,18 @@
 from fastapi import APIRouter, HTTPException, Path, Query, Request, Response
 
 from ..database.creator_chatter_stats_table_gateway import select_creator_regulars_db
+from ..database.creator_table_gateway import select_creator_summary_db
 from ..database.stream_metrics_table_gateway import select_creator_metrics_series_db
 from ..database.stream_table_gateway import select_all_stream_count_db
 from ..logging_config import get_logger
-from .analytics_models import CreatorRegulars, CreatorTrends, Regular, TrendPoint
+from .analytics_models import (
+    CreatorRegulars,
+    CreatorSummary,
+    CreatorTrends,
+    LatestCreatorStream,
+    Regular,
+    TrendPoint,
+)
 from .cache import CacheTTL, get_cache
 from .models import ErrorResponse
 from .monitoring import record_cache_operation
@@ -15,6 +23,70 @@ from .rate_limiter import limiter, rate_limits
 logger = get_logger(__name__)
 
 router = APIRouter(tags=["Creators"])
+
+
+@router.get(
+    "/creator/{creator_id}/summary",
+    response_model=CreatorSummary,
+    summary="Get a creator dossier summary",
+    description="Identity and lifetime analytics assembled from bounded rollup tables.",
+    responses={
+        404: {"model": ErrorResponse, "description": "Creator not found"},
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit(rate_limits.ANALYTICS)
+def get_creator_summary(
+    request: Request,
+    response: Response,
+    creator_id: int = Path(..., description="Creator ID", json_schema_extra={"example": 5}),
+) -> CreatorSummary:
+    """Get the stable header and lifetime totals for a permanent creator page."""
+    try:
+        cache = get_cache()
+        cache_key = cache._generate_key("creator_summary", creator_id)
+        cached_result = cache.get(cache_key)
+        if cached_result is not None:
+            response.headers["X-Cache"] = "HIT"
+            record_cache_operation("hit", "creator_summary")
+            return CreatorSummary(**cached_result)
+
+        record_cache_operation("miss", "creator_summary")
+        row = select_creator_summary_db(creator_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="Creator not found")
+
+        latest_stream = (
+            LatestCreatorStream(stream_id=row[13], title=row[14], start=row[15])
+            if row[13] is not None
+            else None
+        )
+        result = CreatorSummary(
+            creator_id=row[0],
+            nick=row[1],
+            display_name=row[2],
+            profile_image_url=row[3],
+            twitch_id=row[4],
+            total_streams=row[5],
+            first_stream_at=row[6],
+            last_stream_at=row[7],
+            total_messages=row[8],
+            duration_seconds=row[9],
+            messages_per_minute=row[10],
+            audience_size=row[11],
+            regulars=row[12],
+            latest_stream=latest_stream,
+        )
+        cache.set(cache_key, result.model_dump(), CacheTTL.STREAM_ANALYTICS)
+        record_cache_operation("set", "creator_summary")
+        response.headers["X-Cache"] = "MISS"
+        return result
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Error fetching creator summary: {exc}")
+        record_cache_operation("error", "creator_summary")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get(

--- a/backend/stream_sniper/api/analytics_models.py
+++ b/backend/stream_sniper/api/analytics_models.py
@@ -45,3 +45,30 @@ class CreatorRegulars(BaseModel):
     creator_id: int = Field(..., description="Creator ID", json_schema_extra={"example": 5})
     total_streams: int = Field(..., description="Total streams for this creator (attendance denominator)")
     regulars: List[Regular] = Field(..., description="Recurring chatters")
+
+
+class LatestCreatorStream(BaseModel):
+    """Most recent captured stream linked from a creator dossier."""
+
+    stream_id: int
+    title: str
+    start: Optional[str] = None
+
+
+class CreatorSummary(BaseModel):
+    """Identity and lifetime rollup summary used by the permanent creator page."""
+
+    creator_id: int
+    nick: str
+    display_name: str
+    profile_image_url: Optional[str] = None
+    twitch_id: Optional[str] = None
+    total_streams: int
+    first_stream_at: Optional[str] = None
+    last_stream_at: Optional[str] = None
+    total_messages: int
+    duration_seconds: Optional[int] = None
+    messages_per_minute: Optional[float] = None
+    audience_size: int
+    regulars: int
+    latest_stream: Optional[LatestCreatorStream] = None

--- a/backend/stream_sniper/api/api.py
+++ b/backend/stream_sniper/api/api.py
@@ -11,10 +11,12 @@ from slowapi.util import get_remote_address
 from ..database.connection_pool import close_pool
 from ..logging_config import get_logger, setup_logging
 from .analytics_endpoints import router as analytics_router
+from .audience_endpoints import router as audience_router
 from .auth_router import router as auth_router
 from .cache import warm_cache
 from .chatter_endpoints import router as chatter_router
 from .community_endpoints import router as community_router
+from .compare_endpoints import router as compare_router
 from .config import get_config
 from .creator_endpoints import router as creator_router
 from .message_endpoints import router as message_router
@@ -24,6 +26,7 @@ from .monitoring import record_request_metrics, setup_monitoring
 from .operations_endpoints import router as operations_router
 from .rate_limiter import setup_rate_limiting
 from .scene_endpoints import router as scene_router
+from .scene_event_endpoints import router as scene_event_router
 from .stream_endpoints import router as stream_router
 from .stream_insight_endpoints import router as stream_insight_router
 from .stream_report_endpoints import router as stream_report_router
@@ -169,6 +172,7 @@ app.include_router(chatter_router)
 
 # Include stream router
 app.include_router(stream_router)
+app.include_router(compare_router)
 
 # Include creator router
 app.include_router(creator_router)
@@ -187,6 +191,7 @@ app.include_router(timeline_router)
 
 # Include creator analytics router (trends, regulars)
 app.include_router(analytics_router)
+app.include_router(audience_router)
 
 # Include stream insight router (mentions, emotes, phrases)
 app.include_router(stream_insight_router)
@@ -199,6 +204,7 @@ app.include_router(community_router)
 
 # Include scene router (live-now, leaderboard, copypasta library)
 app.include_router(scene_router)
+app.include_router(scene_event_router)
 
 # Include highlight queue + moment review router
 app.include_router(moment_router)

--- a/backend/stream_sniper/api/audience_endpoints.py
+++ b/backend/stream_sniper/api/audience_endpoints.py
@@ -1,0 +1,58 @@
+"""Window-over-window creator audience participation reports."""
+
+from fastapi import APIRouter, HTTPException, Path, Query, Request, Response
+
+from ..database.audience_movement_table_gateway import select_creator_audience_movement_db
+from ..logging_config import get_logger
+from .audience_models import AudienceAssociation, AudienceMovement
+from .cache import CacheTTL, get_cache
+from .rate_limiter import limiter, rate_limits
+
+logger = get_logger(__name__)
+router = APIRouter(tags=["Community"])
+
+
+@router.get("/creator/{creator_id}/audience-movement", response_model=AudienceMovement)
+@limiter.limit(rate_limits.HEAVY)
+def get_audience_movement(
+    request: Request,
+    response: Response,
+    creator_id: int = Path(..., ge=1),
+    days: int = Query(30, ge=7, le=90),
+    limit: int = Query(8, ge=1, le=20),
+) -> AudienceMovement:
+    """Compare distinct participating chatters across adjacent equal windows."""
+    try:
+        cache = get_cache()
+        key = cache._generate_key("audience_movement", creator_id, days, limit)
+        cached = cache.get(key)
+        if cached is not None:
+            response.headers["X-Cache"] = "HIT"
+            return AudienceMovement(**cached)
+        summary, source_rows, destination_rows = select_creator_audience_movement_db(
+            creator_id, days, limit
+        )
+        current, previous, retained, gained, lapsed = summary
+        def association(row):
+            return AudienceAssociation(
+                creator_id=row[0], nick=row[1], display_name=row[2], chatter_count=row[3]
+            )
+        result = AudienceMovement(
+            creator_id=creator_id,
+            window_days=days,
+            current_audience=current,
+            previous_audience=previous,
+            retained=retained,
+            gained=gained,
+            lapsed=lapsed,
+            retention_rate=round(retained / previous, 4) if previous else None,
+            gain_rate=round(gained / current, 4) if current else None,
+            prior_channels_for_gained=[association(row) for row in source_rows],
+            current_channels_for_lapsed=[association(row) for row in destination_rows],
+        )
+        cache.set(key, result.model_dump(), CacheTTL.STREAM_ANALYTICS)
+        response.headers["X-Cache"] = "MISS"
+        return result
+    except Exception as exc:
+        logger.error(f"Error fetching audience movement: {exc}")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/stream_sniper/api/audience_models.py
+++ b/backend/stream_sniper/api/audience_models.py
@@ -1,0 +1,26 @@
+"""Contracts for windowed audience participation movement."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class AudienceAssociation(BaseModel):
+    creator_id: int
+    nick: str
+    display_name: str
+    chatter_count: int
+
+
+class AudienceMovement(BaseModel):
+    creator_id: int
+    window_days: int
+    current_audience: int
+    previous_audience: int
+    retained: int
+    gained: int
+    lapsed: int
+    retention_rate: Optional[float] = None
+    gain_rate: Optional[float] = None
+    prior_channels_for_gained: List[AudienceAssociation]
+    current_channels_for_lapsed: List[AudienceAssociation]

--- a/backend/stream_sniper/api/compare_endpoints.py
+++ b/backend/stream_sniper/api/compare_endpoints.py
@@ -1,0 +1,117 @@
+"""Compare two to four streams using existing bounded analytics rollups."""
+
+from collections import defaultdict
+from datetime import datetime
+from typing import List
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+
+from ..database.stream_compare_table_gateway import (
+    select_stream_compare_buckets_db,
+    select_stream_compare_headers_db,
+    select_stream_pair_retention_db,
+)
+from ..database.stream_viewer_sample_table_gateway import select_stream_viewer_samples_db
+from ..logging_config import get_logger
+from .cache import CacheTTL, get_cache
+from .compare_models import CompareCurvePoint, ComparedStream, PairRetention, StreamComparison
+from .models import ErrorResponse
+from .rate_limiter import limiter, rate_limits
+
+logger = get_logger(__name__)
+router = APIRouter(tags=["Streams"])
+_FMT = "%Y-%m-%dT%H:%M:%S"
+
+
+def _share(part, total):
+    return None if part is None or total in (None, 0) else round(part / total, 4)
+
+
+def _normalise_curve(rows, start, duration):
+    """Collapse an arbitrary stream timeline into at most 101 percentage slots."""
+    if not rows:
+        return []
+    start_dt = datetime.strptime(start, _FMT) if start else None
+    result = {}
+    for index, row in enumerate(rows):
+        if start_dt is not None and duration and duration > 0:
+            elapsed = (datetime.strptime(row[1], _FMT) - start_dt).total_seconds()
+            percent = min(100, max(0, round(elapsed * 100 / duration)))
+        else:
+            percent = round(index * 100 / max(1, len(rows) - 1))
+        existing = result.setdefault(percent, [0, 0])
+        existing[0] += row[2]
+        existing[1] = max(existing[1], row[3])
+    return [
+        CompareCurvePoint(percent=percent, message_count=values[0], unique_chatters=values[1])
+        for percent, values in sorted(result.items())
+    ]
+
+
+@router.get(
+    "/streams/compare",
+    response_model=StreamComparison,
+    summary="Compare two to four streams",
+    responses={
+        404: {"model": ErrorResponse, "description": "One or more streams not found"},
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit(rate_limits.HEAVY)
+def compare_streams(
+    request: Request,
+    response: Response,
+    stream_ids: List[int] = Query(..., min_length=2, max_length=4),
+) -> StreamComparison:
+    if len(set(stream_ids)) != len(stream_ids):
+        raise HTTPException(status_code=422, detail="stream_ids must be unique")
+    try:
+        cache = get_cache()
+        key = cache._generate_key("stream_compare", *stream_ids)
+        cached = cache.get(key)
+        if cached is not None:
+            response.headers["X-Cache"] = "HIT"
+            return StreamComparison(**cached)
+
+        headers = select_stream_compare_headers_db(stream_ids)
+        if len(headers) != len(stream_ids):
+            raise HTTPException(status_code=404, detail="One or more streams not found")
+        header_by_id = {row[0]: row for row in headers}
+        bucket_map = defaultdict(list)
+        for row in select_stream_compare_buckets_db(stream_ids):
+            bucket_map[row[0]].append(row)
+
+        streams = []
+        for stream_id in stream_ids:
+            row = header_by_id[stream_id]
+            samples = select_stream_viewer_samples_db(stream_id)
+            peak_viewers = max((sample[1] for sample in samples), default=None)
+            streams.append(
+                ComparedStream(
+                    stream_id=row[0], creator_id=row[1], creator_nick=row[2],
+                    creator_display_name=row[3], title=row[4], start=row[5],
+                    duration_seconds=row[6], total_messages=row[7], messages_per_minute=row[8],
+                    unique_chatters=row[9], new_chatters=row[10], returning_chatters=row[11],
+                    sub_share=_share(row[12], row[7]), emote_share=_share(row[13], row[7]),
+                    peak_messages=row[14], peak_bucket_minute=row[15], peak_viewers=peak_viewers,
+                    curve=_normalise_curve(bucket_map[stream_id], row[5], row[6]),
+                )
+            )
+
+        retention = [
+            PairRetention(
+                from_stream_id=row[0], to_stream_id=row[1], from_audience=row[2],
+                to_audience=row[3], retained=row[4],
+                retention_rate=round(row[4] / row[2], 4) if row[2] else None,
+            )
+            for row in select_stream_pair_retention_db(stream_ids)
+        ]
+        result = StreamComparison(streams=streams, retention=retention)
+        cache.set(key, result.model_dump(), CacheTTL.STREAM_ANALYTICS)
+        response.headers["X-Cache"] = "MISS"
+        return result
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Error comparing streams: {exc}")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/stream_sniper/api/compare_models.py
+++ b/backend/stream_sniper/api/compare_models.py
@@ -1,0 +1,46 @@
+"""Contracts for the stream comparison lab."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class CompareCurvePoint(BaseModel):
+    percent: int
+    message_count: int
+    unique_chatters: int
+
+
+class ComparedStream(BaseModel):
+    stream_id: int
+    creator_id: int
+    creator_nick: str
+    creator_display_name: str
+    title: str
+    start: Optional[str] = None
+    duration_seconds: Optional[int] = None
+    total_messages: Optional[int] = None
+    messages_per_minute: Optional[float] = None
+    unique_chatters: Optional[int] = None
+    new_chatters: Optional[int] = None
+    returning_chatters: Optional[int] = None
+    sub_share: Optional[float] = None
+    emote_share: Optional[float] = None
+    peak_messages: Optional[int] = None
+    peak_bucket_minute: Optional[str] = None
+    peak_viewers: Optional[int] = None
+    curve: List[CompareCurvePoint]
+
+
+class PairRetention(BaseModel):
+    from_stream_id: int
+    to_stream_id: int
+    from_audience: int
+    to_audience: int
+    retained: int
+    retention_rate: Optional[float] = None
+
+
+class StreamComparison(BaseModel):
+    streams: List[ComparedStream]
+    retention: List[PairRetention]

--- a/backend/stream_sniper/api/moment_endpoints.py
+++ b/backend/stream_sniper/api/moment_endpoints.py
@@ -51,7 +51,7 @@ def _invalidate_moment_caches() -> None:
 def get_moment_queue(
     request: Request,
     response: Response,
-    status: str = Query("", pattern="^(pending|bookmarked|rejected|)$"),
+    status: str = Query("", pattern="^(pending|bookmarked|rejected|clipped|published|)$"),
     creator_id: Optional[int] = Query(None, description="Restrict to one creator", ge=1),
     limit: int = Query(50, description="Page size", ge=1, le=200),
     offset: int = Query(0, description="Page offset", ge=0),
@@ -91,6 +91,8 @@ def get_moment_queue(
                 top_phrases=row[14],
                 sample_messages=row[15],
                 status=row[16] or "pending",
+                clip_url=row[17],
+                note=row[18],
             )
             for row in rows
         ]
@@ -109,7 +111,7 @@ def get_moment_queue(
     "/stream/{stream_id}/moments/{bucket_minute}/review",
     response_model=MomentReviewResponse,
     summary="Set a moment's review status (Admin only)",
-    description="Bookmark or reject a moment. Curation is global state, so admin only.",
+    description="Bookmark, reject, attach a clip, or publish a moment. Admin only.",
     responses={
         401: {"description": "Authentication required"},
         403: {"description": "Admin role required"},
@@ -131,13 +133,26 @@ def set_moment_review(
         if not select_moment_exists_db(stream_id, bucket_minute):
             raise HTTPException(status_code=404, detail="Moment not found")
 
-        updated_at = upsert_moment_review_db(stream_id, bucket_minute, body.status)
+        if body.status in {"clipped", "published"} and not body.clip_url:
+            raise HTTPException(status_code=422, detail="clip_url is required for clipped/published moments")
+        updated_at = upsert_moment_review_db(
+            stream_id,
+            bucket_minute,
+            body.status,
+            clip_url=body.clip_url,
+            note=body.note,
+        )
         _invalidate_moment_caches()
         logger.info(
             f"Moment review set by admin {current_user.username}: "
             f"stream={stream_id} bucket={bucket_minute} status={body.status}"
         )
-        return MomentReviewResponse(status=body.status, updated_at=updated_at)
+        return MomentReviewResponse(
+            status=body.status,
+            updated_at=updated_at,
+            clip_url=body.clip_url,
+            note=body.note,
+        )
     except HTTPException:
         raise
     except Exception as exc:

--- a/backend/stream_sniper/api/moment_models.py
+++ b/backend/stream_sniper/api/moment_models.py
@@ -24,7 +24,11 @@ class MomentQueueItem(BaseModel):
     emote_share: Optional[float] = Field(None, description="Emote message share (0-1); null if unknown")
     top_phrases: Optional[List[Any]] = Field(None, description="Distinctive phrases for the moment")
     sample_messages: Optional[List[Any]] = Field(None, description="Representative repeated messages")
-    status: str = Field(..., description="Review status: pending, bookmarked, or rejected")
+    status: str = Field(
+        ..., description="Workflow status: pending, bookmarked, rejected, clipped, or published"
+    )
+    clip_url: Optional[str] = Field(None, description="Published Twitch/external clip URL")
+    note: Optional[str] = Field(None, description="Curator note")
 
 
 class MomentQueue(BaseModel):
@@ -39,7 +43,13 @@ class MomentQueue(BaseModel):
 class MomentReviewRequest(BaseModel):
     """Body for setting a moment's review status."""
 
-    status: str = Field(..., pattern="^(bookmarked|rejected)$", description="bookmarked or rejected")
+    status: str = Field(
+        ...,
+        pattern="^(bookmarked|rejected|clipped|published)$",
+        description="Workflow status",
+    )
+    clip_url: Optional[str] = Field(None, pattern=r"^https?://", max_length=2000)
+    note: Optional[str] = Field(None, max_length=500)
 
 
 class MomentReviewResponse(BaseModel):
@@ -47,3 +57,5 @@ class MomentReviewResponse(BaseModel):
 
     status: Optional[str] = Field(None, description="New review status, or null after a clear")
     updated_at: Optional[str] = Field(None, description="When set (ISO 8601), or null after a clear")
+    clip_url: Optional[str] = None
+    note: Optional[str] = None

--- a/backend/stream_sniper/api/scene_endpoints.py
+++ b/backend/stream_sniper/api/scene_endpoints.py
@@ -13,7 +13,11 @@ from ..database.scene_table_gateway import (
     select_scene_leaderboard_db,
     select_scene_peak_viewers_db,
 )
-from ..database.stream_copypasta_stats_table_gateway import select_scene_copypastas_db
+from ..database.stream_copypasta_stats_table_gateway import (
+    select_copypasta_context_db,
+    select_copypasta_propagation_db,
+    select_scene_copypastas_db,
+)
 from ..database.stream_viewer_sample_table_gateway import (
     select_latest_sample_time_db,
     select_live_now_db,
@@ -25,6 +29,9 @@ from .monitoring import record_cache_operation
 from .rate_limiter import limiter, rate_limits
 from .scene_models import (
     Copypasta,
+    CopypastaContextMessage,
+    CopypastaOccurrence,
+    CopypastaPropagation,
     LeaderboardEntry,
     LiveStreamer,
     SceneCopypastas,
@@ -39,6 +46,86 @@ logger = get_logger(__name__)
 _LIVE_CACHE_TTL_SECONDS = 60
 
 router = APIRouter(tags=["Scene"])
+
+
+@router.get(
+    "/scene/copypastas/{message_text_id}",
+    response_model=CopypastaPropagation,
+    summary="Get a copypasta propagation history",
+    description="Every stream/channel where a copypasta appeared, plus context around its origin.",
+    responses={
+        404: {"model": ErrorResponse, "description": "Copypasta not found"},
+        429: {"model": ErrorResponse, "description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit(rate_limits.ANALYTICS)
+def get_copypasta_propagation(
+    request: Request,
+    response: Response,
+    message_text_id: int,
+    context_seconds: int = Query(90, ge=15, le=300),
+) -> CopypastaPropagation:
+    """Return the complete bounded-rollup propagation path for one message text."""
+    try:
+        cache = get_cache()
+        cache_key = cache._generate_key("copypasta_propagation", message_text_id, context_seconds)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            response.headers["X-Cache"] = "HIT"
+            record_cache_operation("hit", "copypasta_propagation")
+            return CopypastaPropagation(**cached)
+
+        record_cache_operation("miss", "copypasta_propagation")
+        text, rows = select_copypasta_propagation_db(message_text_id)
+        if text is None:
+            raise HTTPException(status_code=404, detail="Copypasta not found")
+
+        occurrences = [
+            CopypastaOccurrence(
+                stream_id=row[0],
+                creator_id=row[1],
+                nick=row[2],
+                display_name=row[3],
+                profile_image_url=row[4],
+                stream_title=row[5],
+                stream_start=row[6],
+                first_seen=row[7],
+                usage_count=row[8],
+                chatter_count=row[9],
+            )
+            for row in rows
+        ]
+        first = next((item for item in occurrences if item.first_seen is not None), None)
+        context_rows = (
+            select_copypasta_context_db(first.stream_id, first.first_seen, context_seconds, 100)
+            if first is not None
+            else []
+        )
+        context = [
+            CopypastaContextMessage(id=row[0], time=row[1], chatter_id=row[2], nick=row[3], text=row[4])
+            for row in context_rows
+        ]
+        result = CopypastaPropagation(
+            message_text_id=message_text_id,
+            text=text,
+            usage_count=sum(item.usage_count for item in occurrences),
+            chatter_appearances=sum(item.chatter_count for item in occurrences),
+            stream_count=len(occurrences),
+            creator_count=len({item.creator_id for item in occurrences}),
+            first_seen=first.first_seen if first else None,
+            occurrences=occurrences,
+            origin_context=context,
+        )
+        cache.set(cache_key, result.model_dump(), CacheTTL.STREAM_ANALYTICS)
+        record_cache_operation("set", "copypasta_propagation")
+        response.headers["X-Cache"] = "MISS"
+        return result
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Error fetching copypasta propagation: {exc}")
+        record_cache_operation("error", "copypasta_propagation")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get(

--- a/backend/stream_sniper/api/scene_event_endpoints.py
+++ b/backend/stream_sniper/api/scene_event_endpoints.py
@@ -1,0 +1,65 @@
+"""Chronological scene-event feed and digest preview endpoints."""
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+
+from ..analytics.digest import build_digest
+from ..database.scene_event_table_gateway import select_scene_events_db
+from ..logging_config import get_logger
+from .cache import CacheTTL, get_cache
+from .rate_limiter import limiter, rate_limits
+from .scene_event_models import SceneDigest, SceneEvent, ScenePulse
+
+logger = get_logger(__name__)
+router = APIRouter(tags=["Scene"])
+
+
+@router.get("/scene/pulse", response_model=ScenePulse)
+@limiter.limit(rate_limits.ANALYTICS)
+def get_scene_pulse(
+    request: Request,
+    response: Response,
+    days: int = Query(7, ge=1, le=90),
+    event_type: str = Query("", pattern="^(stream_report|personal_record|standout_moment|copypasta_spread|)$"),
+    creator_id: Optional[int] = Query(None, ge=1),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+) -> ScenePulse:
+    try:
+        cache = get_cache()
+        key = cache._generate_key("scene_pulse", days, event_type, creator_id, limit, offset)
+        cached = cache.get(key)
+        if cached is not None:
+            response.headers["X-Cache"] = "HIT"
+            return ScenePulse(**cached)
+        rows, total = select_scene_events_db(days, event_type or None, creator_id, limit, offset)
+        items = [
+            SceneEvent(
+                id=row[0], event_type=row[1], occurred_at=row[2], creator_id=row[3],
+                creator_nick=row[4], creator_display_name=row[5], stream_id=row[6],
+                message_text_id=row[7], title=row[8], summary=row[9], metadata=row[10] or {},
+            )
+            for row in rows
+        ]
+        result = ScenePulse(items=items, total=total, days=days, limit=limit, offset=offset)
+        cache.set(key, result.model_dump(), CacheTTL.STREAM_ANALYTICS)
+        response.headers["X-Cache"] = "MISS"
+        return result
+    except Exception as exc:
+        logger.error(f"Error fetching scene pulse: {exc}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.get("/scene/digest", response_model=SceneDigest)
+@limiter.limit(rate_limits.ANALYTICS)
+def get_scene_digest(
+    request: Request,
+    response: Response,
+    days: int = Query(7, ge=1, le=30),
+) -> SceneDigest:
+    try:
+        return SceneDigest(days=days, markdown=build_digest(days))
+    except Exception as exc:
+        logger.error(f"Error building scene digest: {exc}")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/backend/stream_sniper/api/scene_event_models.py
+++ b/backend/stream_sniper/api/scene_event_models.py
@@ -1,0 +1,32 @@
+"""Contracts for the scene pulse and digest preview."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class SceneEvent(BaseModel):
+    id: int
+    event_type: str
+    occurred_at: str
+    creator_id: Optional[int] = None
+    creator_nick: Optional[str] = None
+    creator_display_name: Optional[str] = None
+    stream_id: Optional[int] = None
+    message_text_id: Optional[int] = None
+    title: str
+    summary: str
+    metadata: Dict[str, Any]
+
+
+class ScenePulse(BaseModel):
+    items: List[SceneEvent]
+    total: int
+    days: int
+    limit: int
+    offset: int
+
+
+class SceneDigest(BaseModel):
+    days: int
+    markdown: str

--- a/backend/stream_sniper/api/scene_models.py
+++ b/backend/stream_sniper/api/scene_models.py
@@ -83,3 +83,42 @@ class SceneCopypastas(BaseModel):
 
     total: int = Field(..., description="Total distinct copypastas matching the filter")
     items: List[Copypasta] = Field(..., description="Copypastas for this page")
+
+
+class CopypastaOccurrence(BaseModel):
+    """One stream in the propagation history of a copypasta."""
+
+    stream_id: int
+    creator_id: int
+    nick: str
+    display_name: str
+    profile_image_url: Optional[str] = None
+    stream_title: str
+    stream_start: Optional[str] = None
+    first_seen: Optional[str] = None
+    usage_count: int
+    chatter_count: int
+
+
+class CopypastaContextMessage(BaseModel):
+    """One chat line surrounding the copypasta's earliest appearance."""
+
+    id: int
+    time: str
+    chatter_id: int
+    nick: str
+    text: str
+
+
+class CopypastaPropagation(BaseModel):
+    """Chronological spread history and first-appearance context."""
+
+    message_text_id: int
+    text: str
+    usage_count: int
+    chatter_appearances: int
+    stream_count: int
+    creator_count: int
+    first_seen: Optional[str] = None
+    occurrences: List[CopypastaOccurrence]
+    origin_context: List[CopypastaContextMessage]

--- a/backend/stream_sniper/api/timeline_endpoints.py
+++ b/backend/stream_sniper/api/timeline_endpoints.py
@@ -6,6 +6,7 @@ from typing import Any, List, cast
 from fastapi import APIRouter, HTTPException, Path, Request, Response
 
 from ..analytics.moments import detect_moments
+from ..database.stream_context_table_gateway import select_stream_context_changes_db
 from ..database.stream_metrics_table_gateway import (
     select_stream_header_db,
     select_stream_metrics_db,
@@ -19,6 +20,7 @@ from .models import ErrorResponse
 from .monitoring import record_cache_operation
 from .rate_limiter import limiter, rate_limits
 from .timeline_models import (
+    StreamContextChange,
     StreamTimeline,
     TimelineBucket,
     TimelineMetrics,
@@ -128,6 +130,7 @@ def get_stream_timeline(
         header_row = select_stream_header_db(stream_id)
         moment_rows = select_stream_moments_db(stream_id)
         sample_rows = select_stream_viewer_samples_db(stream_id)
+        context_rows = select_stream_context_changes_db(stream_id)
 
         stream_start = header_row[0] if header_row else None
         twitch_id = header_row[1] if header_row else None
@@ -141,6 +144,13 @@ def get_stream_timeline(
 
         viewer_samples = [ViewerSample(t=row[0], viewer_count=row[1]) for row in sample_rows]
         peak_viewers = max((s.viewer_count for s in viewer_samples), default=None)
+        context_changes = [
+            StreamContextChange(
+                t=row[0], title=row[1], category_id=row[2], category_name=row[3],
+                language=row[4], tags=row[5] or [], is_mature=row[6],
+            )
+            for row in context_rows
+        ]
 
         metrics = None
         if metrics_row is not None:
@@ -167,6 +177,7 @@ def get_stream_timeline(
             metrics=metrics,
             viewer_samples=viewer_samples,
             peak_viewers=peak_viewers,
+            context_changes=context_changes,
         )
         payload = result.model_dump()
         cache.set(cache_key, payload, CacheTTL.STREAM_ANALYTICS)

--- a/backend/stream_sniper/api/timeline_models.py
+++ b/backend/stream_sniper/api/timeline_models.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class TimelineBucket(BaseModel):
@@ -53,6 +53,16 @@ class ViewerSample(BaseModel):
     viewer_count: int
 
 
+class StreamContextChange(BaseModel):
+    t: str
+    title: Optional[str] = None
+    category_id: Optional[str] = None
+    category_name: Optional[str] = None
+    language: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
+    is_mature: Optional[bool] = None
+
+
 class StreamTimeline(BaseModel):
     stream_id: int
     stream_start: Optional[str]
@@ -61,5 +71,6 @@ class StreamTimeline(BaseModel):
     buckets: List[TimelineBucket]
     moments: List[TimelineMoment]
     metrics: Optional[TimelineMetrics]  # None when stream_metrics has no row (un-rolled-up)
-    viewer_samples: List[ViewerSample] = []
+    viewer_samples: List[ViewerSample] = Field(default_factory=list)
     peak_viewers: Optional[int] = None  # None when no viewer samples exist
+    context_changes: List[StreamContextChange] = Field(default_factory=list)

--- a/backend/stream_sniper/collector/irc_chat_downloader.py
+++ b/backend/stream_sniper/collector/irc_chat_downloader.py
@@ -2,6 +2,10 @@ from typing import Any, Iterator, Optional, Tuple
 
 from chat_downloader import ChatDownloader
 
+from ..database.live_chat_table_gateway import (
+    reconcile_live_stream_vod_db,
+    select_live_stream_by_session_db,
+)
 from ..database.stream_table_gateway import select_stream_by_twitch_id_db
 from ..logging_config import get_logger
 from . import twitch_gql_patch  # noqa: F401  (import applies the VideoMetadata GQL patch)
@@ -39,6 +43,23 @@ class IrcChatDownloader:
                 return None, None, None, None, None, None
 
             currently_processed_video: Any = self.available_video_ids.pop(0)
+
+            # A completed live capture already contains this broadcast's chat. Attach
+            # the VOD id to its stream row for deep-links, then avoid double-counting.
+            session_id = getattr(currently_processed_video, "stream_id", None)
+            if session_id:
+                captured = select_live_stream_by_session_db(session_id)
+                if captured and captured[1]:
+                    reconcile_live_stream_vod_db(
+                        session_id,
+                        currently_processed_video.id,
+                        currently_processed_video.thumbnail_url,
+                    )
+                    self.logger.info(
+                        f"Skipping VOD {currently_processed_video.id}; session {session_id} "
+                        "was captured live"
+                    )
+                    continue
 
             # available video was already processed - is in the database
             if select_stream_by_twitch_id_db(currently_processed_video.id):

--- a/backend/stream_sniper/collector/live/__init__.py
+++ b/backend/stream_sniper/collector/live/__init__.py
@@ -1,0 +1,5 @@
+"""Loop-native Twitch live chat collector."""
+
+from .live_chat_collector import LiveChatCollector
+
+__all__ = ["LiveChatCollector"]

--- a/backend/stream_sniper/collector/live/live_chat_collector.py
+++ b/backend/stream_sniper/collector/live/live_chat_collector.py
@@ -1,0 +1,168 @@
+"""One websocket, many rooms, periodic durable flushes."""
+
+import asyncio
+import os
+from pathlib import Path
+
+from twitchAPI.chat import Chat, ChatEvent
+from twitchAPI.oauth import refresh_access_token
+from twitchAPI.twitch import Twitch
+from twitchAPI.type import AuthScope
+
+from ...analytics.rollup_engine import compute_stream_rollup
+from ...database.creator_table_gateway import insert_new_creator_db, select_creator_id_db
+from ...database.tracked_streamers_table_gateway import select_active_tracked_streamers_db
+from ...logging_config import get_logger
+from .live_message_sink import LiveMessageSink
+
+logger = get_logger(__name__)
+
+
+def _read_token(path: str) -> str:
+    return Path(path).read_text().strip()
+
+
+def _write_token(path: str, token: str) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(token)
+    target.chmod(0o600)
+
+
+class LiveChatCollector:
+    def __init__(self, channels=None, flush_interval=None, buffer_size=None):
+        configured = channels or os.getenv("LIVE_CHANNELS", "").split(",")
+        self._static_channels = {c.strip().lower() for c in configured if c.strip()}
+        self.channels: set[str] = set()
+        self.tracking_driven = os.getenv("LIVE_TRACKED_CHANNELS", "true").lower() in {"1", "true", "yes"}
+        self.flush_interval = float(flush_interval or os.getenv("LIVE_FLUSH_INTERVAL", "5"))
+        self.sink = LiveMessageSink(int(buffer_size or os.getenv("LIVE_BUFFER_SIZE", "1000")))
+        self.twitch = None
+        self.chat = None
+        self._running = False
+        self._tasks: list[asyncio.Task] = []
+        self._streams: dict[str, object] = {}
+
+    async def initialize(self) -> None:
+        client_id = os.environ["TWITCH_CLIENT_ID"]
+        client_secret = os.environ["TWITCH_CLIENT_SECRET"]
+        token_file = os.getenv("TWITCH_BOT_TOKEN_FILE")
+        refresh_token = os.getenv("TWITCH_BOT_REFRESH_TOKEN", "")
+        if token_file and await asyncio.to_thread(Path(token_file).exists):
+            refresh_token = await asyncio.to_thread(_read_token, token_file)
+        if not refresh_token:
+            raise RuntimeError("TWITCH_BOT_REFRESH_TOKEN or a populated TWITCH_BOT_TOKEN_FILE is required")
+        access_token, refreshed = await refresh_access_token(refresh_token, client_id, client_secret)
+        if token_file:
+            await asyncio.to_thread(_write_token, token_file, refreshed)
+        self.twitch = await Twitch(client_id, client_secret)
+        if token_file:
+            async def persist_refresh(_access_token: str, new_refresh_token: str) -> None:
+                await asyncio.to_thread(_write_token, token_file, new_refresh_token)
+
+            self.twitch.user_auth_refresh_callback = persist_refresh
+        await self.twitch.set_user_authentication(
+            access_token, [AuthScope.CHAT_READ], refresh_token=refreshed,
+        )
+        self.chat = await Chat(self.twitch)
+        self.chat.register_event(ChatEvent.MESSAGE, self._on_message)
+
+    async def start(self) -> None:
+        if self.chat is None:
+            await self.initialize()
+        self._running = True
+        self.chat.start()
+        await self._sync_channels()
+        self._tasks = [
+            asyncio.create_task(self._flush_loop()),
+            asyncio.create_task(self._status_loop()),
+        ]
+        logger.info(f"Live chat collector started for {len(self.channels)} channels")
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+
+    async def stop(self) -> None:
+        self._running = False
+        for task in self._tasks:
+            task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks = []
+        await self.sink.flush()
+        if self.chat is not None:
+            self.chat.stop()
+        if self.twitch is not None:
+            await self.twitch.close()
+
+    async def _stream_for(self, channel: str):
+        async for stream in self.twitch.get_streams(user_login=[channel], first=1):
+            return stream
+        return None
+
+    async def _on_message(self, message) -> None:
+        channel = message.room.name.lower() if message.room else ""
+        stream = self._streams.get(channel)
+        if stream is None:
+            stream = await self._stream_for(channel)
+            if stream is not None:
+                self._streams[channel] = stream
+        if stream is not None:
+            await self.sink.handle(message, stream)
+
+    async def _flush_loop(self) -> None:
+        while self._running:
+            await asyncio.sleep(self.flush_interval)
+            await self.sink.flush()
+
+    async def _status_loop(self) -> None:
+        while self._running:
+            await asyncio.sleep(60)
+            await self._sync_channels()
+            for channel in self.channels:
+                active = self.sink.active_session(channel)
+                if active is None:
+                    continue
+                stream = await self._stream_for(channel)
+                if stream is None or int(stream.id) != active:
+                    stream_id = await self.sink.finalize(channel)
+                    self._streams.pop(channel, None)
+                    if stream_id is not None:
+                        try:
+                            await asyncio.to_thread(compute_stream_rollup, stream_id)
+                        except Exception:
+                            logger.exception(f"Live rollup failed for stream={stream_id}")
+                else:
+                    self._streams[channel] = stream
+
+    async def _sync_channels(self) -> None:
+        desired = set(self._static_channels)
+        if self.tracking_driven:
+            rows = await asyncio.to_thread(select_active_tracked_streamers_db)
+            desired.update(row[2].lower() for row in rows)
+        added = desired - self.channels
+        removed = self.channels - desired
+        if added:
+            valid = {channel for channel in added if await self._ensure_creator(channel)}
+            desired -= added - valid
+            added = valid
+            if added:
+                await self.chat.join_room(sorted(added))
+        if removed:
+            await self.chat.leave_room(sorted(removed))
+            for channel in removed:
+                await self.sink.finalize(channel)
+                self._streams.pop(channel, None)
+        self.channels = desired
+
+    async def _ensure_creator(self, channel: str) -> bool:
+        if await asyncio.to_thread(select_creator_id_db, channel):
+            return True
+        async for user in self.twitch.get_users(logins=[channel]):
+            creator_id = await asyncio.to_thread(
+                insert_new_creator_db,
+                channel,
+                user.display_name,
+                user.profile_image_url,
+                user.id,
+            )
+            return creator_id is not None
+        logger.warning(f"Cannot join unknown Twitch channel={channel}")
+        return False

--- a/backend/stream_sniper/collector/live/live_message_sink.py
+++ b/backend/stream_sniper/collector/live/live_message_sink.py
@@ -1,0 +1,114 @@
+"""Bounded, asynchronous sink from Twitch IRC events to canonical message rows."""
+
+import asyncio
+from datetime import UTC, datetime
+
+from ...database.chatter_table_gateway import insert_new_chatter_db
+from ...database.live_chat_table_gateway import (
+    bulk_insert_live_messages_db,
+    ensure_live_stream_db,
+    finalize_live_stream_db,
+)
+from ...database.message_text_table_gateway import find_or_insert_message_text_id_db
+from ...logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _emote_count(raw) -> int:
+    """Count IRC emote ranges from ``id:start-end,start-end/id:start-end``."""
+    if not raw:
+        return 0
+    return sum(
+        len(group.split(":", 1)[1].split(","))
+        for group in str(raw).split("/")
+        if ":" in group and group.split(":", 1)[1]
+    )
+
+
+class LiveMessageSink:
+    def __init__(self, buffer_size: int = 1000):
+        self.buffer_size = max(10, buffer_size)
+        self._items: list[tuple] = []
+        self._streams: dict[str, tuple[int, int]] = {}
+        self._chatters: dict[str, int] = {}
+        self._texts: dict[str, int] = {}
+        self._flush_lock = asyncio.Lock()
+
+    async def set_stream(self, channel: str, stream) -> int | None:
+        session_id = int(stream.id)
+        current = self._streams.get(channel)
+        if current and current[0] == session_id:
+            return current[1]
+        stream_id = await asyncio.to_thread(
+            ensure_live_stream_db,
+            channel,
+            session_id,
+            stream.started_at,
+            stream.title,
+            stream.thumbnail_url,
+        )
+        if stream_id is not None:
+            self._streams[channel] = (session_id, stream_id)
+        return stream_id
+
+    async def handle(self, message, stream) -> bool:
+        channel = message.room.name.lower() if message.room else None
+        if not channel or not message.id:
+            return False
+        stream_id = await self.set_stream(channel, stream)
+        if stream_id is None:
+            logger.warning(f"Ignoring live message for unknown creator channel={channel}")
+            return False
+
+        nick = message.user.name.lower()
+        chatter_id = self._chatters.get(nick)
+        if chatter_id is None:
+            chatter_id = await asyncio.to_thread(insert_new_chatter_db, nick)
+            self._chatters[nick] = chatter_id
+
+        text = message.text
+        text_id = self._texts.get(text)
+        if text_id is None:
+            text_id = await asyncio.to_thread(find_or_insert_message_text_id_db, text)
+            self._texts[text] = text_id
+
+        tagged_id = None
+        if "@" in text:
+            tagged = text.lower().split("@", 1)[1].split(" ", 1)[0].rstrip(".,:;!?")
+            tagged_id = self._chatters.get(tagged)
+        badges = message.user.badges or None
+        emote_count = _emote_count(message.emotes)
+        sent_at = datetime.fromtimestamp(message.sent_timestamp / 1000, UTC)
+        self._items.append(
+            (
+                chatter_id, tagged_id, stream_id, text_id, sent_at,
+                message.user.subscriber, badges, emote_count, message.id,
+            )
+        )
+        if len(self._items) >= self.buffer_size:
+            await self.flush()
+        return True
+
+    async def flush(self) -> None:
+        async with self._flush_lock:
+            if not self._items:
+                return
+            batch, self._items = self._items, []
+            try:
+                await asyncio.to_thread(bulk_insert_live_messages_db, batch)
+            except Exception:
+                self._items = batch + self._items
+                logger.exception(f"Live message flush failed; retained {len(batch)} rows")
+
+    async def finalize(self, channel: str, ended_at=None) -> int | None:
+        await self.flush()
+        current = self._streams.pop(channel, None)
+        if current is None:
+            return None
+        await asyncio.to_thread(finalize_live_stream_db, current[1], ended_at)
+        return current[1]
+
+    def active_session(self, channel: str) -> int | None:
+        current = self._streams.get(channel)
+        return current[0] if current else None

--- a/backend/stream_sniper/database/audience_movement_table_gateway.py
+++ b/backend/stream_sniper/database/audience_movement_table_gateway.py
@@ -1,0 +1,95 @@
+"""Windowed audience-participation movement over stream chatter rollups."""
+
+from .decorators import with_cursor
+
+_AUDIENCE_CTES = """
+    WITH current_audience AS (
+        SELECT DISTINCT scs.chatter_id
+        FROM stream_chatter_stats scs
+        JOIN stream s ON s.id = scs.stream_id
+        JOIN chatter ch ON ch.id = scs.chatter_id
+        WHERE s.creator_id = %(creator_id)s
+          AND s.start >= (now() AT TIME ZONE 'UTC') - (%(days)s * interval '1 day')
+          AND ch.is_bot IS NOT TRUE
+    ), previous_audience AS (
+        SELECT DISTINCT scs.chatter_id
+        FROM stream_chatter_stats scs
+        JOIN stream s ON s.id = scs.stream_id
+        JOIN chatter ch ON ch.id = scs.chatter_id
+        WHERE s.creator_id = %(creator_id)s
+          AND s.start >= (now() AT TIME ZONE 'UTC') - (%(days)s * 2 * interval '1 day')
+          AND s.start < (now() AT TIME ZONE 'UTC') - (%(days)s * interval '1 day')
+          AND ch.is_bot IS NOT TRUE
+    )
+"""
+
+
+@with_cursor
+def select_creator_audience_movement_db(creator_id: int, days: int, limit: int, cursor):
+    params = {"creator_id": creator_id, "days": days, "limit": limit}
+    cursor.execute(
+        _AUDIENCE_CTES
+        + """
+        SELECT
+            (SELECT count(*) FROM current_audience),
+            (SELECT count(*) FROM previous_audience),
+            (SELECT count(*) FROM current_audience c JOIN previous_audience p USING (chatter_id)),
+            (SELECT count(*) FROM current_audience c
+             LEFT JOIN previous_audience p USING (chatter_id) WHERE p.chatter_id IS NULL),
+            (SELECT count(*) FROM previous_audience p
+             LEFT JOIN current_audience c USING (chatter_id) WHERE c.chatter_id IS NULL)
+        """,
+        params,
+    )
+    summary = cursor.fetchone()
+
+    # "Sources" are other channels where this period's gained chatters participated
+    # during the previous period. A chatter may contribute to multiple channels; this is
+    # association, deliberately not a causal migration claim.
+    cursor.execute(
+        _AUDIENCE_CTES
+        + """
+        , gained AS (
+            SELECT c.chatter_id FROM current_audience c
+            LEFT JOIN previous_audience p USING (chatter_id)
+            WHERE p.chatter_id IS NULL
+        )
+        SELECT s.creator_id, cr.nick, cr.display_name, count(DISTINCT g.chatter_id)::int
+        FROM gained g
+        JOIN stream_chatter_stats scs ON scs.chatter_id = g.chatter_id
+        JOIN stream s ON s.id = scs.stream_id
+        JOIN creator cr ON cr.id = s.creator_id
+        WHERE s.creator_id <> %(creator_id)s
+          AND s.start >= (now() AT TIME ZONE 'UTC') - (%(days)s * 2 * interval '1 day')
+          AND s.start < (now() AT TIME ZONE 'UTC') - (%(days)s * interval '1 day')
+        GROUP BY s.creator_id, cr.nick, cr.display_name
+        ORDER BY count(DISTINCT g.chatter_id) DESC, s.creator_id
+        LIMIT %(limit)s
+        """,
+        params,
+    )
+    sources = cursor.fetchall()
+
+    cursor.execute(
+        _AUDIENCE_CTES
+        + """
+        , lapsed AS (
+            SELECT p.chatter_id FROM previous_audience p
+            LEFT JOIN current_audience c USING (chatter_id)
+            WHERE c.chatter_id IS NULL
+        )
+        SELECT s.creator_id, cr.nick, cr.display_name, count(DISTINCT l.chatter_id)::int
+        FROM lapsed l
+        JOIN stream_chatter_stats scs ON scs.chatter_id = l.chatter_id
+        JOIN stream s ON s.id = scs.stream_id
+        JOIN creator cr ON cr.id = s.creator_id
+        WHERE s.creator_id <> %(creator_id)s
+          AND s.start >= (now() AT TIME ZONE 'UTC') - (%(days)s * interval '1 day')
+        GROUP BY s.creator_id, cr.nick, cr.display_name
+        ORDER BY count(DISTINCT l.chatter_id) DESC, s.creator_id
+        LIMIT %(limit)s
+        """,
+        params,
+    )
+    destinations = cursor.fetchall()
+    return summary, sources, destinations

--- a/backend/stream_sniper/database/creator_table_gateway.py
+++ b/backend/stream_sniper/database/creator_table_gateway.py
@@ -46,6 +46,66 @@ def select_creators_db(cursor):
 
 
 @with_cursor
+def select_creator_summary_db(creator_id, cursor):
+    """Return a cheap, dossier-ready creator summary from rollup tables only.
+
+    The query deliberately never touches ``message``. Stream totals come from the
+    one-row-per-stream metrics table and audience totals from the one-row-per
+    creator/chatter table, so the endpoint remains suitable for the Pi deployment.
+    """
+    cursor.execute(
+        """
+        WITH stream_summary AS (
+            SELECT
+                COUNT(s.id)::int AS total_streams,
+                MIN(s.start) AS first_stream_at,
+                MAX(s.start) AS last_stream_at,
+                COALESCE(SUM(s.message_count), 0)::bigint AS total_messages,
+                SUM(sm.duration_seconds)::bigint AS duration_seconds,
+                SUM(COALESCE(sm.total_messages, 0))::float
+                    / NULLIF(SUM(COALESCE(sm.duration_seconds, 0)) / 60.0, 0)
+                    AS messages_per_minute
+            FROM stream s
+            LEFT JOIN stream_metrics sm ON sm.stream_id = s.id
+            WHERE s.creator_id = %(creator_id)s
+        ),
+        audience_summary AS (
+            SELECT
+                COUNT(*) FILTER (WHERE ch.is_bot IS NOT TRUE)::int AS audience_size,
+                COUNT(*) FILTER (
+                    WHERE ch.is_bot IS NOT TRUE AND ccs.streams_attended >= 3
+                )::int AS regulars
+            FROM creator_chatter_stats ccs
+            JOIN chatter ch ON ch.id = ccs.chatter_id
+            WHERE ccs.creator_id = %(creator_id)s
+        ),
+        latest_stream AS (
+            SELECT s.id, s.title, s.start
+            FROM stream s
+            WHERE s.creator_id = %(creator_id)s
+            ORDER BY s.start DESC NULLS LAST, s.id DESC
+            LIMIT 1
+        )
+        SELECT
+            c.id, c.nick, c.display_name, c.profile_image_url, c.twitch_id,
+            ss.total_streams,
+            TO_CHAR(ss.first_stream_at, 'YYYY-MM-DD"T"HH24:MI:SS'),
+            TO_CHAR(ss.last_stream_at, 'YYYY-MM-DD"T"HH24:MI:SS'),
+            ss.total_messages, ss.duration_seconds, ss.messages_per_minute,
+            COALESCE(a.audience_size, 0), COALESCE(a.regulars, 0),
+            ls.id, ls.title, TO_CHAR(ls.start, 'YYYY-MM-DD"T"HH24:MI:SS')
+        FROM creator c
+        CROSS JOIN stream_summary ss
+        CROSS JOIN audience_summary a
+        LEFT JOIN latest_stream ls ON TRUE
+        WHERE c.id = %(creator_id)s
+        """,
+        {"creator_id": creator_id},
+    )
+    return cursor.fetchone()
+
+
+@with_cursor
 def select_creator_top_chatters_db(creator_id, limit, cursor):
     cursor.execute(
         """

--- a/backend/stream_sniper/database/live_chat_table_gateway.py
+++ b/backend/stream_sniper/database/live_chat_table_gateway.py
@@ -1,0 +1,103 @@
+"""Persistence primitives for real-time Twitch chat capture."""
+
+from .connection_pool import get_pool
+from .decorators import with_cursor, with_cursor_connection
+
+
+@with_cursor_connection
+def ensure_live_stream_db(
+    creator_nick, session_id, started_at, title, thumbnail_url, cursor, connection,
+):
+    """Create or return the provisional stream row for a Twitch live session."""
+    cursor.execute(
+        """
+        WITH creator_row AS (
+            SELECT id FROM stream_sniper.creator WHERE lower(nick) = lower(%s)
+        ), inserted AS (
+            INSERT INTO stream_sniper.stream
+                (twitch_id, twitch_stream_session_id, start, creator_id, title,
+                 "end", thumbnail_url)
+            SELECT -(%s::bigint), %s, %s, id, left(%s, 255), NULL, left(%s, 255)
+            FROM creator_row
+            ON CONFLICT DO NOTHING
+            RETURNING id
+        )
+        SELECT id FROM inserted
+        UNION ALL
+        SELECT id FROM stream_sniper.stream WHERE twitch_stream_session_id = %s
+        LIMIT 1
+        """,
+        (creator_nick, session_id, session_id, started_at, title, thumbnail_url, session_id),
+    )
+    row = cursor.fetchone()
+    connection.commit()
+    return row[0] if row else None
+
+
+def insert_live_messages_db(items, cursor, connection):
+    """Bulk-insert IRC messages, idempotently keyed by Twitch message UUID."""
+    cursor.executemany(
+        """
+        INSERT INTO stream_sniper.message
+            (chatter_id, tagged_chatter_id, stream_id, message_text_id, time,
+             is_subscriber, badges, emote_count, source_message_id)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (source_message_id) WHERE source_message_id IS NOT NULL DO NOTHING
+        """,
+        items,
+    )
+    connection.commit()
+
+
+def bulk_insert_live_messages_db(items):
+    """Write one detached async-sink batch through the shared connection pool."""
+    if not items:
+        return
+    with get_pool().get_connection() as connection:
+        cursor = connection.cursor()
+        try:
+            insert_live_messages_db(items, cursor, connection)
+        finally:
+            cursor.close()
+
+
+@with_cursor_connection
+def finalize_live_stream_db(stream_id, ended_at, cursor, connection):
+    cursor.execute(
+        """
+        UPDATE stream_sniper.stream s
+        SET "end" = COALESCE(%s, now() AT TIME ZONE 'UTC'),
+            live_capture_complete = true,
+            message_count = (SELECT count(*) FROM stream_sniper.message m WHERE m.stream_id = s.id)
+        WHERE s.id = %s
+        """,
+        (ended_at, stream_id),
+    )
+    connection.commit()
+
+
+@with_cursor
+def select_live_stream_by_session_db(session_id, cursor):
+    cursor.execute(
+        """SELECT id, live_capture_complete
+           FROM stream_sniper.stream WHERE twitch_stream_session_id = %s""",
+        (session_id,),
+    )
+    return cursor.fetchone()
+
+
+@with_cursor_connection
+def reconcile_live_stream_vod_db(session_id, video_id, thumbnail_url, cursor, connection):
+    """Attach the later VOD id to its live row so Twitch deep-links remain valid."""
+    cursor.execute(
+        """
+        UPDATE stream_sniper.stream
+        SET twitch_id = %s, thumbnail_url = COALESCE(%s, thumbnail_url)
+        WHERE twitch_stream_session_id = %s AND live_capture_complete
+        RETURNING id
+        """,
+        (video_id, thumbnail_url, session_id),
+    )
+    row = cursor.fetchone()
+    connection.commit()
+    return row[0] if row else None

--- a/backend/stream_sniper/database/migrations/versions/0010_highlight_workflow.py
+++ b/backend/stream_sniper/database/migrations/versions/0010_highlight_workflow.py
@@ -1,0 +1,44 @@
+"""Add clip workflow metadata and states to moment reviews.
+
+Revision ID: 0010
+Revises: 0009
+"""
+
+from alembic import op
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE stream_sniper.moment_review
+            DROP CONSTRAINT IF EXISTS moment_review_status_check;
+        ALTER TABLE stream_sniper.moment_review
+            ADD COLUMN IF NOT EXISTS clip_url text NULL,
+            ADD COLUMN IF NOT EXISTS note text NULL,
+            ADD CONSTRAINT moment_review_status_check
+                CHECK (status IN ('bookmarked', 'rejected', 'clipped', 'published'));
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE stream_sniper.moment_review
+        SET status = 'bookmarked'
+        WHERE status IN ('clipped', 'published');
+        ALTER TABLE stream_sniper.moment_review
+            DROP CONSTRAINT IF EXISTS moment_review_status_check;
+        ALTER TABLE stream_sniper.moment_review
+            ADD CONSTRAINT moment_review_status_check
+                CHECK (status IN ('bookmarked', 'rejected'));
+        ALTER TABLE stream_sniper.moment_review
+            DROP COLUMN IF EXISTS note,
+            DROP COLUMN IF EXISTS clip_url;
+        """
+    )

--- a/backend/stream_sniper/database/migrations/versions/0011_scene_events.py
+++ b/backend/stream_sniper/database/migrations/versions/0011_scene_events.py
@@ -1,0 +1,40 @@
+"""Add deterministic scene-event feed storage.
+
+Revision ID: 0011
+Revises: 0010
+"""
+
+from alembic import op
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS stream_sniper.scene_event (
+            id              bigserial   PRIMARY KEY,
+            event_type      text        NOT NULL,
+            occurred_at     timestamp   NOT NULL,
+            creator_id      int         NULL REFERENCES stream_sniper.creator (id),
+            stream_id       int         NULL REFERENCES stream_sniper.stream (id),
+            message_text_id bigint      NULL REFERENCES stream_sniper.message_text (id),
+            title           text        NOT NULL,
+            summary         text        NOT NULL,
+            metadata        jsonb       NOT NULL DEFAULT '{}'::jsonb,
+            dedupe_key      text        NOT NULL UNIQUE,
+            created_at      timestamptz NOT NULL DEFAULT now()
+        );
+        CREATE INDEX IF NOT EXISTS scene_event_occurred_idx
+            ON stream_sniper.scene_event (occurred_at DESC, id DESC);
+        CREATE INDEX IF NOT EXISTS scene_event_creator_idx
+            ON stream_sniper.scene_event (creator_id, occurred_at DESC);
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS stream_sniper.scene_event")

--- a/backend/stream_sniper/database/migrations/versions/0012_stream_context_history.py
+++ b/backend/stream_sniper/database/migrations/versions/0012_stream_context_history.py
@@ -1,0 +1,42 @@
+"""Capture title/category/tag context during live tracking.
+
+Revision ID: 0012
+Revises: 0011
+"""
+
+from alembic import op
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS stream_sniper.stream_context_sample (
+            id                       bigserial   PRIMARY KEY,
+            tracked_streamer_id      int         NOT NULL
+                REFERENCES stream_sniper.tracked_streamers (id),
+            twitch_stream_session_id bigint      NOT NULL,
+            sampled_at               timestamptz NOT NULL,
+            session_started_at       timestamptz NULL,
+            title                    text        NULL,
+            category_id              text        NULL,
+            category_name            text        NULL,
+            language                 text        NULL,
+            tags                     jsonb       NULL,
+            is_mature                boolean     NULL,
+            CONSTRAINT stream_context_sample_uq
+                UNIQUE (tracked_streamer_id, twitch_stream_session_id, sampled_at)
+        );
+        CREATE INDEX IF NOT EXISTS stream_context_sample_session_idx
+            ON stream_sniper.stream_context_sample
+               (tracked_streamer_id, twitch_stream_session_id, sampled_at);
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS stream_sniper.stream_context_sample")

--- a/backend/stream_sniper/database/migrations/versions/0013_live_chat_capture.py
+++ b/backend/stream_sniper/database/migrations/versions/0013_live_chat_capture.py
@@ -1,0 +1,44 @@
+"""Add live chat session identity and message deduplication.
+
+Revision ID: 0013
+Revises: 0012
+"""
+
+from alembic import op
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE stream_sniper.stream
+            ADD COLUMN IF NOT EXISTS twitch_stream_session_id bigint NULL,
+            ADD COLUMN IF NOT EXISTS live_capture_complete boolean NOT NULL DEFAULT false;
+        CREATE UNIQUE INDEX IF NOT EXISTS stream_twitch_session_uq
+            ON stream_sniper.stream (twitch_stream_session_id)
+            WHERE twitch_stream_session_id IS NOT NULL;
+
+        ALTER TABLE stream_sniper.message
+            ADD COLUMN IF NOT EXISTS source_message_id text NULL;
+        CREATE UNIQUE INDEX IF NOT EXISTS message_source_message_id_uq
+            ON stream_sniper.message (source_message_id)
+            WHERE source_message_id IS NOT NULL;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DROP INDEX IF EXISTS stream_sniper.message_source_message_id_uq;
+        ALTER TABLE stream_sniper.message DROP COLUMN IF EXISTS source_message_id;
+        DROP INDEX IF EXISTS stream_sniper.stream_twitch_session_uq;
+        ALTER TABLE stream_sniper.stream
+            DROP COLUMN IF EXISTS live_capture_complete,
+            DROP COLUMN IF EXISTS twitch_stream_session_id;
+        """
+    )

--- a/backend/stream_sniper/database/moment_review_table_gateway.py
+++ b/backend/stream_sniper/database/moment_review_table_gateway.py
@@ -8,18 +8,22 @@ from .decorators import with_cursor_connection
 
 
 @with_cursor_connection
-def upsert_moment_review_db(stream_id, bucket_minute, status, cursor, connection):
-    """Set a moment's review status (bookmarked/rejected); returns the new updated_at."""
+def upsert_moment_review_db(
+    stream_id, bucket_minute, status, cursor, connection, *, clip_url=None, note=None
+):
+    """Set workflow status and optional clip metadata; returns the new updated_at."""
     cursor.execute(
         """
-        INSERT INTO moment_review (stream_id, bucket_minute, status, updated_at)
-        VALUES (%s, %s, %s, now())
+        INSERT INTO moment_review (stream_id, bucket_minute, status, clip_url, note, updated_at)
+        VALUES (%s, %s, %s, %s, %s, now())
         ON CONFLICT (stream_id, bucket_minute) DO UPDATE SET
             status = EXCLUDED.status,
+            clip_url = EXCLUDED.clip_url,
+            note = EXCLUDED.note,
             updated_at = EXCLUDED.updated_at
         RETURNING TO_CHAR(updated_at, 'YYYY-MM-DD"T"HH24:MI:SS')
         """,
-        (stream_id, bucket_minute, status),
+        (stream_id, bucket_minute, status, clip_url, note),
     )
     updated_at = cursor.fetchone()[0]
     connection.commit()

--- a/backend/stream_sniper/database/scene_event_table_gateway.py
+++ b/backend/stream_sniper/database/scene_event_table_gateway.py
@@ -1,0 +1,130 @@
+"""Small-table persistence and reads for deterministic scene events."""
+
+from psycopg2.extras import Json, execute_values
+
+from .decorators import with_cursor, with_cursor_connection
+
+
+@with_cursor
+def select_stream_event_signals_db(stream_id, cursor):
+    cursor.execute(
+        """
+        SELECT s.id, s.creator_id, c.display_name, s.title,
+               TO_CHAR(COALESCE(s."end", s.start), 'YYYY-MM-DD"T"HH24:MI:SS'),
+               sm.total_messages, sm.unique_chatters, sm.messages_per_minute,
+               (SELECT max(pm.total_messages)
+                FROM stream_metrics pm JOIN stream ps ON ps.id = pm.stream_id
+                WHERE ps.creator_id = s.creator_id AND (ps.start, ps.id) < (s.start, s.id)),
+               (SELECT max(pm.unique_chatters)
+                FROM stream_metrics pm JOIN stream ps ON ps.id = pm.stream_id
+                WHERE ps.creator_id = s.creator_id AND (ps.start, ps.id) < (s.start, s.id)),
+               (SELECT max(pm.messages_per_minute)
+                FROM stream_metrics pm JOIN stream ps ON ps.id = pm.stream_id
+                WHERE ps.creator_id = s.creator_id AND (ps.start, ps.id) < (s.start, s.id))
+        FROM stream s
+        JOIN creator c ON c.id = s.creator_id
+        LEFT JOIN stream_metrics sm ON sm.stream_id = s.id
+        WHERE s.id = %s
+        """,
+        (stream_id,),
+    )
+    header = cursor.fetchone()
+
+    cursor.execute(
+        """
+        SELECT TO_CHAR(sm.bucket_minute, 'YYYY-MM-DD"T"HH24:MI:SS'),
+               sm.ratio::double precision, sm.message_count
+        FROM stream_moment sm
+        LEFT JOIN moment_review mr
+          ON mr.stream_id = sm.stream_id AND mr.bucket_minute = sm.bucket_minute
+        WHERE sm.stream_id = %s AND mr.status IS DISTINCT FROM 'rejected'
+        ORDER BY sm.ratio DESC NULLS LAST, sm.bucket_minute
+        LIMIT 1
+        """,
+        (stream_id,),
+    )
+    moment = cursor.fetchone()
+
+    cursor.execute(
+        """
+        SELECT scs.message_text_id, mt.text, scs.usage_count,
+               (SELECT count(DISTINCT os.creator_id)
+                FROM stream_copypasta_stats o
+                JOIN stream os ON os.id = o.stream_id
+                WHERE o.message_text_id = scs.message_text_id) AS creator_count
+        FROM stream_copypasta_stats scs
+        JOIN message_text mt ON mt.id = scs.message_text_id
+        WHERE scs.stream_id = %s
+          AND EXISTS (
+              SELECT 1 FROM stream_copypasta_stats earlier
+              JOIN stream es ON es.id = earlier.stream_id
+              JOIN stream current_stream ON current_stream.id = scs.stream_id
+              WHERE earlier.message_text_id = scs.message_text_id
+                AND es.creator_id <> current_stream.creator_id
+                AND (earlier.first_seen, earlier.stream_id) < (scs.first_seen, scs.stream_id)
+          )
+        ORDER BY creator_count DESC, scs.usage_count DESC
+        LIMIT 3
+        """,
+        (stream_id,),
+    )
+    return header, moment, cursor.fetchall()
+
+
+@with_cursor_connection
+def replace_stream_scene_events_db(stream_id, events, cursor, connection):
+    cursor.execute("DELETE FROM scene_event WHERE stream_id = %s", (stream_id,))
+    if events:
+        execute_values(
+            cursor,
+            """
+            INSERT INTO scene_event
+                (event_type, occurred_at, creator_id, stream_id, message_text_id,
+                 title, summary, metadata, dedupe_key)
+            VALUES %s
+            ON CONFLICT (dedupe_key) DO UPDATE SET
+                occurred_at = EXCLUDED.occurred_at,
+                title = EXCLUDED.title,
+                summary = EXCLUDED.summary,
+                metadata = EXCLUDED.metadata
+            """,
+            [
+                (
+                    event["event_type"], event["occurred_at"], event["creator_id"],
+                    stream_id, event.get("message_text_id"), event["title"],
+                    event["summary"], Json(event.get("metadata", {})), event["dedupe_key"],
+                )
+                for event in events
+            ],
+        )
+    connection.commit()
+
+
+@with_cursor
+def select_scene_events_db(days, event_type, creator_id, limit, offset, cursor):
+    filters = ["se.occurred_at >= (now() AT TIME ZONE 'UTC') - (%s * interval '1 day')"]
+    params = [days]
+    if event_type:
+        filters.append("se.event_type = %s")
+        params.append(event_type)
+    if creator_id is not None:
+        filters.append("se.creator_id = %s")
+        params.append(creator_id)
+    where = " AND ".join(filters)
+    cursor.execute(f"SELECT count(*) FROM scene_event se WHERE {where}", tuple(params))
+    total = cursor.fetchone()[0]
+    cursor.execute(
+        f"""
+        SELECT se.id, se.event_type,
+               TO_CHAR(se.occurred_at, 'YYYY-MM-DD"T"HH24:MI:SS'),
+               se.creator_id, c.nick, c.display_name, se.stream_id, se.message_text_id,
+               se.title, se.summary, se.metadata
+        FROM scene_event se
+        LEFT JOIN creator c ON c.id = se.creator_id
+        WHERE {where}
+        ORDER BY se.occurred_at DESC, se.id DESC
+        LIMIT %s OFFSET %s
+        """,
+        tuple(params) + (limit, offset),
+    )
+    return cursor.fetchall(), total

--- a/backend/stream_sniper/database/stream_compare_table_gateway.py
+++ b/backend/stream_sniper/database/stream_compare_table_gateway.py
@@ -1,0 +1,69 @@
+"""Bounded rollup queries for comparing two to four streams."""
+
+from .decorators import with_cursor
+
+
+@with_cursor
+def select_stream_compare_headers_db(stream_ids, cursor):
+    cursor.execute(
+        """
+        SELECT
+            s.id, s.creator_id, c.nick, c.display_name, s.title,
+            TO_CHAR(s.start, 'YYYY-MM-DD"T"HH24:MI:SS'),
+            sm.duration_seconds, sm.total_messages, sm.messages_per_minute,
+            sm.unique_chatters, sm.new_chatters, sm.returning_chatters,
+            sm.sub_messages, sm.emote_messages, sm.peak_messages,
+            TO_CHAR(sm.peak_bucket_minute, 'YYYY-MM-DD"T"HH24:MI:SS')
+        FROM stream s
+        JOIN creator c ON c.id = s.creator_id
+        LEFT JOIN stream_metrics sm ON sm.stream_id = s.id
+        WHERE s.id = ANY(%s)
+        """,
+        (stream_ids,),
+    )
+    return cursor.fetchall()
+
+
+@with_cursor
+def select_stream_compare_buckets_db(stream_ids, cursor):
+    cursor.execute(
+        """
+        SELECT stb.stream_id,
+               TO_CHAR(stb.bucket_minute, 'YYYY-MM-DD"T"HH24:MI:SS'),
+               stb.message_count, stb.unique_chatters
+        FROM stream_time_bucket stb
+        WHERE stb.stream_id = ANY(%s)
+        ORDER BY stb.stream_id, stb.bucket_minute
+        """,
+        (stream_ids,),
+    )
+    return cursor.fetchall()
+
+
+@with_cursor
+def select_stream_pair_retention_db(stream_ids, cursor):
+    """Audience overlap for each adjacent pair in the caller's chosen order."""
+    cursor.execute(
+        """
+        WITH requested AS (
+            SELECT stream_id, ordinal::int
+            FROM unnest(%s::int[]) WITH ORDINALITY AS r(stream_id, ordinal)
+        ), pairs AS (
+            SELECT a.stream_id AS from_id, b.stream_id AS to_id
+            FROM requested a
+            JOIN requested b ON b.ordinal = a.ordinal + 1
+        )
+        SELECT p.from_id, p.to_id,
+               (SELECT count(*) FROM stream_chatter_stats WHERE stream_id = p.from_id) AS from_size,
+               (SELECT count(*) FROM stream_chatter_stats WHERE stream_id = p.to_id) AS to_size,
+               (SELECT count(*)
+                FROM stream_chatter_stats a
+                JOIN stream_chatter_stats b ON b.chatter_id = a.chatter_id
+                JOIN chatter ch ON ch.id = a.chatter_id
+                WHERE a.stream_id = p.from_id AND b.stream_id = p.to_id
+                  AND ch.is_bot IS NOT TRUE) AS retained
+        FROM pairs p
+        """,
+        (stream_ids,),
+    )
+    return cursor.fetchall()

--- a/backend/stream_sniper/database/stream_context_table_gateway.py
+++ b/backend/stream_sniper/database/stream_context_table_gateway.py
@@ -1,0 +1,95 @@
+"""Live stream context snapshots and VOD-time-window linkage."""
+
+from psycopg2.extras import Json
+
+from ..logging_config import get_logger
+from .connection_pool import get_pool
+from .decorators import log_database_operation, with_cursor
+
+logger = get_logger(__name__)
+
+
+@log_database_operation
+def insert_stream_context_sample_db(
+    tracked_streamer_id, twitch_stream_session_id, sampled_at, session_started_at,
+    title, category_id, category_name, language, tags, is_mature,
+) -> bool:
+    """Persist a context snapshot without ever disrupting the monitor loop."""
+    try:
+        with get_pool().get_cursor(commit=True) as cursor:
+            cursor.execute(
+                """
+                INSERT INTO stream_sniper.stream_context_sample
+                    (tracked_streamer_id, twitch_stream_session_id, sampled_at,
+                     session_started_at, title, category_id, category_name,
+                     language, tags, is_mature)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (tracked_streamer_id, twitch_stream_session_id, sampled_at)
+                DO NOTHING
+                """,
+                (
+                    tracked_streamer_id, twitch_stream_session_id, sampled_at,
+                    session_started_at, title, category_id, category_name,
+                    language, Json(tags) if tags is not None else None, is_mature,
+                ),
+            )
+        return True
+    except Exception as exc:
+        logger.error(
+            f"Error inserting stream context for tracked_streamer_id={tracked_streamer_id}, "
+            f"session={twitch_stream_session_id}: {exc}"
+        )
+        return False
+
+
+@with_cursor
+def select_stream_context_changes_db(stream_id, cursor):
+    """Return only changed context states linked to a stored VOD by creator/time."""
+    cursor.execute(
+        """
+        WITH tgt AS (
+            SELECT s.creator_id, s.start AS s_start,
+                   s.start - interval '10 minutes' AS win_start,
+                   COALESCE(s."end", s.start + interval '12 hours') + interval '30 minutes' AS win_end
+            FROM stream s WHERE s.id = %s
+        ), windowed AS (
+            SELECT scs.*
+            FROM stream_context_sample scs
+            JOIN tracked_streamers ts ON ts.id = scs.tracked_streamer_id
+            JOIN tgt t ON t.creator_id = ts.creator_id
+            WHERE scs.sampled_at AT TIME ZONE 'UTC' BETWEEN t.win_start AND t.win_end
+        ), best_session AS (
+            SELECT w.twitch_stream_session_id
+            FROM windowed w CROSS JOIN tgt t
+            WHERE w.session_started_at IS NOT NULL
+              AND abs(EXTRACT(EPOCH FROM
+                  (w.session_started_at AT TIME ZONE 'UTC' - t.s_start))) <= 900
+            GROUP BY w.twitch_stream_session_id
+            ORDER BY min(abs(EXTRACT(EPOCH FROM
+                (w.session_started_at AT TIME ZONE 'UTC' - t.s_start))))
+            LIMIT 1
+        ), selected AS (
+            SELECT w.* FROM windowed w
+            WHERE NOT EXISTS (SELECT 1 FROM best_session)
+               OR w.twitch_stream_session_id = (SELECT twitch_stream_session_id FROM best_session)
+        ), states AS (
+            SELECT s.*, row_number() OVER (ORDER BY sampled_at, id) AS rn,
+                   lag(title) OVER (ORDER BY sampled_at, id) AS previous_title,
+                   lag(category_id) OVER (ORDER BY sampled_at, id) AS previous_category_id,
+                   lag(language) OVER (ORDER BY sampled_at, id) AS previous_language,
+                   lag(tags) OVER (ORDER BY sampled_at, id) AS previous_tags
+            FROM selected s
+        )
+        SELECT TO_CHAR(sampled_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS'),
+               title, category_id, category_name, language, tags, is_mature
+        FROM states
+        WHERE rn = 1
+           OR title IS DISTINCT FROM previous_title
+           OR category_id IS DISTINCT FROM previous_category_id
+           OR language IS DISTINCT FROM previous_language
+           OR tags IS DISTINCT FROM previous_tags
+        ORDER BY sampled_at, id
+        """,
+        (stream_id,),
+    )
+    return cursor.fetchall()

--- a/backend/stream_sniper/database/stream_copypasta_stats_table_gateway.py
+++ b/backend/stream_sniper/database/stream_copypasta_stats_table_gateway.py
@@ -143,3 +143,53 @@ def select_scene_copypastas_db(
     )
     rows = cursor.fetchall()
     return rows, total
+
+
+@with_cursor
+def select_copypasta_propagation_db(message_text_id: int, cursor):
+    """Return the text plus every per-stream occurrence in chronological order."""
+    cursor.execute("SELECT text FROM message_text WHERE id = %s", (message_text_id,))
+    text_row = cursor.fetchone()
+    if text_row is None:
+        return None, []
+
+    cursor.execute(
+        """
+        SELECT
+            scs.stream_id, s.creator_id, c.nick, c.display_name, c.profile_image_url,
+            s.title, TO_CHAR(s.start, 'YYYY-MM-DD"T"HH24:MI:SS'),
+            TO_CHAR(scs.first_seen, 'YYYY-MM-DD"T"HH24:MI:SS'),
+            scs.usage_count, scs.chatter_count
+        FROM stream_copypasta_stats scs
+        JOIN stream s ON s.id = scs.stream_id
+        JOIN creator c ON c.id = s.creator_id
+        WHERE scs.message_text_id = %s
+        ORDER BY scs.first_seen ASC NULLS LAST, scs.stream_id ASC
+        """,
+        (message_text_id,),
+    )
+    return text_row[0], cursor.fetchall()
+
+
+@with_cursor
+def select_copypasta_context_db(stream_id: int, first_seen: str, seconds: int, limit: int, cursor):
+    """Messages surrounding one occurrence, supported by message(stream_id,time,id)."""
+    cursor.execute(
+        """
+        SELECT id, TO_CHAR(time, 'YYYY-MM-DD"T"HH24:MI:SS.US'), chatter_id, nick, text
+        FROM (
+            SELECT m.id, m.time, m.chatter_id, c.nick, mt.text
+            FROM message m
+            JOIN chatter c ON c.id = m.chatter_id
+            JOIN message_text mt ON mt.id = m.message_text_id
+            WHERE m.stream_id = %s
+              AND m.time BETWEEN %s::timestamp - (%s * interval '1 second')
+                             AND %s::timestamp + (%s * interval '1 second')
+            ORDER BY ABS(EXTRACT(EPOCH FROM (m.time - %s::timestamp))), m.id
+            LIMIT %s
+        ) context
+        ORDER BY time ASC, id ASC
+        """,
+        (stream_id, first_seen, seconds, first_seen, seconds, first_seen, limit),
+    )
+    return cursor.fetchall()

--- a/backend/stream_sniper/database/stream_moment_table_gateway.py
+++ b/backend/stream_sniper/database/stream_moment_table_gateway.py
@@ -19,6 +19,8 @@ _QUEUE_STATUS_CLAUSE = {
     "pending": "mr.status IS NULL",
     "bookmarked": "mr.status = 'bookmarked'",
     "rejected": "mr.status = 'rejected'",
+    "clipped": "mr.status = 'clipped'",
+    "published": "mr.status = 'published'",
 }
 
 
@@ -37,7 +39,9 @@ def select_stream_moments_db(stream_id, cursor):
             sm.emote_share::double precision,
             sm.top_phrases,
             sm.sample_messages,
-            mr.status
+            mr.status,
+            mr.clip_url,
+            mr.note
         FROM stream_moment sm
         LEFT JOIN moment_review mr
             ON mr.stream_id = sm.stream_id AND mr.bucket_minute = sm.bucket_minute
@@ -56,7 +60,7 @@ def select_moment_queue_db(status, creator_id, limit, offset, cursor):
     Returns (rows, total). Each row:
       (stream_id, title, start, twitch_id, creator_id, creator_display_name,
        bucket_minute, offset_seconds, message_count, baseline, ratio, unique_chatters,
-       sub_share, emote_share, top_phrases, sample_messages, status)
+       sub_share, emote_share, top_phrases, sample_messages, status, clip_url, note)
     where status is NULL for pending (no moment_review row). `status` filters through a
     hardcoded whitelist; `creator_id` (optional) restricts to one creator. Ordering places
     reviewed moments first by recency, then pending moments by spike ratio.
@@ -106,7 +110,9 @@ def select_moment_queue_db(status, creator_id, limit, offset, cursor):
             sm.emote_share::double precision,
             sm.top_phrases,
             sm.sample_messages,
-            mr.status
+            mr.status,
+            mr.clip_url,
+            mr.note
         FROM stream_moment sm
         JOIN stream s ON s.id = sm.stream_id
         LEFT JOIN creator c ON c.id = s.creator_id

--- a/backend/stream_sniper/live_auth_cli.py
+++ b/backend/stream_sniper/live_auth_cli.py
@@ -1,0 +1,50 @@
+"""One-time browser bootstrap for the live chat bot refresh token."""
+
+import argparse
+import asyncio
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+from twitchAPI.oauth import UserAuthenticator
+from twitchAPI.twitch import Twitch
+from twitchAPI.type import AuthScope
+
+
+def _save_token(output: Path, refresh_token: str) -> Path:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(refresh_token)
+    output.chmod(0o600)
+    return output.resolve()
+
+
+async def authenticate(output: Path) -> None:
+    client_id = os.environ.get("TWITCH_CLIENT_ID")
+    client_secret = os.environ.get("TWITCH_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        raise RuntimeError("TWITCH_CLIENT_ID and TWITCH_CLIENT_SECRET must be set")
+    twitch = await Twitch(client_id, client_secret)
+    try:
+        authenticator = UserAuthenticator(twitch, [AuthScope.CHAT_READ])
+        _, refresh_token = await authenticator.authenticate()
+        saved_to = await asyncio.to_thread(_save_token, output, refresh_token)
+        print(f"Refresh token saved to {saved_to} with mode 0600")
+    finally:
+        await twitch.close()
+
+
+def main() -> None:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description="Authorize the read-only Twitch chat bot")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(".live-refresh-token"),
+        help="Secure file receiving the refresh token",
+    )
+    args = parser.parse_args()
+    asyncio.run(authenticate(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/stream_sniper/live_service.py
+++ b/backend/stream_sniper/live_service.py
@@ -1,0 +1,31 @@
+"""Management command for the standalone live Twitch chat collector."""
+
+import asyncio
+import signal
+from contextlib import suppress
+
+from dotenv import load_dotenv
+
+from .collector.live import LiveChatCollector
+from .logging_config import get_logger, setup_logging
+
+
+async def main() -> None:
+    load_dotenv()
+    setup_logging(environment="production")
+    logger = get_logger(__name__)
+    collector = LiveChatCollector()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with suppress(NotImplementedError):
+            loop.add_signal_handler(sig, lambda: asyncio.create_task(collector.stop()))
+    logger.info("Starting standalone live chat capture")
+    await collector.start()
+
+
+def run_live_service() -> None:
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    run_live_service()

--- a/backend/stream_sniper/tracking/stream_monitor.py
+++ b/backend/stream_sniper/tracking/stream_monitor.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 
 from ..collector.twitch_api import TwitchAPI
 from ..database.processing_jobs_table_gateway import insert_processing_job_db, job_exists_db
+from ..database.stream_context_table_gateway import insert_stream_context_sample_db
 from ..database.stream_viewer_sample_table_gateway import insert_stream_viewer_sample_db
 from ..database.tracked_streamers_table_gateway import (
     select_active_tracked_streamers_db,
@@ -28,6 +29,11 @@ class StreamStatus:
     title: Optional[str] = None
     started_at: Optional[datetime] = None
     viewer_count: Optional[int] = None
+    category_id: Optional[str] = None
+    category_name: Optional[str] = None
+    language: Optional[str] = None
+    tags: Optional[List[str]] = None
+    is_mature: Optional[bool] = None
     last_checked: Optional[datetime] = None
 
 
@@ -156,6 +162,11 @@ class StreamMonitor:
                     title=stream_info.title,
                     started_at=stream_info.started_at,
                     viewer_count=stream_info.viewer_count,
+                    category_id=stream_info.game_id,
+                    category_name=stream_info.game_name,
+                    language=stream_info.language,
+                    tags=list(stream_info.tags or []),
+                    is_mature=stream_info.is_mature,
                     last_checked=datetime.now()
                 )
             else:
@@ -174,15 +185,28 @@ class StreamMonitor:
             )
 
     def _record_viewer_snapshot(self, tracked_streamer_id: int, status: StreamStatus) -> None:
-        """Persist a viewer-count snapshot for a live stream. Never raises."""
+        """Persist viewer and context snapshots for a live stream. Never raises."""
         try:
+            sampled_at = datetime.now(UTC)
             insert_stream_viewer_sample_db(
                 tracked_streamer_id=tracked_streamer_id,
                 twitch_stream_session_id=status.stream_id,
-                sampled_at=datetime.now(UTC),
+                sampled_at=sampled_at,
                 viewer_count=status.viewer_count,
                 title=status.title,
                 session_started_at=status.started_at,
+            )
+            insert_stream_context_sample_db(
+                tracked_streamer_id=tracked_streamer_id,
+                twitch_stream_session_id=status.stream_id,
+                sampled_at=sampled_at,
+                session_started_at=status.started_at,
+                title=status.title,
+                category_id=status.category_id,
+                category_name=status.category_name,
+                language=status.language,
+                tags=status.tags,
+                is_mature=status.is_mature,
             )
         except Exception as e:
             self.logger.error(f"Error recording viewer snapshot for ts_id={tracked_streamer_id}: {e}")

--- a/backend/tests/unit/analytics/__init__.py
+++ b/backend/tests/unit/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Analytics unit-test package."""

--- a/backend/tests/unit/analytics/test_scene_events.py
+++ b/backend/tests/unit/analytics/test_scene_events.py
@@ -1,0 +1,42 @@
+"""Tests for deterministic scene-event derivation and digest formatting."""
+
+from unittest.mock import patch
+
+from stream_sniper.analytics.digest import format_digest
+from stream_sniper.analytics.scene_events import refresh_stream_events
+
+
+@patch("stream_sniper.analytics.scene_events.replace_stream_scene_events_db")
+@patch("stream_sniper.analytics.scene_events.select_stream_event_signals_db")
+def test_refresh_builds_report_records_moment_and_spread(signals, replace):
+    signals.return_value = (
+        (42, 5, "Alice", "Big show", "2024-01-02T22:00:00", 2000, 300, 20.0, 1500, 250, 18.0),
+        ("2024-01-02T21:00:00", 6.5, 120),
+        [(99, "legendary pasta", 12, 3)],
+    )
+
+    count = refresh_stream_events(42)
+
+    assert count == 6
+    events = replace.call_args.args[1]
+    assert {event["event_type"] for event in events} == {
+        "stream_report", "personal_record", "standout_moment", "copypasta_spread"
+    }
+    assert len({event["dedupe_key"] for event in events}) == 6
+    assert next(e for e in events if e["event_type"] == "copypasta_spread")["message_text_id"] == 99
+
+
+@patch("stream_sniper.analytics.scene_events.replace_stream_scene_events_db")
+@patch("stream_sniper.analytics.scene_events.select_stream_event_signals_db")
+def test_unrolled_stream_clears_events(signals, replace):
+    signals.return_value = ((42, 5, "Alice", "No rollup", "2024-01-02T22:00:00", None, None, None, None, None, None), None, [])
+    assert refresh_stream_events(42) == 0
+    replace.assert_called_once_with(42, [])
+
+
+def test_digest_is_deterministic_markdown():
+    rows = [(1, "personal_record", "2024-01-02T22:00:00", 5, "alice", "Alice", 42, None, "New record", "2,000", {})]
+    digest = format_digest(rows, 7)
+    assert digest.startswith("## Stream Sniper · 7-day scene pulse")
+    assert "**New record**" in digest
+    assert "Alice" in digest

--- a/backend/tests/unit/api/__init__.py
+++ b/backend/tests/unit/api/__init__.py
@@ -1,0 +1,1 @@
+"""API unit-test package."""

--- a/backend/tests/unit/api/test_audience_movement.py
+++ b/backend/tests/unit/api/test_audience_movement.py
@@ -1,0 +1,44 @@
+"""Unit tests for windowed audience participation movement."""
+
+from unittest.mock import Mock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stream_sniper.api.audience_endpoints import router
+from stream_sniper.api.rate_limiter import setup_rate_limiting
+
+
+def _client():
+    app = FastAPI()
+    setup_rate_limiting(app)
+    app.include_router(router)
+    return TestClient(app)
+
+
+@patch("stream_sniper.api.audience_endpoints.get_cache")
+@patch("stream_sniper.api.audience_endpoints.select_creator_audience_movement_db")
+def test_audience_movement_maps_window_and_associations(gateway, get_cache):
+    cache = Mock()
+    cache._generate_key.return_value = "key"
+    cache.get.return_value = None
+    get_cache.return_value = cache
+    gateway.return_value = (
+        (100, 80, 60, 40, 20),
+        [(2, "source", "Source", 12)],
+        [(3, "dest", "Destination", 8)],
+    )
+
+    response = _client().get("/creator/5/audience-movement?days=30")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["retention_rate"] == 0.75
+    assert data["gain_rate"] == 0.4
+    assert data["prior_channels_for_gained"][0]["creator_id"] == 2
+    gateway.assert_called_once_with(5, 30, 8)
+
+
+def test_audience_window_is_bounded():
+    assert _client().get("/creator/5/audience-movement?days=6").status_code == 422
+    assert _client().get("/creator/5/audience-movement?days=91").status_code == 422

--- a/backend/tests/unit/api/test_compare.py
+++ b/backend/tests/unit/api/test_compare.py
@@ -1,0 +1,65 @@
+"""Unit tests for the bounded stream-comparison endpoint."""
+
+from unittest.mock import Mock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stream_sniper.api.compare_endpoints import _normalise_curve, router
+from stream_sniper.api.rate_limiter import setup_rate_limiting
+
+
+def _client():
+    app = FastAPI()
+    setup_rate_limiting(app)
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _cache():
+    cache = Mock()
+    cache._generate_key.return_value = "key"
+    cache.get.return_value = None
+    return cache
+
+
+def test_normalise_curve_uses_percentage_slots():
+    rows = [
+        (1, "2024-01-01T20:00:00", 10, 5),
+        (1, "2024-01-01T20:05:00", 20, 8),
+        (1, "2024-01-01T20:10:00", 30, 10),
+    ]
+    points = _normalise_curve(rows, "2024-01-01T20:00:00", 600)
+    assert [point.percent for point in points] == [0, 50, 100]
+
+
+@patch("stream_sniper.api.compare_endpoints.get_cache")
+@patch("stream_sniper.api.compare_endpoints.select_stream_pair_retention_db")
+@patch("stream_sniper.api.compare_endpoints.select_stream_viewer_samples_db")
+@patch("stream_sniper.api.compare_endpoints.select_stream_compare_buckets_db")
+@patch("stream_sniper.api.compare_endpoints.select_stream_compare_headers_db")
+def test_compare_maps_metrics_curve_and_retention(headers, buckets, samples, retention, get_cache):
+    get_cache.return_value = _cache()
+    headers.return_value = [
+        (1, 10, "a", "A", "One", "2024-01-01T20:00:00", 600, 100, 10.0, 20, 8, 12, 25, 50, 30, "2024-01-01T20:05:00"),
+        (2, 10, "a", "A", "Two", "2024-01-02T20:00:00", 600, 200, 20.0, 30, 10, 20, 40, 80, 50, "2024-01-02T20:05:00"),
+    ]
+    buckets.return_value = [
+        (1, "2024-01-01T20:00:00", 10, 5),
+        (2, "2024-01-02T20:00:00", 20, 8),
+    ]
+    samples.side_effect = [[("x", 50)], [("y", 80)]]
+    retention.return_value = [(1, 2, 20, 30, 12)]
+
+    response = _client().get("/streams/compare?stream_ids=1&stream_ids=2")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["streams"][0]["sub_share"] == 0.25
+    assert data["streams"][1]["peak_viewers"] == 80
+    assert data["retention"][0]["retention_rate"] == 0.6
+
+
+def test_compare_requires_unique_two_to_four_ids():
+    assert _client().get("/streams/compare?stream_ids=1").status_code == 422
+    assert _client().get("/streams/compare?stream_ids=1&stream_ids=1").status_code == 422

--- a/backend/tests/unit/api/test_creator_analytics.py
+++ b/backend/tests/unit/api/test_creator_analytics.py
@@ -119,6 +119,91 @@ class TestCreatorTrendsEndpoint:
         assert response.json()["detail"] == "Internal server error"
 
 
+class TestCreatorSummaryEndpoint:
+    """Test suite for GET /creator/{creator_id}/summary."""
+
+    @patch("stream_sniper.api.analytics_endpoints.get_cache")
+    @patch("stream_sniper.api.analytics_endpoints.select_creator_summary_db")
+    def test_summary_maps_rollup_row(self, mock_summary, mock_get_cache):
+        mock_get_cache.return_value = _miss_cache()
+        mock_summary.return_value = (
+            5,
+            "alice",
+            "Alice",
+            "https://example.com/avatar.png",
+            "12345",
+            12,
+            "2024-01-01T20:00:00",
+            "2024-02-01T20:00:00",
+            15000,
+            72000,
+            12.5,
+            900,
+            75,
+            99,
+            "Latest stream",
+            "2024-02-01T20:00:00",
+        )
+
+        with TestClient(app) as client:
+            response = client.get("/creator/5/summary")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "creator_id": 5,
+            "nick": "alice",
+            "display_name": "Alice",
+            "profile_image_url": "https://example.com/avatar.png",
+            "twitch_id": "12345",
+            "total_streams": 12,
+            "first_stream_at": "2024-01-01T20:00:00",
+            "last_stream_at": "2024-02-01T20:00:00",
+            "total_messages": 15000,
+            "duration_seconds": 72000,
+            "messages_per_minute": 12.5,
+            "audience_size": 900,
+            "regulars": 75,
+            "latest_stream": {
+                "stream_id": 99,
+                "title": "Latest stream",
+                "start": "2024-02-01T20:00:00",
+            },
+        }
+        mock_summary.assert_called_once_with(5)
+
+    @patch("stream_sniper.api.analytics_endpoints.get_cache")
+    @patch("stream_sniper.api.analytics_endpoints.select_creator_summary_db")
+    def test_summary_missing_creator_404(self, mock_summary, mock_get_cache):
+        mock_get_cache.return_value = _miss_cache()
+        mock_summary.return_value = None
+
+        with TestClient(app) as client:
+            response = client.get("/creator/404/summary")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Creator not found"
+
+    @patch("stream_sniper.api.analytics_endpoints.get_cache")
+    def test_summary_cache_hit_skips_gateway(self, mock_get_cache):
+        cache = _miss_cache()
+        cache.get.return_value = {
+            "creator_id": 5,
+            "nick": "alice",
+            "display_name": "Alice",
+            "total_streams": 0,
+            "total_messages": 0,
+            "audience_size": 0,
+            "regulars": 0,
+        }
+        mock_get_cache.return_value = cache
+
+        with TestClient(app) as client:
+            response = client.get("/creator/5/summary")
+
+        assert response.status_code == 200
+        assert response.headers["X-Cache"] == "HIT"
+
+
 class TestCreatorRegularsEndpoint:
     """Test suite for GET /creator/{creator_id}/regulars."""
 

--- a/backend/tests/unit/api/test_moment_endpoints.py
+++ b/backend/tests/unit/api/test_moment_endpoints.py
@@ -74,6 +74,8 @@ def _queue_row(status=None):
         [{"phrase": "pog", "count": 9, "lift": 3.2}],  # top_phrases
         [{"text": "POG", "count": 5}],                 # sample_messages
         status,                   # review status (None -> pending)
+        None,                     # clip_url
+        None,                     # note
     )
 
 
@@ -96,6 +98,8 @@ class TestMomentQueueEndpoint:
         assert item["creator_display_name"] == "TheCreator"
         assert item["ratio"] == 24.0
         assert item["status"] == "pending"  # NULL review row -> pending
+        assert item["clip_url"] is None
+        assert item["note"] is None
         assert item["top_phrases"] == [{"phrase": "pog", "count": 9, "lift": 3.2}]
         mock_queue.assert_called_once_with("pending", 7, 50, 0)
 
@@ -146,8 +150,16 @@ class TestSetMomentReview:
         assert response.json() == {
             "status": "bookmarked",
             "updated_at": "2024-01-15T21:00:00",
+            "clip_url": None,
+            "note": None,
         }
-        mock_upsert.assert_called_once_with(42, "2024-01-15T20:10:00", "bookmarked")
+        mock_upsert.assert_called_once_with(
+            42,
+            "2024-01-15T20:10:00",
+            "bookmarked",
+            clip_url=None,
+            note=None,
+        )
         mock_invalidate.assert_any_call("stream_timeline:*")
         mock_invalidate.assert_any_call("moments_queue:*")
         mock_invalidate.assert_any_call("stream_report:*")
@@ -175,6 +187,40 @@ class TestSetMomentReview:
             json={"status": "loved"},
         )
         assert response.status_code == 422
+
+    @patch("stream_sniper.api.moment_endpoints.invalidate_cache_pattern")
+    @patch("stream_sniper.api.moment_endpoints.upsert_moment_review_db")
+    @patch("stream_sniper.api.moment_endpoints.select_moment_exists_db")
+    def test_clipped_requires_url_and_persists_metadata(
+        self, mock_exists, mock_upsert, mock_invalidate
+    ):
+        mock_exists.return_value = True
+        missing = _admin_client().put(
+            "/stream/42/moments/2024-01-15T20:10:00/review",
+            json={"status": "clipped"},
+        )
+        assert missing.status_code == 422
+        mock_upsert.assert_not_called()
+
+        mock_upsert.return_value = "2024-01-15T21:00:00"
+        response = _admin_client().put(
+            "/stream/42/moments/2024-01-15T20:10:00/review",
+            json={
+                "status": "clipped",
+                "clip_url": "https://clips.twitch.tv/example",
+                "note": "Great reaction",
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["clip_url"] == "https://clips.twitch.tv/example"
+        assert response.json()["note"] == "Great reaction"
+        mock_upsert.assert_called_once_with(
+            42,
+            "2024-01-15T20:10:00",
+            "clipped",
+            clip_url="https://clips.twitch.tv/example",
+            note="Great reaction",
+        )
 
     def test_unauthenticated_rejected(self):
         response = _client().put(
@@ -204,7 +250,12 @@ class TestClearMomentReview:
         response = _admin_client().delete("/stream/42/moments/2024-01-15T20:10:00/review")
 
         assert response.status_code == 200
-        assert response.json() == {"status": None, "updated_at": None}
+        assert response.json() == {
+            "status": None,
+            "updated_at": None,
+            "clip_url": None,
+            "note": None,
+        }
         mock_delete.assert_called_once_with(42, "2024-01-15T20:10:00")
         mock_invalidate.assert_any_call("stream_timeline:*")
         mock_invalidate.assert_any_call("moments_queue:*")
@@ -245,10 +296,16 @@ CREATE TABLE IF NOT EXISTS stream_moment (
 );
 CREATE TABLE IF NOT EXISTS moment_review (
     stream_id int NOT NULL, bucket_minute timestamp NOT NULL,
-    status text NOT NULL CHECK (status IN ('bookmarked','rejected')),
+    status text NOT NULL CHECK (status IN ('bookmarked','rejected','clipped','published')),
+    clip_url text NULL, note text NULL,
     updated_at timestamptz NOT NULL DEFAULT now(),
     CONSTRAINT moment_review_pk PRIMARY KEY (stream_id, bucket_minute)
 );
+ALTER TABLE moment_review ADD COLUMN IF NOT EXISTS clip_url text NULL;
+ALTER TABLE moment_review ADD COLUMN IF NOT EXISTS note text NULL;
+ALTER TABLE moment_review DROP CONSTRAINT IF EXISTS moment_review_status_check;
+ALTER TABLE moment_review ADD CONSTRAINT moment_review_status_check
+    CHECK (status IN ('bookmarked','rejected','clipped','published'));
 """
 
 

--- a/backend/tests/unit/api/test_scene_endpoints.py
+++ b/backend/tests/unit/api/test_scene_endpoints.py
@@ -272,3 +272,55 @@ class TestSceneCopypastasEndpoint:
 
         assert response.status_code == 500
         assert response.json()["detail"] == "Internal server error"
+
+
+class TestCopypastaPropagationEndpoint:
+    """GET /scene/copypastas/{message_text_id}."""
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_copypasta_context_db")
+    @patch("stream_sniper.api.scene_endpoints.select_copypasta_propagation_db")
+    def test_propagation_maps_occurrences_and_origin_context(
+        self, mock_propagation, mock_context, mock_get_cache
+    ):
+        mock_get_cache.return_value = _miss_cache()
+        mock_propagation.return_value = (
+            "a legendary pasta",
+            [
+                (1, 5, "alice", "Alice", None, "Origin", "2024-01-01T20:00:00", "2024-01-01T20:05:00", 3, 2),
+                (2, 6, "bob", "Bob", None, "Spread", "2024-01-02T20:00:00", "2024-01-02T20:06:00", 7, 4),
+            ],
+        )
+        mock_context.return_value = [
+            (10, "2024-01-01T20:04:59.000000", 9, "viewer", "what happened"),
+            (11, "2024-01-01T20:05:00.000000", 10, "starter", "a legendary pasta"),
+        ]
+
+        response = TestClient(app).get("/scene/copypastas/42?context_seconds=120")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["message_text_id"] == 42
+        assert data["usage_count"] == 10
+        assert data["chatter_appearances"] == 6
+        assert data["stream_count"] == 2
+        assert data["creator_count"] == 2
+        assert data["first_seen"] == "2024-01-01T20:05:00"
+        assert data["occurrences"][1]["creator_id"] == 6
+        assert data["origin_context"][1]["text"] == "a legendary pasta"
+        mock_context.assert_called_once_with(1, "2024-01-01T20:05:00", 120, 100)
+
+    @patch("stream_sniper.api.scene_endpoints.get_cache")
+    @patch("stream_sniper.api.scene_endpoints.select_copypasta_propagation_db")
+    def test_missing_text_404(self, mock_propagation, mock_get_cache):
+        mock_get_cache.return_value = _miss_cache()
+        mock_propagation.return_value = (None, [])
+
+        response = TestClient(app).get("/scene/copypastas/404")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Copypasta not found"
+
+    def test_context_window_is_bounded(self):
+        response = TestClient(app).get("/scene/copypastas/42?context_seconds=301")
+        assert response.status_code == 422

--- a/backend/tests/unit/api/test_scene_events.py
+++ b/backend/tests/unit/api/test_scene_events.py
@@ -1,0 +1,40 @@
+"""API tests for the scene pulse and digest preview."""
+
+from unittest.mock import Mock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stream_sniper.api.rate_limiter import setup_rate_limiting
+from stream_sniper.api.scene_event_endpoints import router
+
+
+def _client():
+    app = FastAPI()
+    setup_rate_limiting(app)
+    app.include_router(router)
+    return TestClient(app)
+
+
+@patch("stream_sniper.api.scene_event_endpoints.get_cache")
+@patch("stream_sniper.api.scene_event_endpoints.select_scene_events_db")
+def test_pulse_maps_rows(events, get_cache):
+    cache = Mock()
+    cache._generate_key.return_value = "key"
+    cache.get.return_value = None
+    get_cache.return_value = cache
+    events.return_value = ([(1, "personal_record", "2024-01-02T22:00:00", 5, "alice", "Alice", 42, None, "New record", "2,000", {"metric": "messages"})], 1)
+
+    response = _client().get("/scene/pulse?days=7&event_type=personal_record")
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["creator_display_name"] == "Alice"
+    events.assert_called_once_with(7, "personal_record", None, 50, 0)
+
+
+@patch("stream_sniper.api.scene_event_endpoints.build_digest", return_value="## digest")
+def test_digest_preview(build):
+    response = _client().get("/scene/digest?days=7")
+    assert response.status_code == 200
+    assert response.json() == {"days": 7, "markdown": "## digest"}
+    build.assert_called_once_with(7)

--- a/backend/tests/unit/api/test_timeline.py
+++ b/backend/tests/unit/api/test_timeline.py
@@ -12,6 +12,7 @@ Gateway arities after migration 0008: buckets are 5-tuples
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -19,6 +20,14 @@ from stream_sniper.api.rate_limiter import setup_rate_limiting
 from stream_sniper.api.timeline_endpoints import router
 
 _BASE = datetime(2024, 1, 15, 20, 0, 0)
+
+
+@pytest.fixture(autouse=True)
+def _empty_context_changes(monkeypatch):
+    monkeypatch.setattr(
+        "stream_sniper.api.timeline_endpoints.select_stream_context_changes_db",
+        lambda _stream_id: [],
+    )
 
 
 def _iso(minute_offset: int) -> str:
@@ -310,3 +319,35 @@ class TestTimelineEndpoint:
         assert data["metrics"]["emote_messages"] is None
         assert data["buckets"][0]["sub_messages"] is None
         assert data["buckets"][0]["emote_messages"] is None
+
+    @patch("stream_sniper.api.timeline_endpoints.get_cache")
+    @patch("stream_sniper.api.timeline_endpoints.select_stream_viewer_samples_db")
+    @patch("stream_sniper.api.timeline_endpoints.select_stream_moments_db")
+    @patch("stream_sniper.api.timeline_endpoints.select_stream_header_db")
+    @patch("stream_sniper.api.timeline_endpoints.select_stream_metrics_db")
+    @patch("stream_sniper.api.timeline_endpoints.select_stream_buckets_db")
+    def test_context_changes_are_exposed(
+        self, mock_buckets, mock_metrics, mock_header, mock_moments, mock_samples,
+        mock_get_cache, monkeypatch,
+    ):
+        mock_get_cache.return_value = _miss_cache()
+        mock_buckets.return_value = [(_iso(0), 4, 2, 0, 0)]
+        mock_metrics.return_value = None
+        mock_header.return_value = (_iso(0), "vod1")
+        mock_moments.return_value = []
+        mock_samples.return_value = []
+        monkeypatch.setattr(
+            "stream_sniper.api.timeline_endpoints.select_stream_context_changes_db",
+            lambda _stream_id: [
+                (_iso(0), "Opening", "509658", "Just Chatting", "en", ["English"], False),
+            ],
+        )
+
+        response = _client().get("/stream/1/timeline")
+
+        assert response.status_code == 200
+        assert response.json()["context_changes"] == [{
+            "t": _iso(0), "title": "Opening", "category_id": "509658",
+            "category_name": "Just Chatting", "language": "en",
+            "tags": ["English"], "is_mature": False,
+        }]

--- a/backend/tests/unit/collector/test_live_message_sink.py
+++ b/backend/tests/unit/collector/test_live_message_sink.py
@@ -1,0 +1,88 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from stream_sniper.collector.live import live_message_sink as sink_module
+from stream_sniper.collector.live.live_message_sink import LiveMessageSink, _emote_count
+
+
+def _stream(session_id=123):
+    return SimpleNamespace(
+        id=str(session_id),
+        started_at=datetime(2026, 7, 13, 12, 0, tzinfo=UTC),
+        title="Live title",
+        thumbnail_url="https://example.test/thumb.jpg",
+    )
+
+
+def _message(message_id="uuid-1"):
+    return SimpleNamespace(
+        id=message_id,
+        room=SimpleNamespace(name="SomeStreamer"),
+        user=SimpleNamespace(name="Viewer", subscriber=True, badges="subscriber/3"),
+        text="hello @other",
+        emotes=None,
+        sent_timestamp=1_752_408_100_000,
+    )
+
+
+def test_emote_count_counts_each_range():
+    assert _emote_count(None) == 0
+    assert _emote_count("25:0-4,6-10/1902:12-16") == 3
+
+
+@pytest.mark.asyncio
+async def test_handle_maps_and_flushes_live_message(monkeypatch):
+    written = []
+    monkeypatch.setattr(sink_module, "ensure_live_stream_db", lambda *args: 77)
+    monkeypatch.setattr(sink_module, "insert_new_chatter_db", lambda nick: 8)
+    monkeypatch.setattr(sink_module, "find_or_insert_message_text_id_db", lambda text: 9)
+    monkeypatch.setattr(sink_module, "bulk_insert_live_messages_db", lambda rows: written.extend(rows))
+    sink = LiveMessageSink(buffer_size=10)
+
+    assert await sink.handle(_message(), _stream()) is True
+    await sink.flush()
+
+    assert len(written) == 1
+    row = written[0]
+    assert row[0:4] == (8, None, 77, 9)
+    assert row[5:9] == (True, "subscriber/3", 0, "uuid-1")
+    assert sink.active_session("somestreamer") == 123
+
+
+@pytest.mark.asyncio
+async def test_flush_failure_retains_batch_for_retry(monkeypatch):
+    attempts = 0
+
+    def flaky(rows):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(sink_module, "ensure_live_stream_db", lambda *args: 77)
+    monkeypatch.setattr(sink_module, "insert_new_chatter_db", lambda nick: 8)
+    monkeypatch.setattr(sink_module, "find_or_insert_message_text_id_db", lambda text: 9)
+    monkeypatch.setattr(sink_module, "bulk_insert_live_messages_db", flaky)
+    sink = LiveMessageSink(buffer_size=10)
+
+    await sink.handle(_message(), _stream())
+    await sink.flush()
+    await sink.flush()
+
+    assert attempts == 2
+    assert sink._items == []
+
+
+@pytest.mark.asyncio
+async def test_finalize_flushes_and_marks_stream(monkeypatch):
+    finalized = []
+    monkeypatch.setattr(sink_module, "ensure_live_stream_db", lambda *args: 77)
+    monkeypatch.setattr(sink_module, "finalize_live_stream_db", lambda *args: finalized.append(args))
+    sink = LiveMessageSink()
+    await sink.set_stream("somestreamer", _stream())
+
+    assert await sink.finalize("somestreamer") == 77
+    assert finalized == [(77, None)]
+    assert sink.active_session("somestreamer") is None

--- a/backend/tests/unit/collector/test_live_vod_reconciliation.py
+++ b/backend/tests/unit/collector/test_live_vod_reconciliation.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+
+from stream_sniper.collector import irc_chat_downloader as downloader_module
+from stream_sniper.collector.irc_chat_downloader import IrcChatDownloader
+
+
+def test_completed_live_capture_reconciles_and_skips_vod(monkeypatch):
+    reconciled = []
+    video = SimpleNamespace(
+        id="987", stream_id="123", thumbnail_url="thumb", title="title",
+        created_at=None, duration="1h",
+    )
+    downloader = IrcChatDownloader.__new__(IrcChatDownloader)
+    downloader.available_video_ids = [video]
+    downloader.logger = SimpleNamespace(info=lambda *args: None, debug=lambda *args: None)
+    downloader.downloader = SimpleNamespace(
+        get_chat=lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not download"))
+    )
+    monkeypatch.setattr(downloader_module, "select_live_stream_by_session_db", lambda session: (77, True))
+    monkeypatch.setattr(
+        downloader_module,
+        "reconcile_live_stream_vod_db",
+        lambda *args: reconciled.append(args),
+    )
+
+    result = downloader.download_chat()
+
+    assert result == (None, None, None, None, None, None)
+    assert reconciled == [("123", "987", "thumb")]

--- a/backend/tests/unit/tracking/test_viewer_snapshot.py
+++ b/backend/tests/unit/tracking/test_viewer_snapshot.py
@@ -150,6 +150,8 @@ def monitor(monkeypatch):
     monkeypatch.setattr(monitor_module, "TwitchAPI", lambda: object())
     m = StreamMonitor()
     monkeypatch.setattr(monitor_module, "update_stream_check_time_db", lambda *a, **kw: True)
+    monkeypatch.setattr(monitor_module, "insert_stream_viewer_sample_db", lambda **kw: True)
+    monkeypatch.setattr(monitor_module, "insert_stream_context_sample_db", lambda **kw: True)
     return m
 
 
@@ -184,6 +186,24 @@ async def test_live_stream_records_viewer_snapshot(monitor, monkeypatch):
     assert call["viewer_count"] == 123
     assert call["title"] == "Live now"
     assert call["session_started_at"] == status.started_at
+
+
+@pytest.mark.asyncio
+async def test_live_stream_records_context_snapshot(monitor, monkeypatch):
+    calls = []
+    monkeypatch.setattr(monitor_module, "insert_stream_context_sample_db", lambda **kw: calls.append(kw))
+    status = StreamStatus(
+        twitch_username="somestreamer", is_live=True, stream_id=999,
+        title="New title", category_id="509658", category_name="Just Chatting",
+        language="en", tags=["English", "NoBackseating"], is_mature=False,
+    )
+    monkeypatch.setattr(monitor, "_get_stream_status", AsyncMock(return_value=status))
+
+    await monitor._check_single_stream(_streamer_data(ts_id=7))
+
+    assert len(calls) == 1
+    assert calls[0]["category_name"] == "Just Chatting"
+    assert calls[0]["tags"] == ["English", "NoBackseating"]
 
 
 @pytest.mark.asyncio

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -67,7 +67,36 @@ services:
     depends_on:
       - stream-sniper-api
 
+  stream-sniper-live:
+    image: stream-sniper-api:latest
+    command: ["python", "-m", "stream_sniper.live_service"]
+    environment:
+      - POSTGRES_HOST=172.17.0.1
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=stream_sniper
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      - TWITCH_CLIENT_ID=${TWITCH_CLIENT_ID}
+      - TWITCH_CLIENT_SECRET=${TWITCH_CLIENT_SECRET}
+      - TWITCH_BOT_REFRESH_TOKEN=${TWITCH_BOT_REFRESH_TOKEN}
+      - LIVE_CHANNELS=${LIVE_CHANNELS}
+      - LIVE_TRACKED_CHANNELS=${LIVE_TRACKED_CHANNELS:-true}
+      - LIVE_FLUSH_INTERVAL=${LIVE_FLUSH_INTERVAL:-5}
+      - LIVE_BUFFER_SIZE=${LIVE_BUFFER_SIZE:-1000}
+      - TWITCH_BOT_TOKEN_FILE=/tokens/refresh-token
+    volumes:
+      - live_tokens:/tokens
+    restart: unless-stopped
+    container_name: stream-sniper-live
+    networks:
+      - stream-sniper-prod
+    depends_on:
+      - stream-sniper-api
+
 
 networks:
   stream-sniper-prod:
     driver: bridge
+
+volumes:
+  live_tokens:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,24 @@ services:
     networks:
       - stream-sniper
 
+  live:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.api
+    volumes:
+      - ./backend/stream_sniper:/app/.venv/lib/python3.14/site-packages/stream_sniper
+      - ./logs:/app/logs
+      - live_tokens:/tokens
+    env_file:
+      - .env
+    environment:
+      - PYTHONUNBUFFERED=1
+      - TWITCH_BOT_TOKEN_FILE=/tokens/refresh-token
+    command: ["stream-sniper-live"]
+    restart: unless-stopped
+    networks:
+      - stream-sniper
+
   # Optional: PostgreSQL container (comment out if using external database)
   # postgres:
   #   image: postgres:16-alpine
@@ -87,5 +105,6 @@ networks:
   stream-sniper:
     driver: bridge
 
-# volumes:
-#   postgres_data:
+volumes:
+  live_tokens:
+  # postgres_data:

--- a/docs/live-capture-collector-design.md
+++ b/docs/live-capture-collector-design.md
@@ -165,6 +165,12 @@ LIVE_FLUSH_INTERVAL=5      # seconds
 LIVE_BUFFER_SIZE=1000      # rows per flush (lower than VOD's 5000)
 ```
 
+Bootstrap the dedicated bot once by registering `http://localhost:17563` as an
+OAuth redirect URL for the Twitch application, then run
+`stream-sniper-live-auth --output .live-refresh-token` while logged into the bot
+account. The command requests only `chat:read` and writes the refresh token with
+mode `0600`; provision that value as `TWITCH_BOT_REFRESH_TOKEN` on first deploy.
+
 Add to `docs/../.env.example`. **Docker:** a new `live` service in
 `docker-compose.yml` reusing `Dockerfile.collector`/api image with the
 hot-reload bind mount, `command: ["stream-sniper-live"]`, `restart: unless-stopped`

--- a/docs/live-capture-collector-design.md
+++ b/docs/live-capture-collector-design.md
@@ -1,6 +1,7 @@
 # Design: Live Twitch Chat Capture Collector
 
-Status: proposal (no implementation). Scope: `backend/stream_sniper/`.
+Status: implemented in migrations 0013 and the `stream-sniper-live` service.
+Scope: `backend/stream_sniper/`.
 
 ## 1. Goal & scope
 
@@ -103,16 +104,13 @@ message for a channel, `LiveMessageSink` inserts the stream via
 pass `None` for `stopped_at`). On stream end it sets `"end"` and calls
 `update_stream_message_count_db`.
 
-**Reconciliation key (recommended).** Standardize `stream.twitch_id` on the
-**Twitch stream-session id** for *both* paths. Twitch's archive `Video` object
-exposes `stream_id` linking a VOD back to its originating session; the VOD
-collector can key `insert_stream_db` on `video.stream_id` instead of the video id.
-Both paths then converge on the same unique `twitch_id`, and the existing
-`insert_stream_db` `ON CONFLICT DO NOTHING … UNION SELECT id` returns the same
-row — natural dedup at the stream level. This is a schema-*semantics* change
-(existing rows are keyed by video id); migration is called out in §8. If we defer
-that, the interim rule is: **a live-captured stream must not be VOD-reprocessed**
-(§7 dedup).
+**Implemented reconciliation key.** Migration 0013 adds a separate unique
+`stream.twitch_stream_session_id`, preserving the existing meaning of
+`stream.twitch_id` as the VOD video id (which the frontend needs for deep links).
+An in-progress row temporarily uses the negative session id as its non-null
+`twitch_id`; when Twitch publishes the archive, the VOD collector attaches the
+real video id and skips duplicate message ingestion. `message.source_message_id`
+also makes websocket reconnect/replay idempotent.
 
 ## 4. Entry point & tracking integration
 

--- a/frontend/app/(app)/compare/page.tsx
+++ b/frontend/app/(app)/compare/page.tsx
@@ -1,0 +1,9 @@
+'use client'
+import { use } from 'react'
+import StreamCompare from '@/views/StreamCompare'
+
+export default function ComparePage({ searchParams }: { searchParams: Promise<{ ids?: string }> }) {
+  const { ids = '' } = use(searchParams)
+  const initialIds = ids.split(',').map(Number).filter(id => Number.isInteger(id) && id > 0).slice(0, 4)
+  return <StreamCompare initialIds={initialIds} />
+}

--- a/frontend/app/(app)/copypasta/[id]/page.tsx
+++ b/frontend/app/(app)/copypasta/[id]/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+import { use } from 'react'
+import CopypastaPropagation from '@/views/CopypastaPropagation'
+
+export default function CopypastaPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  return <CopypastaPropagation messageTextId={Number(id)} />
+}

--- a/frontend/app/(app)/creator/[id]/page.tsx
+++ b/frontend/app/(app)/creator/[id]/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+import { use } from 'react'
+import CreatorDossier from '@/views/CreatorDossier'
+
+export default function CreatorPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  return <CreatorDossier creatorId={Number(id)} />
+}

--- a/frontend/app/(app)/movement/page.tsx
+++ b/frontend/app/(app)/movement/page.tsx
@@ -1,0 +1,9 @@
+'use client'
+import { use } from 'react'
+import AudienceMovement from '@/views/AudienceMovement'
+
+export default function MovementPage({ searchParams }: { searchParams: Promise<{ creator?: string }> }) {
+  const { creator } = use(searchParams)
+  const creatorId = Number(creator)
+  return <AudienceMovement initialCreatorId={Number.isInteger(creatorId) && creatorId > 0 ? creatorId : null} />
+}

--- a/frontend/app/(app)/pulse/page.tsx
+++ b/frontend/app/(app)/pulse/page.tsx
@@ -1,0 +1,6 @@
+'use client'
+import ScenePulse from '@/views/ScenePulse'
+
+export default function PulsePage() {
+  return <ScenePulse />
+}

--- a/frontend/components/community/NeighborsExplorer.jsx
+++ b/frontend/components/community/NeighborsExplorer.jsx
@@ -1,5 +1,6 @@
 'use client'
 import { useMemo } from 'react'
+import Link from 'next/link'
 import Select from 'react-select'
 import { useCreatorNeighbors } from '@/hooks/useApiQuery'
 import LoadingSpinner from '@/components/LoadingSpinner'
@@ -133,7 +134,9 @@ const NeighborsExplorer = ({
                     {neighbors.map((nbr, index) => (
                         <li key={nbr.creatorId}>
                             <span className="rank">{String(index + 1).padStart(2, '0')}</span>
-                            <span className="nick">{nbr.displayName || nbr.nick || `#${nbr.creatorId}`}</span>
+                            <Link className="nick" href={`/creator/${nbr.creatorId}`}>
+                                {nbr.displayName || nbr.nick || `#${nbr.creatorId}`}
+                            </Link>
                             <span className="neighbors-bar-wrap">
                                 <span
                                     className="data-bar"

--- a/frontend/components/community/OverlapTable.jsx
+++ b/frontend/components/community/OverlapTable.jsx
@@ -1,5 +1,6 @@
 'use client'
 import { useMemo, useState, useCallback } from 'react'
+import Link from 'next/link'
 import { Table } from 'react-bootstrap'
 
 const COLUMNS = [
@@ -184,8 +185,8 @@ const OverlapTable = ({
                             onClick={() => onSelectPair({ aId: row.aId, bId: row.bId })}
                             aria-selected={isSelected(row) || undefined}
                         >
-                            <td>{row.aName}</td>
-                            <td>{row.bName}</td>
+                            <td><Link href={`/creator/${row.aId}`} onClick={event => event.stopPropagation()}>{row.aName}</Link></td>
+                            <td><Link href={`/creator/${row.bId}`} onClick={event => event.stopPropagation()}>{row.bName}</Link></td>
                             <td className="mono text-end">{row.shared.toLocaleString()}</td>
                             <td className="mono text-end">
                                 {row.jaccard == null ? '--' : `${(row.jaccard * 100).toFixed(1)}%`}

--- a/frontend/components/layout/Sidebar.jsx
+++ b/frontend/components/layout/Sidebar.jsx
@@ -35,9 +35,19 @@ const navigation = [
         icon: 'bi bi-diagram-3',
     },
     {
+        title: 'Movement',
+        href: '/movement',
+        icon: 'bi bi-arrow-left-right',
+    },
+    {
         title: 'Scene',
         href: '/scene',
         icon: 'bi bi-trophy',
+    },
+    {
+        title: 'Pulse',
+        href: '/pulse',
+        icon: 'bi bi-activity',
     },
     {
         title: 'Copypasta',
@@ -48,6 +58,11 @@ const navigation = [
         title: 'Highlights',
         href: '/moments',
         icon: 'bi bi-bookmark-star',
+    },
+    {
+        title: 'Compare',
+        href: '/compare',
+        icon: 'bi bi-columns-gap',
     },
 ]
 

--- a/frontend/components/moments/MomentCard.jsx
+++ b/frontend/components/moments/MomentCard.jsx
@@ -1,4 +1,5 @@
 'use client'
+import { useState } from 'react'
 import Link from 'next/link'
 import { vodDeepLink } from '@/utils/chatRender'
 import { formatTimeAgo } from '@/utils/dateUtils'
@@ -41,7 +42,13 @@ const MomentCard = ({
         topPhrases,
         sampleMessages,
         status,
+        clipUrl,
+        note,
     } = moment
+
+    const [showClipForm, setShowClipForm] = useState(false)
+    const [draftClipUrl, setDraftClipUrl] = useState(clipUrl || '')
+    const [draftNote, setDraftNote] = useState(note || '')
 
     const vodHref = vodDeepLink(twitchId, streamStart, t)
     const topPhrase = Array.isArray(topPhrases) && topPhrases.length ? topPhrases[0] : null
@@ -52,6 +59,8 @@ const MomentCard = ({
     const chipClass =
         status === 'bookmarked'
             ? 'status-chip is-ok'
+            : status === 'clipped' || status === 'published'
+                ? 'status-chip is-ok'
             : status === 'rejected'
                 ? 'status-chip is-warn'
                 : 'status-chip'
@@ -136,6 +145,46 @@ const MomentCard = ({
                 </p>
             ) : null}
 
+            {clipUrl ? (
+                <div className="moment-clip-result">
+                    <a href={clipUrl} target="_blank" rel="noopener noreferrer">Watch clip</a>
+                    {note ? <p>{note}</p> : null}
+                </div>
+            ) : null}
+
+            {isAdmin && showClipForm ? (
+                <form className="moment-clip-form" onSubmit={event => {
+                    event.preventDefault()
+                    onReview('clipped', { clipUrl: draftClipUrl, note: draftNote })
+                    setShowClipForm(false)
+                }}>
+                    <label>
+                        Clip URL
+                        <input
+                            className="form-control form-control-sm"
+                            type="url"
+                            required
+                            value={draftClipUrl}
+                            onChange={event => setDraftClipUrl(event.target.value)}
+                            placeholder="https://clips.twitch.tv/..."
+                        />
+                    </label>
+                    <label>
+                        Curator note
+                        <textarea
+                            className="form-control form-control-sm"
+                            maxLength={500}
+                            value={draftNote}
+                            onChange={event => setDraftNote(event.target.value)}
+                        />
+                    </label>
+                    <div>
+                        <button className="btn btn-primary btn-sm" type="submit" disabled={pending}>Save clip</button>
+                        <button className="btn btn-link btn-sm" type="button" onClick={() => setShowClipForm(false)}>Cancel</button>
+                    </div>
+                </form>
+            ) : null}
+
             <footer className="moment-actions">
                 {vodHref ? (
                     <a
@@ -168,6 +217,26 @@ const MomentCard = ({
                                 aria-hidden="true" />
                             Bookmark
                         </button>
+                        {(status === 'bookmarked' || status === 'clipped') ? (
+                            <button
+                                type="button"
+                                className={`moment-review-btn${status === 'clipped' ? ' is-active-ok' : ''}`}
+                                disabled={pending}
+                                onClick={() => setShowClipForm(value => !value)}>
+                                <i className="bi bi-camera-video" aria-hidden="true" />
+                                {clipUrl ? 'Edit clip' : 'Attach clip'}
+                            </button>
+                        ) : null}
+                        {status === 'clipped' ? (
+                            <button
+                                type="button"
+                                className="moment-review-btn"
+                                disabled={pending}
+                                onClick={() => onReview('published', { clipUrl, note })}>
+                                <i className="bi bi-send" aria-hidden="true" />
+                                Publish
+                            </button>
+                        ) : null}
                         <button
                             type="button"
                             className={`moment-review-btn${status === 'rejected' ? ' is-active-warn' : ''}`}
@@ -179,7 +248,7 @@ const MomentCard = ({
                                 aria-hidden="true" />
                             Reject
                         </button>
-                        {status === 'bookmarked' || status === 'rejected' ? (
+                        {status !== 'pending' ? (
                             <button
                                 type="button"
                                 className="moment-review-btn"

--- a/frontend/components/scene/CopypastaCard.jsx
+++ b/frontend/components/scene/CopypastaCard.jsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState } from 'react'
+import Link from 'next/link'
 
 /** Naive UTC "YYYY-MM-DDTHH:MM:SS" -> "YYYY-MM-DD" date slice (no TZ drift). */
 const dateOnly = ts => (typeof ts === 'string' && ts.length >= 10 ? ts.slice(0, 10) : null)
@@ -17,6 +18,7 @@ const CLAMP_CHARS = 240
  */
 const CopypastaCard = ({ pasta }) => {
     const {
+        messageTextId,
         text,
         usageCount,
         streamCount,
@@ -66,6 +68,9 @@ const CopypastaCard = ({ pasta }) => {
                         first seen {firstSeenDate}
                     </span>
                 ) : null}
+                <Link className="pasta-chip pasta-trace-link" href={`/copypasta/${messageTextId}`}>
+                    Trace spread →
+                </Link>
             </div>
         </article>
     )

--- a/frontend/components/streams/StreamTimeline.jsx
+++ b/frontend/components/streams/StreamTimeline.jsx
@@ -107,6 +107,9 @@ const StreamTimeline = ({ timeline, onJump }) => {
     const viewerSamples = useMemo(() => timeline?.viewerSamples || [], [
         timeline?.viewerSamples,
     ])
+    const contextChanges = useMemo(() => timeline?.contextChanges || [], [
+        timeline?.contextChanges,
+    ])
 
     const n = buckets.length
 
@@ -330,6 +333,15 @@ const StreamTimeline = ({ timeline, onJump }) => {
                         </svg>
 
                         <div className="timeline-markers">
+                            {contextChanges.map(change => (
+                                <span
+                                    key={`context-${change.t}`}
+                                    className="timeline-context-marker"
+                                    style={{ left: `${markerLeft(change.t)}%` }}
+                                    title={`${clock(change.t)} · ${change.categoryName || 'Uncategorized'} · ${change.title || 'Untitled'}`}
+                                    aria-label={`Context changed at ${clock(change.t)} to ${change.categoryName || 'uncategorized'}: ${change.title || 'untitled'}`}
+                                    role="img" />
+                            ))}
                             {moments.map(moment => (
                                 <button
                                     key={moment.t}
@@ -425,6 +437,27 @@ const StreamTimeline = ({ timeline, onJump }) => {
                     </div>
                 ) : null}
 
+                {contextChanges.length ? (
+                    <div className="timeline-context-list" aria-label="Stream context changes">
+                        {contextChanges.map(change => (
+                            <div key={change.t} className="timeline-context-item">
+                                <time>{clock(change.t)}</time>
+                                <span className="timeline-context-category">
+                                    {change.categoryName || 'Uncategorized'}
+                                </span>
+                                <span className="timeline-context-title">
+                                    {change.title || 'Untitled stream'}
+                                </span>
+                                {change.tags.length ? (
+                                    <span className="timeline-context-tags">
+                                        {change.tags.slice(0, 3).join(' · ')}
+                                    </span>
+                                ) : null}
+                            </div>
+                        ))}
+                    </div>
+                ) : null}
+
                 {activeMoment ? (
                     <div className="timeline-selection">
                         <div className="timeline-selection-head">
@@ -435,7 +468,7 @@ const StreamTimeline = ({ timeline, onJump }) => {
                             {activeMoment.status ? (
                                 <span
                                     className={`status-chip ${
-                                        activeMoment.status === 'bookmarked' ? 'is-ok' : 'is-err'
+                                        activeMoment.status === 'rejected' ? 'is-err' : 'is-ok'
                                     }`}>
                                     {activeMoment.status}
                                 </span>

--- a/frontend/hooks/useApiQuery.js
+++ b/frontend/hooks/useApiQuery.js
@@ -1,5 +1,10 @@
 // TanStack Query API hooks index file
 export {
+    useAudienceMovement,
+    audienceMovementKeys,
+} from './useAudienceMovementQuery'
+
+export {
     useStreams,
     useStreamData,
     streamsKeys,
@@ -16,9 +21,19 @@ export {
 } from './useStreamMessagesQuery'
 
 export {
+    useStreamComparison,
+    streamComparisonKeys,
+} from './useStreamComparisonQuery'
+
+export {
     useStreamTimeline,
     streamTimelineKeys,
 } from './useStreamTimelineQuery'
+
+export {
+    useCreatorSummary,
+    creatorSummaryKeys,
+} from './useCreatorSummaryQuery'
 
 export {
     useCreatorTrends,
@@ -57,9 +72,12 @@ export {
 
 export {
     sceneKeys,
+    useCopypastaPropagation,
     useSceneCopypastas,
+    useSceneDigest,
     useSceneLeaderboard,
     useSceneLive,
+    useScenePulse,
 } from './useSceneQueries'
 
 export {

--- a/frontend/hooks/useAudienceMovementQuery.js
+++ b/frontend/hooks/useAudienceMovementQuery.js
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query'
+import { retrieveAudienceMovement } from '@/lib/api'
+
+export const audienceMovementKeys = {
+    all: ['audience-movement'],
+    detail: (creatorId, days) => [...audienceMovementKeys.all, { creatorId, days }],
+}
+
+const mapAssociation = item => ({
+    creatorId: item.creator_id,
+    nick: item.nick,
+    displayName: item.display_name,
+    chatterCount: item.chatter_count,
+})
+
+export const useAudienceMovement = (creatorId, days = 30, options = {}) => useQuery({
+    queryKey: audienceMovementKeys.detail(creatorId, days),
+    queryFn: async () => {
+        const { data = {} } = await retrieveAudienceMovement(creatorId, days)
+        return {
+            creatorId: data.creator_id,
+            windowDays: data.window_days,
+            currentAudience: data.current_audience,
+            previousAudience: data.previous_audience,
+            retained: data.retained,
+            gained: data.gained,
+            lapsed: data.lapsed,
+            retentionRate: data.retention_rate ?? null,
+            gainRate: data.gain_rate ?? null,
+            priorChannelsForGained: (data.prior_channels_for_gained || []).map(mapAssociation),
+            currentChannelsForLapsed: (data.current_channels_for_lapsed || []).map(mapAssociation),
+        }
+    },
+    enabled: Boolean(creatorId),
+    ...options,
+})

--- a/frontend/hooks/useCreatorSummaryQuery.js
+++ b/frontend/hooks/useCreatorSummaryQuery.js
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query'
+import { retrieveCreatorSummary } from '@/lib/api'
+
+export const creatorSummaryKeys = {
+    all: ['creator-summary'],
+    detail: creatorId => [...creatorSummaryKeys.all, { creatorId }],
+}
+
+export const useCreatorSummary = (creatorId, options = {}) => useQuery({
+    queryKey: creatorSummaryKeys.detail(creatorId),
+    queryFn: async () => {
+        const { data = {} } = await retrieveCreatorSummary(creatorId)
+        return {
+            creatorId: data.creator_id,
+            nick: data.nick,
+            displayName: data.display_name,
+            profileImageUrl: data.profile_image_url ?? null,
+            twitchId: data.twitch_id ?? null,
+            totalStreams: data.total_streams ?? 0,
+            firstStreamAt: data.first_stream_at ?? null,
+            lastStreamAt: data.last_stream_at ?? null,
+            totalMessages: data.total_messages ?? 0,
+            durationSeconds: data.duration_seconds ?? null,
+            messagesPerMinute: data.messages_per_minute ?? null,
+            audienceSize: data.audience_size ?? 0,
+            regulars: data.regulars ?? 0,
+            latestStream: data.latest_stream ? {
+                streamId: data.latest_stream.stream_id,
+                title: data.latest_stream.title,
+                start: data.latest_stream.start ?? null,
+            } : null,
+        }
+    },
+    enabled: Boolean(creatorId),
+    ...options,
+})

--- a/frontend/hooks/useMomentsQueries.js
+++ b/frontend/hooks/useMomentsQueries.js
@@ -30,6 +30,8 @@ const mapMoment = m => ({
     topPhrases: m.top_phrases,
     sampleMessages: m.sample_messages,
     status: m.status,
+    clipUrl: m.clip_url ?? null,
+    note: m.note ?? null,
 })
 
 export const useMomentsQueue = ({
@@ -61,10 +63,10 @@ export const useMomentReview = (options = {}) => {
     const queryClient = useQueryClient()
     return useMutation({
         mutationFn: async ({
-            streamId, bucketMinute, status,
+            streamId, bucketMinute, status, clipUrl, note,
         }) => {
             const response = status
-                ? await putMomentReview(streamId, bucketMinute, status)
+                ? await putMomentReview(streamId, bucketMinute, status, { clipUrl, note })
                 : await deleteMomentReview(streamId, bucketMinute)
             return response.data
         },

--- a/frontend/hooks/useSceneQueries.js
+++ b/frontend/hooks/useSceneQueries.js
@@ -1,8 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 import {
+    retrieveCopypastaPropagation,
     retrieveSceneCopypastas,
     retrieveSceneLeaderboard,
     retrieveSceneLive,
+    retrieveScenePulse,
+    retrieveSceneDigest,
 } from '@/lib/api'
 
 /**
@@ -26,6 +29,13 @@ export const sceneKeys = {
         'copypastas',
         filters,
     ],
+    copypasta: (messageTextId, contextSeconds) => [
+        ...sceneKeys.all,
+        'copypasta',
+        { messageTextId, contextSeconds },
+    ],
+    pulse: filters => [...sceneKeys.all, 'pulse', filters],
+    digest: days => [...sceneKeys.all, 'digest', { days }],
 }
 
 /**
@@ -151,5 +161,72 @@ export const useSceneCopypastas = ({
             })),
         }
     },
+    ...options,
+})
+
+export const useCopypastaPropagation = (messageTextId, contextSeconds = 90, options = {}) => useQuery({
+    queryKey: sceneKeys.copypasta(messageTextId, contextSeconds),
+    queryFn: async () => {
+        const { data = {} } = await retrieveCopypastaPropagation(messageTextId, contextSeconds)
+        return {
+            messageTextId: data.message_text_id,
+            text: data.text,
+            usageCount: data.usage_count ?? 0,
+            chatterAppearances: data.chatter_appearances ?? 0,
+            streamCount: data.stream_count ?? 0,
+            creatorCount: data.creator_count ?? 0,
+            firstSeen: data.first_seen ?? null,
+            occurrences: (data.occurrences || []).map(item => ({
+                streamId: item.stream_id,
+                creatorId: item.creator_id,
+                nick: item.nick,
+                displayName: item.display_name,
+                profileImageUrl: item.profile_image_url ?? null,
+                streamTitle: item.stream_title,
+                streamStart: item.stream_start ?? null,
+                firstSeen: item.first_seen ?? null,
+                usageCount: item.usage_count,
+                chatterCount: item.chatter_count,
+            })),
+            originContext: (data.origin_context || []).map(item => ({
+                id: item.id,
+                time: item.time,
+                chatterId: item.chatter_id,
+                nick: item.nick,
+                text: item.text,
+            })),
+        }
+    },
+    enabled: Boolean(messageTextId),
+    ...options,
+})
+
+export const useScenePulse = (filters = {}, options = {}) => useQuery({
+    queryKey: sceneKeys.pulse(filters),
+    queryFn: async () => {
+        const { data = {} } = await retrieveScenePulse(filters)
+        return {
+            total: data.total ?? 0,
+            items: (data.items || []).map(item => ({
+                id: item.id,
+                eventType: item.event_type,
+                occurredAt: item.occurred_at,
+                creatorId: item.creator_id ?? null,
+                creatorNick: item.creator_nick ?? null,
+                creatorDisplayName: item.creator_display_name ?? null,
+                streamId: item.stream_id ?? null,
+                messageTextId: item.message_text_id ?? null,
+                title: item.title,
+                summary: item.summary,
+                metadata: item.metadata || {},
+            })),
+        }
+    },
+    ...options,
+})
+
+export const useSceneDigest = (days = 7, options = {}) => useQuery({
+    queryKey: sceneKeys.digest(days),
+    queryFn: async () => (await retrieveSceneDigest(days)).data?.markdown || '',
     ...options,
 })

--- a/frontend/hooks/useStreamComparisonQuery.js
+++ b/frontend/hooks/useStreamComparisonQuery.js
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query'
+import { retrieveStreamComparison } from '@/lib/api'
+
+export const streamComparisonKeys = {
+    all: ['stream-comparison'],
+    detail: streamIds => [...streamComparisonKeys.all, streamIds],
+}
+
+export const useStreamComparison = (streamIds, options = {}) => useQuery({
+    queryKey: streamComparisonKeys.detail(streamIds),
+    queryFn: async () => {
+        const { data = {} } = await retrieveStreamComparison(streamIds)
+        return {
+            streams: (data.streams || []).map(stream => ({
+                streamId: stream.stream_id,
+                creatorId: stream.creator_id,
+                creatorNick: stream.creator_nick,
+                creatorDisplayName: stream.creator_display_name,
+                title: stream.title,
+                start: stream.start ?? null,
+                durationSeconds: stream.duration_seconds ?? null,
+                totalMessages: stream.total_messages ?? null,
+                messagesPerMinute: stream.messages_per_minute ?? null,
+                uniqueChatters: stream.unique_chatters ?? null,
+                newChatters: stream.new_chatters ?? null,
+                returningChatters: stream.returning_chatters ?? null,
+                subShare: stream.sub_share ?? null,
+                emoteShare: stream.emote_share ?? null,
+                peakMessages: stream.peak_messages ?? null,
+                peakBucketMinute: stream.peak_bucket_minute ?? null,
+                peakViewers: stream.peak_viewers ?? null,
+                curve: (stream.curve || []).map(point => ({
+                    percent: point.percent,
+                    messageCount: point.message_count,
+                    uniqueChatters: point.unique_chatters,
+                })),
+            })),
+            retention: (data.retention || []).map(item => ({
+                fromStreamId: item.from_stream_id,
+                toStreamId: item.to_stream_id,
+                fromAudience: item.from_audience,
+                toAudience: item.to_audience,
+                retained: item.retained,
+                retentionRate: item.retention_rate ?? null,
+            })),
+        }
+    },
+    enabled: streamIds.length >= 2 && streamIds.length <= 4,
+    ...options,
+})

--- a/frontend/hooks/useStreamTimelineQuery.js
+++ b/frontend/hooks/useStreamTimelineQuery.js
@@ -87,6 +87,15 @@ export const useStreamTimeline = (streamId, options = {}) => useQuery({
                 t: s.t,
                 viewerCount: s.viewer_count,
             })),
+            contextChanges: (data.context_changes || []).map(change => ({
+                t: change.t,
+                title: change.title,
+                categoryId: change.category_id,
+                categoryName: change.category_name,
+                language: change.language,
+                tags: change.tags || [],
+                isMature: change.is_mature,
+            })),
             peakViewers,
         }
     },

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -69,14 +69,22 @@ export const retrieveStreamMessages = (streamId: number, p: {
 
 // W3 — stream timeline (buckets + moments + metrics)
 export const retrieveStreamTimeline = (streamId: number) => api.get(`/stream/${streamId}/timeline`)
+export const retrieveStreamComparison = (streamIds: number[]) => {
+  const params = new URLSearchParams()
+  streamIds.forEach(id => params.append('stream_ids', String(id)))
+  return api.get(`/streams/compare?${params}`)
+}
 
 // W4 — creator analytics
+export const retrieveCreatorSummary = (creatorId: number) => api.get(`/creator/${creatorId}/summary`)
 export const retrieveCreatorTrends = (creatorId: number) => api.get(`/creator/${creatorId}/trends`)
 export const retrieveCreatorRegulars = (creatorId: number, p: {
   minStreams?: number, sort?: string, dir?: 'asc' | 'desc', limit?: number,
 }) => api.get(`/creator/${creatorId}/regulars?${qs({
-  min_streams: p.minStreams, sort: p.sort, dir: p.dir, limit: p.limit,
+    min_streams: p.minStreams, sort: p.sort, dir: p.dir, limit: p.limit,
 })}`)
+export const retrieveAudienceMovement = (creatorId: number, days = 30) =>
+  api.get(`/creator/${creatorId}/audience-movement?${qs({ days })}`)
 
 // W5 — per-stream insights (mentions, emotes, phrases) + creator emotes
 export const retrieveStreamMentions = (streamId: number, limit = 20) => api.get(`/stream/${streamId}/mentions?${qs({ limit })}`)
@@ -92,12 +100,20 @@ export const retrieveCreatorNeighbors = (creatorId: number, p: {
 
 // W7 — highlight queue + moment review (review endpoints are admin-only)
 export const retrieveMomentsQueue = (p: {
-  status?: 'pending' | 'bookmarked' | 'rejected', creatorId?: number, limit?: number, offset?: number,
+  status?: 'pending' | 'bookmarked' | 'rejected' | 'clipped' | 'published', creatorId?: number, limit?: number, offset?: number,
 } = {}) => api.get(`/moments?${qs({
   status: p.status, creator_id: p.creatorId, limit: p.limit, offset: p.offset,
 })}`)
-export const putMomentReview = (streamId: number, bucketMinute: string, status: 'bookmarked' | 'rejected') =>
-  api.put(`/stream/${streamId}/moments/${encodeURIComponent(bucketMinute)}/review`, { status })
+export const putMomentReview = (
+  streamId: number,
+  bucketMinute: string,
+  status: 'bookmarked' | 'rejected' | 'clipped' | 'published',
+  metadata: { clipUrl?: string | null, note?: string | null } = {},
+) => api.put(`/stream/${streamId}/moments/${encodeURIComponent(bucketMinute)}/review`, {
+  status,
+  clip_url: metadata.clipUrl || null,
+  note: metadata.note || null,
+})
 export const deleteMomentReview = (streamId: number, bucketMinute: string) =>
   api.delete(`/stream/${streamId}/moments/${encodeURIComponent(bucketMinute)}/review`)
 
@@ -119,6 +135,14 @@ export const retrieveSceneCopypastas = (p: {
 } = {}) => api.get(`/scene/copypastas?${qs({
   days: p.days, creator_id: p.creatorId, sort: p.sort, limit: p.limit, offset: p.offset,
 })}`)
+export const retrieveCopypastaPropagation = (messageTextId: number, contextSeconds = 90) =>
+  api.get(`/scene/copypastas/${messageTextId}?${qs({ context_seconds: contextSeconds })}`)
+export const retrieveScenePulse = (p: {
+  days?: number, eventType?: string, creatorId?: number, limit?: number, offset?: number,
+} = {}) => api.get(`/scene/pulse?${qs({
+  days: p.days, event_type: p.eventType, creator_id: p.creatorId, limit: p.limit, offset: p.offset,
+})}`)
+export const retrieveSceneDigest = (days = 7) => api.get(`/scene/digest?${qs({ days })}`)
 
 export const retrieveStreamComprehensive = (streamId: string | number) => api.get(`/stream/${streamId}`)
 export const retrieveAllCreators = () => api.get('/creators')

--- a/frontend/styles/_charts-timeline.scss
+++ b/frontend/styles/_charts-timeline.scss
@@ -207,6 +207,54 @@
     }
 }
 
+.timeline-context-marker {
+    position: absolute;
+    bottom: -5px;
+    width: 7px;
+    height: 7px;
+    transform: translateX(-50%) rotate(45deg);
+    border: 1px solid $sky;
+    background: $bg-surface;
+    pointer-events: auto;
+    z-index: 3;
+}
+
+.timeline-context-list {
+    display: grid;
+    gap: 0.35rem;
+    margin: 0.85rem 0 0 2.6rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid $hairline;
+}
+
+.timeline-context-item {
+    display: grid;
+    grid-template-columns: 3.25rem minmax(7rem, 0.35fr) minmax(12rem, 1fr) auto;
+    gap: 0.65rem;
+    align-items: baseline;
+    font-size: 0.75rem;
+
+    time,
+    .timeline-context-tags {
+        font-family: $font-family-monospace;
+        font-size: 0.64rem;
+        color: $gray-500;
+    }
+
+    .timeline-context-category { color: $sky; }
+    .timeline-context-title { color: $gray-100; }
+    .timeline-context-tags { text-align: right; }
+}
+
+@media (max-width: 720px) {
+    .timeline-context-item {
+        grid-template-columns: 3rem 1fr;
+
+        .timeline-context-title,
+        .timeline-context-tags { grid-column: 2; text-align: left; }
+    }
+}
+
 /* ---------- Hover tooltip ---------- */
 .chart-tooltip {
     position: absolute;

--- a/frontend/styles/_moments-queue.scss
+++ b/frontend/styles/_moments-queue.scss
@@ -262,3 +262,28 @@
         transition: none;
     }
 }
+.moment-clip-form {
+    display: grid;
+    gap: 0.75rem;
+    margin: 0.75rem 0;
+    padding: 0.75rem;
+    border: 1px solid $hairline;
+
+    label {
+        display: grid;
+        gap: 0.3rem;
+        font-size: 0.78rem;
+        color: $gray-400;
+    }
+}
+
+.moment-clip-result {
+    margin: 0.75rem 0;
+    padding-left: 0.75rem;
+    border-left: 2px solid $phosphor;
+
+    p {
+        margin: 0.25rem 0 0;
+        color: $gray-400;
+    }
+}

--- a/frontend/styles/_scene.scss
+++ b/frontend/styles/_scene.scss
@@ -2,6 +2,207 @@
 // the copypasta library card list. Night-ops tokens throughout.
 
 /* ---------- Live now ---------- */
+.creator-dossier-header .creator-identity {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.creator-avatar {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 1px solid rgba($phosphor, 0.45);
+}
+
+.dossier-section {
+    margin-top: 1.5rem;
+}
+
+.dossier-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+    margin-top: 1.5rem;
+
+    .dossier-copypastas {
+        grid-column: 1 / -1;
+    }
+}
+
+.propagation-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.propagation-timeline {
+    list-style: none;
+    padding: 0 0 0 0.65rem;
+    margin: 1rem 0 0;
+    border-left: 1px solid rgba($phosphor, 0.25);
+
+    li {
+        position: relative;
+        padding: 0 0 1.25rem 1.25rem;
+    }
+
+    .propagation-node {
+        position: absolute;
+        left: -0.98rem;
+        top: 0.25rem;
+        width: 0.6rem;
+        height: 0.6rem;
+        border-radius: 50%;
+        background: $phosphor;
+        box-shadow: 0 0 8px rgba($phosphor, 0.55);
+    }
+}
+
+.propagation-creator,
+.propagation-stream {
+    display: block;
+}
+
+.propagation-creator {
+    font-weight: 700;
+}
+
+.origin-chat {
+    max-height: 34rem;
+    overflow: auto;
+    margin-top: 1rem;
+}
+
+.origin-message {
+    display: grid;
+    grid-template-columns: 5rem minmax(6rem, auto) 1fr;
+    gap: 0.65rem;
+    padding: 0.35rem 0.5rem;
+
+    &.is-pasta {
+        background: rgba($phosphor, 0.12);
+        border-left: 2px solid $phosphor;
+    }
+}
+
+.origin-nick {
+    color: $phosphor;
+    font-weight: 600;
+}
+
+.compare-toolbar .rs__control {
+    min-width: min(680px, 72vw);
+}
+
+.compare-chart-wrap {
+    margin-top: 1rem;
+}
+
+.compare-chart {
+    width: 100%;
+    height: auto;
+    overflow: visible;
+
+    text {
+        fill: $gray-500;
+        font-size: 12px;
+    }
+}
+
+.compare-grid-line {
+    stroke: $hairline;
+}
+
+.compare-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+
+    i {
+        display: inline-block;
+        width: 0.75rem;
+        height: 0.75rem;
+        margin-right: 0.35rem;
+        border-radius: 50%;
+    }
+}
+
+.compare-table th,
+.compare-table td {
+    min-width: 150px;
+}
+
+.retention-strip {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.movement-toolbar .rs__control {
+    min-width: 260px;
+}
+
+.movement-caveat {
+    margin: 1rem 0 0;
+    color: $gray-500;
+    font-size: 0.8rem;
+}
+
+.pulse-toolbar .form-select {
+    width: auto;
+}
+
+.pulse-feed {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.pulse-event .card-body {
+    display: grid;
+    grid-template-columns: 2.5rem 1fr;
+    gap: 0.75rem;
+}
+
+.pulse-icon {
+    display: grid;
+    place-items: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border: 1px solid rgba($phosphor, 0.35);
+    border-radius: 50%;
+    color: $phosphor;
+}
+
+.pulse-content {
+    h2 {
+        margin: 0.2rem 0;
+        font-size: 1rem;
+    }
+
+    p {
+        margin: 0;
+        color: $gray-300;
+    }
+}
+
+.pulse-links {
+    display: flex;
+    gap: 1rem;
+    margin-top: 0.5rem;
+    font-size: 0.78rem;
+}
+
+@media (max-width: 767px) {
+    .dossier-grid,
+    .propagation-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 .live-stale-note {
     display: flex;
     align-items: center;

--- a/frontend/views/AudienceMovement.jsx
+++ b/frontend/views/AudienceMovement.jsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import Select from 'react-select'
+import { Card } from 'react-bootstrap'
+import { useAudienceMovement, useCreators } from '@/hooks/useApiQuery'
+import ErrorAlert from '@/components/ErrorAlert'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+const WINDOWS = [7, 30, 90]
+
+const AssociationList = ({ title, items, empty }) => (
+    <Card><Card.Body>
+        <div className="section-label">{title}</div>
+        {items.length ? <ol className="rank-list">{items.map((item, index) => (
+            <li key={item.creatorId}>
+                <span className="rank">{String(index + 1).padStart(2, '0')}</span>
+                <Link className="nick" href={`/creator/${item.creatorId}`}>{item.displayName || item.nick}</Link>
+                <span className="count">{item.chatterCount}</span>
+            </li>
+        ))}</ol> : <p className="text-muted mt-3">{empty}</p>}
+    </Card.Body></Card>
+)
+
+/** @param {{initialCreatorId?: number|null}} props */
+const AudienceMovement = ({ initialCreatorId = null }) => {
+    const [creatorId, setCreatorId] = useState(initialCreatorId)
+    const [days, setDays] = useState(30)
+    const creatorsQuery = useCreators()
+    const options = useMemo(() => (creatorsQuery.data || []).map(row => ({ value: row[0], label: row[1] })), [creatorsQuery.data])
+    const selected = options.find(option => option.value === creatorId) || null
+    const query = useAudienceMovement(creatorId, days)
+    const data = query.data
+
+    return <>
+        <header className="page-head"><div><p className="page-sub">participation change, not causal migration</p><h1 className="page-title">Audience movement</h1></div></header>
+        <div className="toolbar movement-toolbar">
+            <Select classNamePrefix="rs" instanceId="movement-creator" options={options} value={selected} onChange={option => setCreatorId(option?.value || null)} placeholder="Choose creator..." />
+            <div className="chatter-tabs" role="tablist" aria-label="Movement window">
+                {WINDOWS.map(window => <button key={window} type="button" role="tab" aria-selected={days === window} className={days === window ? 'chatter-tab active' : 'chatter-tab'} onClick={() => setDays(window)}>{window} days</button>)}
+            </div>
+        </div>
+        {!creatorId ? <div className="empty-state"><p className="empty-title">Choose a creator</p><p className="empty-hint">Compare distinct chat participants with the preceding equal window.</p></div> : null}
+        {query.isLoading ? <LoadingSpinner size="lg" text="Following audience participation..." /> : null}
+        {query.error ? <ErrorAlert title="Movement report failed" error={query.error} onRetry={query.refetch} /> : null}
+        {data ? <>
+            <div className="stats-strip" role="list">
+                {[
+                    ['Current audience', data.currentAudience],
+                    ['Previous audience', data.previousAudience],
+                    ['Retained', data.retained],
+                    ['Gained', data.gained],
+                    ['Lapsed', data.lapsed],
+                    ['Retention', data.retentionRate == null ? '--' : `${Math.round(data.retentionRate * 100)}%`],
+                ].map(([label, value]) => <div className="stat-tile" role="listitem" key={label}><div className="stat-label">{label}</div><div className="stat-value">{typeof value === 'number' ? value.toLocaleString() : value}</div></div>)}
+            </div>
+            <p className="movement-caveat">Associations below mean the same chatters participated in those channels during the adjacent window. They do not prove that viewers moved because of a creator.</p>
+            <div className="dossier-grid">
+                <AssociationList title="Earlier channels for gained chatters" items={data.priorChannelsForGained} empty="No earlier cross-channel activity found." />
+                <AssociationList title="Current channels for lapsed chatters" items={data.currentChannelsForLapsed} empty="No current cross-channel activity found." />
+            </div>
+        </> : null}
+    </>
+}
+
+export default AudienceMovement

--- a/frontend/views/CopypastaPropagation.jsx
+++ b/frontend/views/CopypastaPropagation.jsx
@@ -1,0 +1,86 @@
+'use client'
+
+import Link from 'next/link'
+import { Card } from 'react-bootstrap'
+import { useCopypastaPropagation } from '@/hooks/useApiQuery'
+import ErrorAlert from '@/components/ErrorAlert'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+const stamp = value => value ? value.replace('T', ' ').slice(0, 16) : '--'
+
+const CopypastaPropagation = ({ messageTextId }) => {
+    const query = useCopypastaPropagation(messageTextId)
+    if (!Number.isInteger(messageTextId) || messageTextId <= 0) {
+        return <ErrorAlert title="Invalid copypasta" error={new Error('Copypasta ID must be positive.')} />
+    }
+    if (query.isLoading) return <LoadingSpinner size="lg" text="Tracing copypasta propagation..." />
+    if (query.error) return <ErrorAlert title="Failed to trace copypasta" error={query.error} onRetry={query.refetch} />
+
+    const pasta = query.data
+    return (
+        <>
+            <header className="page-head">
+                <div>
+                    <p className="page-sub">meme propagation · first seen {stamp(pasta.firstSeen)}</p>
+                    <h1 className="page-title">Copypasta trace</h1>
+                </div>
+                <Link className="btn btn-outline-primary btn-sm" href="/copypasta">Back to library</Link>
+            </header>
+
+            <Card className="pasta-origin-card">
+                <Card.Body>
+                    <blockquote className="pasta-text mono">{pasta.text}</blockquote>
+                    <div className="pasta-chips">
+                        <span className="pasta-chip mono">{pasta.usageCount.toLocaleString()} uses</span>
+                        <span className="pasta-chip mono">{pasta.creatorCount} channels</span>
+                        <span className="pasta-chip mono">{pasta.streamCount} streams</span>
+                        <span className="pasta-chip mono">{pasta.chatterAppearances} chatter appearances</span>
+                    </div>
+                </Card.Body>
+            </Card>
+
+            <div className="propagation-grid">
+                <Card>
+                    <Card.Body>
+                        <div className="section-label">Propagation timeline</div>
+                        <ol className="propagation-timeline">
+                            {pasta.occurrences.map((item, index) => (
+                                <li key={item.streamId}>
+                                    <span className="propagation-node" aria-hidden="true" />
+                                    <div>
+                                        <div className="mono text-muted">{stamp(item.firstSeen)} {index === 0 ? '· origin' : ''}</div>
+                                        <Link href={`/creator/${item.creatorId}`} className="propagation-creator">
+                                            {item.displayName || item.nick}
+                                        </Link>
+                                        <Link href={`/stream/${item.streamId}`} className="propagation-stream">
+                                            {item.streamTitle}
+                                        </Link>
+                                        <span className="mono text-muted">{item.usageCount} uses · {item.chatterCount} chatters</span>
+                                    </div>
+                                </li>
+                            ))}
+                        </ol>
+                    </Card.Body>
+                </Card>
+
+                <Card>
+                    <Card.Body>
+                        <div className="section-label">Origin chat · ±90 seconds</div>
+                        <div className="origin-chat" role="log">
+                            {pasta.originContext.map(message => (
+                                <div key={message.id} className={message.text === pasta.text ? 'origin-message is-pasta' : 'origin-message'}>
+                                    <span className="mono text-muted">{message.time.slice(11, 19)}</span>
+                                    <span className="origin-nick">{message.nick}</span>
+                                    <span>{message.text}</span>
+                                </div>
+                            ))}
+                            {pasta.originContext.length === 0 ? <p className="text-muted">No surrounding chat available.</p> : null}
+                        </div>
+                    </Card.Body>
+                </Card>
+            </div>
+        </>
+    )
+}
+
+export default CopypastaPropagation

--- a/frontend/views/CreatorDossier.jsx
+++ b/frontend/views/CreatorDossier.jsx
@@ -1,0 +1,152 @@
+'use client'
+
+import Link from 'next/link'
+import { Card } from 'react-bootstrap'
+import {
+    useCreatorEmotes,
+    useCreatorNeighbors,
+    useCreatorSummary,
+    useSceneCopypastas,
+} from '@/hooks/useApiQuery'
+import ErrorAlert from '@/components/ErrorAlert'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import RegularsPanel from '@/components/creator/RegularsPanel'
+import TrendsPanel from '@/components/creator/TrendsPanel'
+import { formatTimeAgo } from '@/utils/dateUtils'
+
+const compact = value => new Intl.NumberFormat('en', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+}).format(value || 0)
+
+const duration = seconds => {
+    if (seconds == null) return '--'
+    return `${Math.round(seconds / 3600).toLocaleString()}h`
+}
+
+const CreatorDossier = ({ creatorId }) => {
+    const summaryQuery = useCreatorSummary(creatorId)
+    const emotesQuery = useCreatorEmotes(creatorId, 8)
+    const neighborsQuery = useCreatorNeighbors(creatorId, { metric: 'regulars', limit: 6 })
+    const copypastasQuery = useSceneCopypastas({ creatorId, sort: 'usage', limit: 5 })
+
+    if (!Number.isInteger(creatorId) || creatorId <= 0) {
+        return <ErrorAlert title="Invalid creator" error={new Error('Creator ID must be a positive integer.')} />
+    }
+    if (summaryQuery.isLoading) return <LoadingSpinner size="lg" text="Building creator dossier..." />
+    if (summaryQuery.error) {
+        return <ErrorAlert title="Failed to load creator" error={summaryQuery.error} onRetry={summaryQuery.refetch} />
+    }
+
+    const creator = summaryQuery.data
+    const stats = [
+        ['Streams', creator.totalStreams.toLocaleString()],
+        ['Chat messages', compact(creator.totalMessages)],
+        ['Hours captured', duration(creator.durationSeconds)],
+        ['Avg msgs/min', creator.messagesPerMinute == null ? '--' : creator.messagesPerMinute.toFixed(1)],
+        ['Known audience', compact(creator.audienceSize)],
+        ['Regulars', creator.regulars.toLocaleString()],
+    ]
+
+    return (
+        <>
+            <header className="page-header creator-dossier-header">
+                <div className="creator-identity">
+                    {creator.profileImageUrl ? (
+                        <img className="creator-avatar" src={creator.profileImageUrl} alt="" />
+                    ) : null}
+                    <div>
+                        <p className="page-sub">creator dossier · last seen {creator.lastStreamAt ? formatTimeAgo(creator.lastStreamAt) : 'never'}</p>
+                        <h1 className="page-title">{creator.displayName || creator.nick}</h1>
+                        <p className="mono text-muted">@{creator.nick}</p>
+                    </div>
+                </div>
+                <div className="d-flex gap-2">
+                    <Link className="btn btn-outline-primary btn-sm" href={`/movement?creator=${creatorId}`}>
+                        Audience movement
+                    </Link>
+                    {creator.latestStream ? (
+                        <Link className="btn btn-outline-primary btn-sm" href={`/stream/${creator.latestStream.streamId}`}>
+                            Latest stream
+                        </Link>
+                    ) : null}
+                </div>
+            </header>
+
+            <div className="stats-strip" role="list" aria-label="Creator lifetime statistics">
+                {stats.map(([label, value]) => (
+                    <div className="stat-tile" role="listitem" key={label}>
+                        <div className="stat-label">{label}</div>
+                        <div className="stat-value">{value}</div>
+                    </div>
+                ))}
+            </div>
+
+            <section className="dossier-section">
+                <div className="section-label">Recent trajectory</div>
+                <TrendsPanel creatorId={creatorId} />
+            </section>
+
+            <div className="dossier-grid">
+                <Card>
+                    <Card.Body>
+                        <div className="section-label">Signature emotes</div>
+                        {emotesQuery.isLoading && <LoadingSpinner text="Loading emotes..." />}
+                        <ol className="rank-list">
+                            {(emotesQuery.data?.emotes || []).map((emote, index) => (
+                                <li key={`${emote.source}:${emote.name}`}>
+                                    <span className="rank">{String(index + 1).padStart(2, '0')}</span>
+                                    <span className="nick">{emote.name}</span>
+                                    <span className="count">{compact(emote.usageCount)}</span>
+                                </li>
+                            ))}
+                        </ol>
+                    </Card.Body>
+                </Card>
+
+                <Card>
+                    <Card.Body>
+                        <div className="section-label">Audience also watches</div>
+                        {neighborsQuery.isLoading && <LoadingSpinner text="Loading neighbors..." />}
+                        <ol className="rank-list">
+                            {(neighborsQuery.data?.neighbors || []).map((neighbor, index) => (
+                                <li key={neighbor.creatorId}>
+                                    <span className="rank">{String(index + 1).padStart(2, '0')}</span>
+                                    <Link className="nick" href={`/creator/${neighbor.creatorId}`}>
+                                        {neighbor.displayName || neighbor.nick}
+                                    </Link>
+                                    <span className="count">{neighbor.sharedRegulars} shared</span>
+                                </li>
+                            ))}
+                        </ol>
+                    </Card.Body>
+                </Card>
+
+                <Card className="dossier-copypastas">
+                    <Card.Body>
+                        <div className="section-label">Signature copypastas</div>
+                        {copypastasQuery.isLoading && <LoadingSpinner text="Loading copypastas..." />}
+                        <ol className="rank-list">
+                            {(copypastasQuery.data?.items || []).map((item, index) => (
+                                <li key={item.messageTextId}>
+                                    <span className="rank">{String(index + 1).padStart(2, '0')}</span>
+                                    <Link className="nick text-truncate" href={`/copypasta/${item.messageTextId}`}>
+                                        {item.text}
+                                    </Link>
+                                    <span className="count">{item.usageCount}×</span>
+                                </li>
+                            ))}
+                        </ol>
+                    </Card.Body>
+                </Card>
+            </div>
+
+            <section className="dossier-section">
+                <div className="section-label">Core regulars</div>
+                <RegularsPanel creatorId={creatorId} />
+            </section>
+        </>
+    )
+}
+
+export default CreatorDossier

--- a/frontend/views/LiveNow.jsx
+++ b/frontend/views/LiveNow.jsx
@@ -1,5 +1,6 @@
 'use client'
 import { useMemo } from 'react'
+import Link from 'next/link'
 import { Card } from 'react-bootstrap'
 import { useSceneLive } from '@/hooks/useApiQuery'
 import LoadingSpinner from '@/components/LoadingSpinner'
@@ -54,6 +55,7 @@ const uptimeLabel = startedAt => {
  */
 const LiveCard = ({ streamer }) => {
     const {
+        creatorId,
         nick,
         displayName,
         profileImageUrl,
@@ -86,7 +88,7 @@ const LiveCard = ({ streamer }) => {
                                 aria-hidden="true" />
                         )}
                     <div className="live-identity">
-                        <span className="live-name">{name}</span>
+                        <Link className="live-name" href={`/creator/${creatorId}`}>{name}</Link>
                         <span
                             className="status-chip is-ok live-chip"
                             aria-label="Live now">

--- a/frontend/views/Moments.jsx
+++ b/frontend/views/Moments.jsx
@@ -42,6 +42,16 @@ const STATUS_TABS = [
         label: 'Rejected',
         value: 'rejected',
     },
+    {
+        key: 'clipped',
+        label: 'Clipped',
+        value: 'clipped',
+    },
+    {
+        key: 'published',
+        label: 'Published',
+        value: 'published',
+    },
 ]
 
 const EMPTY_HINT = {
@@ -49,6 +59,8 @@ const EMPTY_HINT = {
     pending: 'Nothing awaiting review — every surfaced moment has been triaged.',
     bookmarked: 'No bookmarked moments yet. Bookmark spikes worth clipping to collect them here.',
     rejected: 'No rejected moments.',
+    clipped: 'No clips attached yet.',
+    published: 'No published highlights yet.',
 }
 
 /**
@@ -126,11 +138,13 @@ const Moments = () => {
     }, [
     ])
 
-    const handleReview = useCallback((moment, nextStatus) => {
+    const handleReview = useCallback((moment, nextStatus, metadata = {}) => {
         review.mutate({
             streamId: moment.streamId,
             bucketMinute: moment.t,
             status: nextStatus,
+            clipUrl: metadata.clipUrl,
+            note: metadata.note,
         })
     }, [
         review,
@@ -240,7 +254,7 @@ const Moments = () => {
                                     moment={moment}
                                     isAdmin={isAdmin}
                                     pending={pendingKey === key}
-                                    onReview={next => handleReview(moment, next)}
+                                    onReview={(next, metadata) => handleReview(moment, next, metadata)}
                                 />
                             )
                         })}

--- a/frontend/views/Scene.jsx
+++ b/frontend/views/Scene.jsx
@@ -4,6 +4,7 @@ import {
     useMemo,
     useState,
 } from 'react'
+import Link from 'next/link'
 import { Card, Table } from 'react-bootstrap'
 import { useSceneLeaderboard } from '@/hooks/useApiQuery'
 import LoadingSpinner from '@/components/LoadingSpinner'
@@ -278,7 +279,7 @@ const Scene = () => {
                                         <tr key={entry.creatorId}>
                                             <td className="rank-num">{String(entry.rank).padStart(2, '0')}</td>
                                             <td>
-                                                <span className="scene-streamer">
+                                                <Link className="scene-streamer" href={`/creator/${entry.creatorId}`}>
                                                     {entry.profileImageUrl
                                                         ? (
                                                             <img
@@ -298,7 +299,7 @@ const Scene = () => {
                                                     <span className="scene-streamer-name">
                                                         {entry.displayName || entry.nick}
                                                     </span>
-                                                </span>
+                                                </Link>
                                             </td>
                                             <td className="mono text-end">{numCell(entry.streams)}</td>
                                             <td className="mono text-end">{numCell(entry.hoursStreamed, 1)}</td>

--- a/frontend/views/ScenePulse.jsx
+++ b/frontend/views/ScenePulse.jsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Card } from 'react-bootstrap'
+import { useSceneDigest, useScenePulse } from '@/hooks/useApiQuery'
+import ErrorAlert from '@/components/ErrorAlert'
+import LoadingSpinner from '@/components/LoadingSpinner'
+import { formatTimeAgo } from '@/utils/dateUtils'
+
+const FILTERS = [
+    ['', 'Everything'],
+    ['personal_record', 'Records'],
+    ['standout_moment', 'Moments'],
+    ['copypasta_spread', 'Copypastas'],
+    ['stream_report', 'Streams'],
+]
+
+const icon = type => ({
+    personal_record: 'bi-trophy',
+    standout_moment: 'bi-lightning',
+    copypasta_spread: 'bi-chat-quote',
+    stream_report: 'bi-broadcast',
+}[type] || 'bi-activity')
+
+const ScenePulse = () => {
+    const [eventType, setEventType] = useState('')
+    const [days, setDays] = useState(7)
+    const [copied, setCopied] = useState(false)
+    const pulse = useScenePulse({ days, eventType: eventType || undefined, limit: 100 })
+    const digest = useSceneDigest(days)
+
+    const copyDigest = async () => {
+        await navigator.clipboard.writeText(digest.data || '')
+        setCopied(true)
+        window.setTimeout(() => setCopied(false), 1500)
+    }
+
+    return <>
+        <header className="page-head"><div><p className="page-sub">what changed across the captured scene</p><h1 className="page-title">Scene pulse</h1></div><button type="button" className="btn btn-outline-primary btn-sm" disabled={!digest.data} onClick={copyDigest}>{copied ? 'Copied' : 'Copy digest'}</button></header>
+        <div className="toolbar pulse-toolbar">
+            <div className="chatter-tabs" role="tablist" aria-label="Event type">{FILTERS.map(([value, label]) => <button key={value} type="button" role="tab" aria-selected={eventType === value} className={eventType === value ? 'chatter-tab active' : 'chatter-tab'} onClick={() => setEventType(value)}>{label}</button>)}</div>
+            <select className="form-select form-select-sm" value={days} onChange={event => setDays(Number(event.target.value))}><option value="1">24 hours</option><option value="7">7 days</option><option value="30">30 days</option><option value="90">90 days</option></select>
+        </div>
+        {pulse.isLoading ? <LoadingSpinner size="lg" text="Reading the scene..." /> : null}
+        {pulse.error ? <ErrorAlert title="Scene pulse failed" error={pulse.error} onRetry={pulse.refetch} /> : null}
+        {!pulse.isLoading && !pulse.error && !pulse.data?.items.length ? <div className="empty-state"><p className="empty-title">No events yet</p><p className="empty-hint">Re-run stream rollups to populate deterministic scene events.</p></div> : null}
+        <div className="pulse-feed">
+            {(pulse.data?.items || []).map(event => <Card key={event.id} className={`pulse-event pulse-${event.eventType}`}><Card.Body>
+                <div className="pulse-icon"><i className={`bi ${icon(event.eventType)}`} aria-hidden="true" /></div>
+                <div className="pulse-content">
+                    <div className="mono text-muted">{formatTimeAgo(event.occurredAt)} · {event.eventType.replaceAll('_', ' ')}</div>
+                    <h2>{event.title}</h2>
+                    <p>{event.summary}</p>
+                    <div className="pulse-links">
+                        {event.creatorId ? <Link href={`/creator/${event.creatorId}`}>Creator dossier</Link> : null}
+                        {event.streamId ? <Link href={`/stream/${event.streamId}`}>Stream</Link> : null}
+                        {event.messageTextId ? <Link href={`/copypasta/${event.messageTextId}`}>Trace copypasta</Link> : null}
+                    </div>
+                </div>
+            </Card.Body></Card>)}
+        </div>
+    </>
+}
+
+export default ScenePulse

--- a/frontend/views/StreamCompare.jsx
+++ b/frontend/views/StreamCompare.jsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import Select from 'react-select'
+import { Card, Table } from 'react-bootstrap'
+import { useStreamComparison, useStreams } from '@/hooks/useApiQuery'
+import ErrorAlert from '@/components/ErrorAlert'
+import LoadingSpinner from '@/components/LoadingSpinner'
+
+const COLORS = ['#69f0ae', '#ffb74d', '#64b5f6', '#ef9a9a']
+const metrics = [
+    ['Total messages', 'totalMessages', value => value?.toLocaleString?.() ?? '--'],
+    ['Messages/min', 'messagesPerMinute', value => value == null ? '--' : value.toFixed(1)],
+    ['Unique chatters', 'uniqueChatters', value => value?.toLocaleString?.() ?? '--'],
+    ['New chatters', 'newChatters', value => value?.toLocaleString?.() ?? '--'],
+    ['Returning', 'returningChatters', value => value?.toLocaleString?.() ?? '--'],
+    ['Peak viewers', 'peakViewers', value => value?.toLocaleString?.() ?? '--'],
+    ['Subscriber share', 'subShare', value => value == null ? '--' : `${Math.round(value * 100)}%`],
+    ['Emote share', 'emoteShare', value => value == null ? '--' : `${Math.round(value * 100)}%`],
+]
+
+const CurveChart = ({ streams }) => {
+    const max = Math.max(1, ...streams.flatMap(stream => stream.curve.map(point => point.messageCount)))
+    return (
+        <div className="compare-chart-wrap">
+            <svg className="compare-chart" viewBox="0 0 800 260" role="img" aria-label="Normalized chat activity curves">
+                {[0, 25, 50, 75, 100].map(percent => (
+                    <g key={percent}>
+                        <line x1={percent * 8} x2={percent * 8} y1="0" y2="230" className="compare-grid-line" />
+                        <text x={percent * 8} y="252" textAnchor="middle">{percent}%</text>
+                    </g>
+                ))}
+                {streams.map((stream, index) => (
+                    <polyline
+                        key={stream.streamId}
+                        fill="none"
+                        stroke={COLORS[index]}
+                        strokeWidth="3"
+                        points={stream.curve.map(point => `${point.percent * 8},${225 - point.messageCount * 215 / max}`).join(' ')}
+                    />
+                ))}
+            </svg>
+            <div className="compare-legend">
+                {streams.map((stream, index) => (
+                    <span key={stream.streamId}><i style={{ background: COLORS[index] }} />{stream.creatorDisplayName} · #{stream.streamId}</span>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+/** @param {{initialIds?: number[]}} props */
+const StreamCompare = ({ initialIds = [] }) => {
+    const [selectedIds, setSelectedIds] = useState(initialIds)
+    const streamsQuery = useStreams({ sort: 'start', dir: 'desc' })
+    const options = useMemo(() => {
+        const recent = (streamsQuery.data?.streams || []).map(row => ({
+            value: row[0],
+            label: `${row[1]} · ${row[2]} · #${row[0]}`,
+        }))
+        initialIds.forEach(id => {
+            if (!recent.some(option => option.value === id)) recent.push({ value: id, label: `Stream #${id}` })
+        })
+        return recent
+    }, [streamsQuery.data, initialIds])
+    const selected = options.filter(option => selectedIds.includes(option.value))
+    const comparison = useStreamComparison(selectedIds)
+    const streams = comparison.data?.streams || []
+
+    return (
+        <>
+            <header className="page-head">
+                <div><p className="page-sub">normalized side-by-side analytics</p><h1 className="page-title">Stream comparison</h1></div>
+            </header>
+            <div className="toolbar compare-toolbar">
+                <label className="visually-hidden" htmlFor="compare-streams">Choose streams</label>
+                <Select
+                    classNamePrefix="rs"
+                    instanceId="compare-streams"
+                    inputId="compare-streams"
+                    isMulti
+                    options={options}
+                    value={selected}
+                    onChange={items => setSelectedIds(items.slice(0, 4).map(item => item.value))}
+                    placeholder="Choose 2–4 recent streams..."
+                />
+                <span className="toolbar-readout">{selectedIds.length}/4 selected</span>
+            </div>
+
+            {selectedIds.length < 2 ? <div className="empty-state"><p className="empty-title">Choose at least two streams</p></div> : null}
+            {comparison.isLoading ? <LoadingSpinner size="lg" text="Comparing streams..." /> : null}
+            {comparison.error ? <ErrorAlert title="Comparison failed" error={comparison.error} onRetry={comparison.refetch} /> : null}
+            {streams.length >= 2 ? (
+                <>
+                    <Card><Card.Body><div className="section-label">Chat activity by stream progress</div><CurveChart streams={streams} /></Card.Body></Card>
+                    <Card className="mt-3"><Card.Body className="p-0"><Table responsive hover className="mb-0 compare-table">
+                        <thead><tr><th>Metric</th>{streams.map(stream => <th key={stream.streamId}><Link href={`/stream/${stream.streamId}`}>{stream.creatorDisplayName}<br /><small>{stream.title}</small></Link></th>)}</tr></thead>
+                        <tbody>{metrics.map(([label, key, format]) => <tr key={key}><th>{label}</th>{streams.map(stream => <td className="mono" key={stream.streamId}>{format(stream[key])}</td>)}</tr>)}</tbody>
+                    </Table></Card.Body></Card>
+                    <div className="retention-strip">
+                        {(comparison.data?.retention || []).map(item => (
+                            <Card key={`${item.fromStreamId}-${item.toStreamId}`}><Card.Body>
+                                <div className="section-label">#{item.fromStreamId} → #{item.toStreamId}</div>
+                                <div className="stat-value">{item.retentionRate == null ? '--' : `${Math.round(item.retentionRate * 100)}%`}</div>
+                                <div className="stat-hint">{item.retained} of {item.fromAudience} chatters returned</div>
+                            </Card.Body></Card>
+                        ))}
+                    </div>
+                </>
+            ) : null}
+        </>
+    )
+}
+
+export default StreamCompare


### PR DESCRIPTION
## Summary
- add creator dossiers, stream comparison, audience movement, and copypasta propagation
- add highlight clip workflow, scene pulse/digest, and context history
- add bounded live Twitch chat capture with VOD reconciliation

## Validation
- 432 backend unit tests pass against PostgreSQL
- Ruff, TypeScript, ESLint, Next.js production build pass
- Alembic 0010 through 0013 offline SQL and Compose configurations validated

## Deployment requirements
- migrate through Alembic 0013
- provision TWITCH_BOT_REFRESH_TOKEN with chat:read before enabling stream-sniper-live
- optionally provision SCENE_DIGEST_WEBHOOK_URL