### PR TITLE
Fix scene event Decimal serialization

### DIFF
--- a/backend/stream_sniper/analytics/scene_events.py
+++ b/backend/stream_sniper/analytics/scene_events.py
@@ -1,9 +1,16 @@
 """Derive human-readable, deterministic events from one stream's rollups."""
 
+from decimal import Decimal
+
 from ..database.scene_event_table_gateway import (
     replace_stream_scene_events_db,
     select_stream_event_signals_db,
 )
+
+
+def _json_number(value):
+    """Convert PostgreSQL NUMERIC values before placing them in JSON metadata."""
+    return float(value) if isinstance(value, Decimal) else value
 
 
 def _record_event(stream_id, creator_id, creator, occurred_at, kind, label, value):
@@ -24,6 +31,8 @@ def refresh_stream_events(stream_id: int) -> int:
         replace_stream_scene_events_db(stream_id, [])
         return 0
     _, creator_id, creator, stream_title, occurred_at, messages, unique, rate, prev_messages, prev_unique, prev_rate = header
+    rate = _json_number(rate)
+    prev_rate = _json_number(prev_rate)
     events = [{
         "event_type": "stream_report",
         "occurred_at": occurred_at,

--- a/backend/tests/unit/analytics/test_scene_events.py
+++ b/backend/tests/unit/analytics/test_scene_events.py
@@ -1,5 +1,7 @@
 """Tests for deterministic scene-event derivation and digest formatting."""
 
+import json
+from decimal import Decimal
 from unittest.mock import patch
 
 from stream_sniper.analytics.digest import format_digest
@@ -24,6 +26,33 @@ def test_refresh_builds_report_records_moment_and_spread(signals, replace):
     }
     assert len({event["dedupe_key"] for event in events}) == 6
     assert next(e for e in events if e["event_type"] == "copypasta_spread")["message_text_id"] == 99
+
+
+@patch("stream_sniper.analytics.scene_events.replace_stream_scene_events_db")
+@patch("stream_sniper.analytics.scene_events.select_stream_event_signals_db")
+def test_refresh_normalizes_database_decimals_for_json(signals, replace):
+    signals.return_value = (
+        (
+            42,
+            5,
+            "Alice",
+            "Big show",
+            "2024-01-02T22:00:00",
+            2000,
+            300,
+            Decimal("20.25"),
+            1500,
+            250,
+            Decimal("18.5"),
+        ),
+        None,
+        [],
+    )
+
+    refresh_stream_events(42)
+
+    events = replace.call_args.args[1]
+    json.dumps([event["metadata"] for event in events])
 
 
 @patch("stream_sniper.analytics.scene_events.replace_stream_scene_events_db")


### PR DESCRIPTION
## Summary
- normalize PostgreSQL `NUMERIC` chat-rate values before storing scene-event JSON metadata
- add a regression test reproducing the production `Decimal is not JSON serializable` failure

## Root cause
`stream_metrics.messages_per_minute` is returned by psycopg2 as `Decimal`; the new scene-event rollup passed it directly to `psycopg2.extras.Json`.

## Validation
- `uv run ruff check stream_sniper/analytics/scene_events.py tests/unit/analytics/test_scene_events.py`
- full backend unit suite: 436 passed