### PR TITLE
Improve bot classification: real dry-run counts, CZ bots, targeted copypasta refresh

### DIFF
--- a/backend/stream_sniper/analytics/operations/bot_detection.py
+++ b/backend/stream_sniper/analytics/operations/bot_detection.py
@@ -13,23 +13,29 @@ signals that never scan the raw `message` table:
 Marking is monotonic: an already-marked bot is never un-marked or re-reasoned (the gateway
 UPDATEs guard on ``is_bot IS NOT TRUE``), so the first classification reason sticks.
 
-Bots are excluded only at the cross-channel layer (community overlap, regulars); per-stream
-rollups keep them as the factual record. After a non-dry run this triggers a blocking
+Bots are excluded at the cross-channel layer (community overlap, regulars) and from the
+copypasta rollup; per-stream factual rollups keep them. After a non-dry run this refreshes
+the copypasta rollup + scene events for every stream a newly-marked bot spoke in (so stale
+bot texts drop out of stream_copypasta_stats) and then triggers a blocking
 community-overlap recompute so the exclusion takes effect immediately.
 """
 
 import argparse
 
 from ...database.core.connection_pool import database_entrypoint
+from ...database.gateways.analytics.stream_chatter_stats_table_gateway import (
+    select_stream_ids_for_chatters_db,
+)
 from ...database.gateways.chat.chatter_table_gateway import (
     count_bots_db,
     mark_bots_by_ids_db,
-    mark_bots_by_nick_db,
     select_bot_candidates_rate_db,
     select_bot_candidates_ubiquity_db,
+    select_unmarked_known_bots_db,
 )
 from ...logging_config import get_logger, setup_logging
 from ..rollups.community import recompute_creator_overlap
+from ..rollups.rollup_engine import refresh_stream_copypasta_and_events
 
 # Well-known Twitch service bots (chat bots, viewer bots, alert/soundboard bots). Matched on
 # lower(nick); expand as new ones appear. This is the primary, 100%-precision signal.
@@ -64,6 +70,13 @@ KNOWN_BOTS: frozenset[str] = frozenset(
         "frostytoolsdotcom",
         "dinu",
         "peepostreambot",
+        # CZ-scene additions confirmed by message content on prod (2026-07-17): song-queue /
+        # scene-switch / AFK / relay / ad bots active in tracked Czech channels.
+        "supibot",
+        "restreambot",
+        "botrixoficial",
+        "herbot_",
+        "spajkk_irl_bot",
     }
 )
 
@@ -73,29 +86,50 @@ DEFAULT_MIN_CHANNELS = 20
 def classify_bots(min_channels: int = DEFAULT_MIN_CHANNELS, *, dry_run: bool = False) -> dict[str, int]:
     """Run the three classification passes and return a counts summary.
 
-    Returns a dict with keys ``known``, ``ubiquity``, ``rate`` (rows marked this run, or the
-    candidate count under ``--dry-run``) and ``total_bots`` (chatters currently flagged). With
+    Returns a dict with keys ``known``, ``ubiquity``, ``rate`` (unmarked candidates found by
+    each pass — identical to rows marked on a non-dry run), ``streams_refreshed`` (streams
+    whose copypasta rollup + scene events were recomputed because a newly-marked bot spoke
+    there; always 0 under dry-run), and ``total_bots`` (chatters currently flagged). With
     ``dry_run`` set no UPDATE runs — the candidate passes are still evaluated and reported.
     """
-    # 1. Known-name list.
-    known_count = len(KNOWN_BOTS) if dry_run else mark_bots_by_nick_db(sorted(KNOWN_BOTS), "known_bot")
+    newly_marked: list[int] = []
+
+    # 1. Known-name list (select-then-mark so dry-run reports real candidates, not list size).
+    known_candidates = select_unmarked_known_bots_db(sorted(KNOWN_BOTS))
+    known_count = len(known_candidates)
+    if not dry_run and known_candidates:
+        known_ids = [chatter_id for chatter_id, _nick in known_candidates]
+        mark_bots_by_ids_db(known_ids, "known_bot")
+        newly_marked.extend(known_ids)
 
     # 2. Cross-channel ubiquity (reads the small creator_chatter_stats rollup).
     ubiquity_candidates = select_bot_candidates_ubiquity_db(min_channels)
     ubiquity_count = len(ubiquity_candidates)
     if not dry_run and ubiquity_candidates:
-        mark_bots_by_ids_db([row[0] for row in ubiquity_candidates], f"ubiquity:{min_channels}")
+        ubiquity_ids = [row[0] for row in ubiquity_candidates]
+        mark_bots_by_ids_db(ubiquity_ids, f"ubiquity:{min_channels}")
+        newly_marked.extend(ubiquity_ids)
 
     # 3. Superhuman sustained message rate (reads the stream_chatter_stats rollup).
     rate_candidates = select_bot_candidates_rate_db()
     rate_count = len(rate_candidates)
     if not dry_run and rate_candidates:
-        mark_bots_by_ids_db([row[0] for row in rate_candidates], "rate")
+        rate_ids = [row[0] for row in rate_candidates]
+        mark_bots_by_ids_db(rate_ids, "rate")
+        newly_marked.extend(rate_ids)
+
+    # Newly-marked bots may have contributed texts to stream_copypasta_stats when they were
+    # still unclassified; refresh only the streams they spoke in so the rollup re-applies the
+    # is_bot filter and derived scene events stop referencing their texts.
+    affected_streams = select_stream_ids_for_chatters_db(newly_marked) if newly_marked else []
+    for stream_id in affected_streams:
+        refresh_stream_copypasta_and_events(stream_id)
 
     return {
         "known": known_count,
         "ubiquity": ubiquity_count,
         "rate": rate_count,
+        "streams_refreshed": len(affected_streams),
         "total_bots": count_bots_db(),
     }
 
@@ -138,7 +172,8 @@ def main() -> int:
     logger.info(
         f"{prefix}Bot classification: known={counts['known']}, "
         f"ubiquity={counts['ubiquity']} (>{args.min_channels} channels), "
-        f"rate={counts['rate']}; total bots now {counts['total_bots']}."
+        f"rate={counts['rate']}; copypasta/scene events refreshed for "
+        f"{counts['streams_refreshed']} streams; total bots now {counts['total_bots']}."
     )
 
     if args.dry_run:

--- a/backend/stream_sniper/analytics/rollups/rollup_engine.py
+++ b/backend/stream_sniper/analytics/rollups/rollup_engine.py
@@ -164,6 +164,18 @@ def compute_stream_rollup(stream_id: int, *, refresh_overlap: bool = True) -> Ro
     )
 
 
+def refresh_stream_copypasta_and_events(stream_id: int) -> None:
+    """Recompute one stream's copypasta rollup and its derived scene events.
+
+    Targeted alternative to a full ``compute_stream_rollup``: used after bot
+    classification so freshly-marked bots drop out of the copypasta source (the
+    SQL re-applies the ``is_bot`` filter) and the copypasta_spread events stop
+    referencing their texts. Per-stream factual rollups are left untouched.
+    """
+    _compute_and_store_copypasta_rollup(stream_id)
+    refresh_stream_events(stream_id)
+
+
 def _compute_and_store_text_rollups(stream_id: int) -> None:
     """TX2: compute phrases + enriched moments in Python, then write both in one transaction."""
     emote_names = {name.lower() for name in select_emote_names_db()}

--- a/backend/stream_sniper/database/gateways/analytics/stream_chatter_stats_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/analytics/stream_chatter_stats_table_gateway.py
@@ -47,6 +47,30 @@ def select_rollup_stream_ids_db(
     return cast(list[tuple[int, int]], cursor.fetchall())
 
 
+@with_cursor
+def select_stream_ids_for_chatters_db(
+    cursor: Cursor,
+    chatter_ids: list[int],
+) -> list[int]:
+    """Distinct streams where any of the given chatters spoke, from the rollup (no message scan).
+
+    Used after bot classification to target the copypasta/scene-event refresh at only
+    the streams a newly-marked bot participated in.
+    """
+    if not chatter_ids:
+        return []
+    cursor.execute(
+        """
+        SELECT DISTINCT stream_id
+        FROM stream_chatter_stats
+        WHERE chatter_id = ANY(%s)
+        ORDER BY stream_id ASC
+        """,
+        (chatter_ids,),
+    )
+    return [int(row[0]) for row in cursor.fetchall()]
+
+
 def _replace_time_buckets(cursor: Cursor, params: dict[str, int]) -> None:
     """Replace per-minute message, chatter, subscriber, and emote buckets."""
     cursor.execute("DELETE FROM stream_time_bucket WHERE stream_id = %(sid)s", params)

--- a/backend/stream_sniper/database/gateways/chat/chatter_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/chat/chatter_table_gateway.py
@@ -135,30 +135,30 @@ def select_all_chatters_db(
     return {str(row[1]): int(row[0]) for row in cursor.fetchall()}
 
 
-@with_cursor_connection
-def mark_bots_by_nick_db(
+@with_cursor
+def select_unmarked_known_bots_db(
     cursor: Cursor,
-    connection: Connection,
     nicks: Sequence[str],
-    reason: str,
-) -> int:
-    """Mark chatters whose lowercased nick is in `nicks` as bots. Returns rows updated.
+) -> list[tuple[int, str]]:
+    """Chatters whose lowercased nick is in `nicks` and who are not yet marked as bots.
 
-    Never un-marks or re-reasons an already-marked bot (is_bot IS NOT TRUE guard),
-    so the first classification reason sticks.
+    Feeds the known-name classification pass: the caller marks the returned ids (so it
+    knows exactly which chatters were newly flagged) and dry-run reports the real
+    candidate count instead of the size of the curated list.
+    :return: List of (chatter_id, nick) tuples ordered by nick.
     """
     if not nicks:
-        return 0
+        return []
     cursor.execute(
         """
-        UPDATE chatter
-        SET is_bot = TRUE, bot_reason = %s
+        SELECT id, nick
+        FROM chatter
         WHERE lower(nick) = ANY(%s) AND is_bot IS NOT TRUE
+        ORDER BY nick ASC
         """,
-        (reason, [nick.lower() for nick in nicks]),
+        ([nick.lower() for nick in nicks],),
     )
-    connection.commit()
-    return int(cursor.rowcount)
+    return cursor.fetchall()
 
 
 @with_cursor_connection

--- a/backend/tests/unit/analytics/test_bot_detection.py
+++ b/backend/tests/unit/analytics/test_bot_detection.py
@@ -1,14 +1,41 @@
 """Unit tests for bot classification (stream_sniper.analytics.operations.bot_detection).
 
-Gateways and the overlap recompute are patched at the bot_detection module path; no
-Postgres is touched. Covers the known-name list, the three-pass orchestrator, dry-run
-behavior, reason strings, and CLI argument handling.
+Gateways, the overlap recompute, and the targeted copypasta/scene-event refresh are
+patched at the bot_detection module path; no Postgres is touched. Covers the known-name
+list, the three-pass orchestrator, dry-run behavior, reason strings, the post-marking
+stream refresh, and CLI argument handling.
 """
 
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from stream_sniper.analytics.operations import bot_detection
 from stream_sniper.analytics.operations.bot_detection import KNOWN_BOTS, classify_bots
+
+_MODULE = "stream_sniper.analytics.operations.bot_detection"
+
+
+def _patch_classify_gateways(**overrides):
+    """Patch every gateway classify_bots touches; returns a dict of started mocks.
+
+    Callers must pair with _stop_patches. Defaults: no candidates anywhere.
+    """
+    defaults = {
+        "select_unmarked_known_bots_db": [],
+        "select_bot_candidates_ubiquity_db": [],
+        "select_bot_candidates_rate_db": [],
+        "mark_bots_by_ids_db": 0,
+        "select_stream_ids_for_chatters_db": [],
+        "refresh_stream_copypasta_and_events": None,
+        "count_bots_db": 0,
+    }
+    defaults.update(overrides)
+    patchers = {name: patch(f"{_MODULE}.{name}", return_value=value) for name, value in defaults.items()}
+    return {name: p.start() for name, p in patchers.items()}, list(patchers.values())
+
+
+def _stop_patches(patchers):
+    for p in patchers:
+        p.stop()
 
 
 class TestKnownBots:
@@ -25,72 +52,93 @@ class TestKnownBots:
         for expected in ("nightbot", "streamelements", "streamlabs", "moobot", "fossabot"):
             assert expected in KNOWN_BOTS
 
+    def test_contains_cz_scene_bots(self):
+        """Content-confirmed bots active in tracked Czech channels (2026-07-17 audit)."""
+        for expected in ("supibot", "restreambot", "botrixoficial", "herbot_", "spajkk_irl_bot"):
+            assert expected in KNOWN_BOTS
+
 
 class TestClassifyBots:
     """The three-pass orchestrator classify_bots()."""
 
-    @patch("stream_sniper.analytics.operations.bot_detection.count_bots_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.select_bot_candidates_rate_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.select_bot_candidates_ubiquity_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.mark_bots_by_ids_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.mark_bots_by_nick_db")
-    def test_marks_all_three_layers(self, mock_nick, mock_ids, mock_ubiq, mock_rate, mock_count):
-        mock_nick.return_value = 3
-        mock_ubiq.return_value = [(101, 25), (102, 30)]
-        mock_rate.return_value = [(201, 5)]
-        mock_count.return_value = 6
+    def test_marks_all_three_layers_and_refreshes_streams(self):
+        mocks, patchers = _patch_classify_gateways(
+            select_unmarked_known_bots_db=[(11, "nightbot"), (12, "blerp"), (13, "supibot")],
+            select_bot_candidates_ubiquity_db=[(101, 25), (102, 30)],
+            select_bot_candidates_rate_db=[(201, 5)],
+            select_stream_ids_for_chatters_db=[7, 9],
+            count_bots_db=6,
+        )
+        try:
+            counts = classify_bots(20)
+        finally:
+            _stop_patches(patchers)
 
-        counts = classify_bots(20)
+        assert counts == {"known": 3, "ubiquity": 2, "rate": 1, "streams_refreshed": 2, "total_bots": 6}
+        mocks["select_unmarked_known_bots_db"].assert_called_once_with(sorted(KNOWN_BOTS))
+        mocks["select_bot_candidates_ubiquity_db"].assert_called_once_with(20)
+        mocks["mark_bots_by_ids_db"].assert_any_call([11, 12, 13], "known_bot")
+        mocks["mark_bots_by_ids_db"].assert_any_call([101, 102], "ubiquity:20")
+        mocks["mark_bots_by_ids_db"].assert_any_call([201], "rate")
+        # The stream refresh targets every newly-marked chatter, across all three passes.
+        mocks["select_stream_ids_for_chatters_db"].assert_called_once_with([11, 12, 13, 101, 102, 201])
+        assert mocks["refresh_stream_copypasta_and_events"].call_args_list == [call(7), call(9)]
 
-        assert counts == {"known": 3, "ubiquity": 2, "rate": 1, "total_bots": 6}
-        mock_nick.assert_called_once_with(sorted(KNOWN_BOTS), "known_bot")
-        mock_ubiq.assert_called_once_with(20)
-        mock_ids.assert_any_call([101, 102], "ubiquity:20")
-        mock_ids.assert_any_call([201], "rate")
-
-    @patch("stream_sniper.analytics.operations.bot_detection.count_bots_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.select_bot_candidates_rate_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.select_bot_candidates_ubiquity_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.mark_bots_by_ids_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.mark_bots_by_nick_db")
-    def test_min_channels_in_reason(self, mock_nick, mock_ids, mock_ubiq, mock_rate, mock_count):
+    def test_min_channels_in_reason(self):
         """The ubiquity reason string carries the configured threshold."""
-        mock_nick.return_value = 0
-        mock_ubiq.return_value = [(101, 40)]
-        mock_rate.return_value = []
-        mock_count.return_value = 1
+        mocks, patchers = _patch_classify_gateways(
+            select_bot_candidates_ubiquity_db=[(101, 40)],
+            count_bots_db=1,
+        )
+        try:
+            classify_bots(35)
+        finally:
+            _stop_patches(patchers)
 
-        classify_bots(35)
+        mocks["select_bot_candidates_ubiquity_db"].assert_called_once_with(35)
+        mocks["mark_bots_by_ids_db"].assert_called_once_with([101], "ubiquity:35")
 
-        mock_ubiq.assert_called_once_with(35)
-        mock_ids.assert_called_once_with([101], "ubiquity:35")
+    def test_no_candidates_skips_marking_and_refresh(self):
+        mocks, patchers = _patch_classify_gateways()
+        try:
+            counts = classify_bots(20)
+        finally:
+            _stop_patches(patchers)
 
-    @patch("stream_sniper.analytics.operations.bot_detection.count_bots_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.select_bot_candidates_rate_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.select_bot_candidates_ubiquity_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.mark_bots_by_ids_db")
-    @patch("stream_sniper.analytics.operations.bot_detection.mark_bots_by_nick_db")
-    def test_dry_run_writes_nothing(self, mock_nick, mock_ids, mock_ubiq, mock_rate, mock_count):
-        mock_ubiq.return_value = [(101, 25), (102, 30)]
-        mock_rate.return_value = [(201, 5)]
-        mock_count.return_value = 0
+        assert counts == {"known": 0, "ubiquity": 0, "rate": 0, "streams_refreshed": 0, "total_bots": 0}
+        mocks["mark_bots_by_ids_db"].assert_not_called()
+        mocks["select_stream_ids_for_chatters_db"].assert_not_called()
+        mocks["refresh_stream_copypasta_and_events"].assert_not_called()
 
-        counts = classify_bots(20, dry_run=True)
+    def test_dry_run_writes_nothing_and_reports_real_candidates(self):
+        """Dry-run counts actual unmarked matches — not the size of the curated list."""
+        mocks, patchers = _patch_classify_gateways(
+            select_unmarked_known_bots_db=[(11, "nightbot")],
+            select_bot_candidates_ubiquity_db=[(101, 25), (102, 30)],
+            select_bot_candidates_rate_db=[(201, 5)],
+        )
+        try:
+            counts = classify_bots(20, dry_run=True)
+        finally:
+            _stop_patches(patchers)
 
-        mock_nick.assert_not_called()
-        mock_ids.assert_not_called()
-        assert counts["known"] == len(KNOWN_BOTS)
+        mocks["mark_bots_by_ids_db"].assert_not_called()
+        mocks["refresh_stream_copypasta_and_events"].assert_not_called()
+        assert counts["known"] == 1
         assert counts["ubiquity"] == 2
         assert counts["rate"] == 1
+        assert counts["streams_refreshed"] == 0
 
 
 class TestMainCli:
     """CLI argument handling in main()."""
 
-    @patch("stream_sniper.analytics.operations.bot_detection.recompute_creator_overlap")
-    @patch("stream_sniper.analytics.operations.bot_detection.classify_bots")
+    _COUNTS_ZERO = {"known": 0, "ubiquity": 0, "rate": 0, "streams_refreshed": 0, "total_bots": 0}
+
+    @patch(f"{_MODULE}.recompute_creator_overlap")
+    @patch(f"{_MODULE}.classify_bots")
     def test_default_run_recomputes_overlap(self, mock_classify, mock_recompute):
-        mock_classify.return_value = {"known": 1, "ubiquity": 0, "rate": 0, "total_bots": 1}
+        mock_classify.return_value = {"known": 1, "ubiquity": 0, "rate": 0, "streams_refreshed": 2, "total_bots": 1}
 
         with patch("sys.argv", ["stream-sniper-classify-bots"]):
             assert bot_detection.main.__wrapped__() == 0
@@ -98,10 +146,10 @@ class TestMainCli:
         mock_classify.assert_called_once_with(20, dry_run=False)
         mock_recompute.assert_called_once_with(blocking=True)
 
-    @patch("stream_sniper.analytics.operations.bot_detection.recompute_creator_overlap")
-    @patch("stream_sniper.analytics.operations.bot_detection.classify_bots")
+    @patch(f"{_MODULE}.recompute_creator_overlap")
+    @patch(f"{_MODULE}.classify_bots")
     def test_dry_run_skips_recompute(self, mock_classify, mock_recompute):
-        mock_classify.return_value = {"known": 0, "ubiquity": 0, "rate": 0, "total_bots": 0}
+        mock_classify.return_value = self._COUNTS_ZERO
 
         with patch("sys.argv", ["stream-sniper-classify-bots", "--dry-run"]):
             assert bot_detection.main.__wrapped__() == 0
@@ -109,10 +157,10 @@ class TestMainCli:
         mock_classify.assert_called_once_with(20, dry_run=True)
         mock_recompute.assert_not_called()
 
-    @patch("stream_sniper.analytics.operations.bot_detection.recompute_creator_overlap")
-    @patch("stream_sniper.analytics.operations.bot_detection.classify_bots")
+    @patch(f"{_MODULE}.recompute_creator_overlap")
+    @patch(f"{_MODULE}.classify_bots")
     def test_min_channels_and_skip_flag(self, mock_classify, mock_recompute):
-        mock_classify.return_value = {"known": 0, "ubiquity": 0, "rate": 0, "total_bots": 0}
+        mock_classify.return_value = self._COUNTS_ZERO
 
         with patch(
             "sys.argv",


### PR DESCRIPTION
## Why

A prod-data audit (2026-07-17) against the copypasta definition ("repeated, substantial, non-command messages **from humans**") found:

- **8 active bots unflagged** — 3 already on the known list but never re-classified since they appeared (`blerp`, `soundalerts`, `streamlabs`) and 5 new ones confirmed by message content (`supibot`, `restreambot`, `botrixoficial`, `herbot_`, `spajkk_irl_bot`).
- **44 `stream_copypasta_stats` rows (16 texts, 18 streams) holding pure bot spam** — Botrix casino ads (`csgonet.net` links), herbot_ "video added to the queue", blerp bit alerts.
- A classifier bug: `--dry-run` reported `known=len(KNOWN_BOTS)` (always 29) instead of actual unmarked matches.
- A pipeline gap: marking a bot never removed its texts from existing copypasta rollups — that waited for a manual `stream-sniper-rollup --force`.

## What

- **KNOWN_BOTS** + 5 content-confirmed CZ-scene bots.
- **Known pass is now select-then-mark** (`select_unmarked_known_bots_db`): dry-run reports real candidates, and the run knows exactly which chatters it newly flagged. Dead `mark_bots_by_nick_db` removed.
- **Targeted post-marking refresh**: recompute copypasta rollup + scene events for just the streams each newly-marked bot spoke in (via the `stream_chatter_stats` rollup — no message scan), then the existing blocking overlap recompute. New `refresh_stream_copypasta_and_events` in the rollup engine; summary gains `streams_refreshed`.

## Deliberately unchanged

- Humans with bot-like nicks (`botmsqt`, `frantabot`, `trolda_bot`, `botzulasch`, `fiaskobot`, `rudaxbot`, `tonysobot`) verified by message content and **not** listed — name-pattern flagging would misfire.
- Ubiquity (`>20` channels) and rate passes audited on prod: max observed ubiquity is 13 (streamelements, already known), zero rate qualifiers even at half thresholds. Left as-is.

## After merge (prod runbook)

```
docker exec stream-sniper-api stream-sniper-classify-bots --dry-run   # expect known=8
docker exec stream-sniper-api stream-sniper-classify-bots            # marks 8, refreshes ~18 streams + overlap
```

No migration.