### PR TITLE
Fix creator summary Twitch ID serialization

### DIFF
--- a/backend/stream_sniper/api/analytics_endpoints.py
+++ b/backend/stream_sniper/api/analytics_endpoints.py
@@ -66,7 +66,7 @@ def get_creator_summary(
             nick=row[1],
             display_name=row[2],
             profile_image_url=row[3],
-            twitch_id=row[4],
+            twitch_id=str(row[4]) if row[4] is not None else None,
             total_streams=row[5],
             first_stream_at=row[6],
             last_stream_at=row[7],

--- a/backend/tests/unit/api/test_creator_analytics.py
+++ b/backend/tests/unit/api/test_creator_analytics.py
@@ -125,13 +125,14 @@ class TestCreatorSummaryEndpoint:
     @patch("stream_sniper.api.analytics_endpoints.get_cache")
     @patch("stream_sniper.api.analytics_endpoints.select_creator_summary_db")
     def test_summary_maps_rollup_row(self, mock_summary, mock_get_cache):
+        """Production BIGINT Twitch IDs serialize using the public string contract."""
         mock_get_cache.return_value = _miss_cache()
         mock_summary.return_value = (
             5,
             "alice",
             "Alice",
             "https://example.com/avatar.png",
-            "12345",
+            12345,
             12,
             "2024-01-01T20:00:00",
             "2024-02-01T20:00:00",


### PR DESCRIPTION
## Summary
- normalize production BIGINT Twitch creator IDs to the API string contract
- cover the production-shaped integer value with a regression test

## Root cause
Production PostgreSQL returns `creator.twitch_id` as a BIGINT, while `CreatorSummary.twitch_id` is a string. Pydantic rejected the integer and the endpoint converted that validation error into HTTP 500.

## Validation
- `uv run pytest tests/unit/api/test_creator_analytics.py -q` (20 passed)
- `uv run ruff check stream_sniper/api/analytics_endpoints.py tests/unit/api/test_creator_analytics.py`
- broader `tests/unit` run: 395 passed; 53 setup errors because local PostgreSQL rejected the checkout default test credentials