### PR TITLE
Fix live capture production boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,13 @@ jobs:
         docker run --rm -e JWT_SECRET_KEY=ci-test-secret stream-sniper-api:test \
           python -c "import stream_sniper.api.api; print('API image import OK')"
 
+        # An empty named volume inherits /tokens ownership from the image. The
+        # non-root live service must be able to persist OAuth token rotations.
+        token_volume=$(docker volume create)
+        trap 'docker volume rm -f "$token_volume"' EXIT
+        docker run --rm -v "$token_volume:/tokens" stream-sniper-api:test \
+          sh -c "touch /tokens/refresh-token && test -w /tokens/refresh-token"
+
         # Collector image: the CLI supports --help
         docker run --rm stream-sniper-collector:test --help
 

--- a/backend/Dockerfile.api
+++ b/backend/Dockerfile.api
@@ -36,6 +36,10 @@ WORKDIR /app
 # Copy only the built virtualenv — no uv, no build tools, no source-as-editable
 COPY --from=builder --chown=app:app /app/.venv /app/.venv
 
+# Docker copies this ownership into a newly created named volume. The live-chat
+# service must be able to persist rotated Twitch refresh tokens as `app`.
+RUN install -d -o app -g app /tokens
+
 # Make the venv's console scripts / interpreter the default PATH
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/backend/stream_sniper/collector/live/live_message_sink.py
+++ b/backend/stream_sniper/collector/live/live_message_sink.py
@@ -26,6 +26,20 @@ def _emote_count(raw) -> int:
     )
 
 
+def _badge_text(raw) -> str | None:
+    """Match the canonical ``name/version`` text used by VOD ingestion."""
+    if not raw:
+        return None
+    if isinstance(raw, dict):
+        pairs = (
+            f"{name}/{version if version is not None else 0}"
+            for name, version in sorted(raw.items())
+            if name
+        )
+        return ",".join(pairs) or None
+    return str(raw)
+
+
 class LiveMessageSink:
     def __init__(self, buffer_size: int = 1000):
         self.buffer_size = max(10, buffer_size)
@@ -77,7 +91,7 @@ class LiveMessageSink:
         if "@" in text:
             tagged = text.lower().split("@", 1)[1].split(" ", 1)[0].rstrip(".,:;!?")
             tagged_id = self._chatters.get(tagged)
-        badges = message.user.badges or None
+        badges = _badge_text(message.user.badges)
         emote_count = _emote_count(message.emotes)
         sent_at = datetime.fromtimestamp(message.sent_timestamp / 1000, UTC)
         self._items.append(

--- a/backend/tests/unit/collector/test_live_message_sink.py
+++ b/backend/tests/unit/collector/test_live_message_sink.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import pytest
 
 from stream_sniper.collector.live import live_message_sink as sink_module
-from stream_sniper.collector.live.live_message_sink import LiveMessageSink, _emote_count
+from stream_sniper.collector.live.live_message_sink import LiveMessageSink, _badge_text, _emote_count
 
 
 def _stream(session_id=123):
@@ -20,7 +20,11 @@ def _message(message_id="uuid-1"):
     return SimpleNamespace(
         id=message_id,
         room=SimpleNamespace(name="SomeStreamer"),
-        user=SimpleNamespace(name="Viewer", subscriber=True, badges="subscriber/3"),
+        user=SimpleNamespace(
+            name="Viewer",
+            subscriber=True,
+            badges={"subscriber": "3", "moderator": "1"},
+        ),
         text="hello @other",
         emotes=None,
         sent_timestamp=1_752_408_100_000,
@@ -30,6 +34,11 @@ def _message(message_id="uuid-1"):
 def test_emote_count_counts_each_range():
     assert _emote_count(None) == 0
     assert _emote_count("25:0-4,6-10/1902:12-16") == 3
+
+
+def test_badge_text_handles_empty_and_already_serialized_values():
+    assert _badge_text(None) is None
+    assert _badge_text("subscriber/3") == "subscriber/3"
 
 
 @pytest.mark.asyncio
@@ -47,7 +56,7 @@ async def test_handle_maps_and_flushes_live_message(monkeypatch):
     assert len(written) == 1
     row = written[0]
     assert row[0:4] == (8, None, 77, 9)
-    assert row[5:9] == (True, "subscriber/3", 0, "uuid-1")
+    assert row[5:9] == (True, "moderator/1,subscriber/3", 0, "uuid-1")
     assert sink.active_session("somestreamer") == 123
 
 


### PR DESCRIPTION
## Summary
- create `/tokens` as `app:app` so empty named volumes inherit writable ownership
- serialize Twitch live badge dictionaries into the canonical text format used by VOD ingestion
- add production-shaped regression coverage for both failures

## Production evidence
1. Live startup failed with `PermissionError: /tokens/refresh-token`; repairing volume ownership made it stable.
2. Real chat then failed with `psycopg2.ProgrammingError: can't adapt type dict`; Twitch supplies badges as a dictionary while the canonical DB column is text.

## Validation
- full backend unit suite: 437 passed
- Ruff passes for changed Python files
- built API image locally
- fresh named volume write succeeded as non-root UID/GID 999:999
- production analytics rollup: 30 succeeded, 0 failed