### PR TITLE
Clear the IMPROVEMENTS.md backlog: versioned cache keys, rollup stats prune, log sanitization, CodeQL FPs, health split

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,15 @@ POSTGRES_HOST=localhost
 POSTGRES_DB=your_database_name
 POSTGRES_PORT=5432
 
+# Auth (Required for the API — composition fails fast without a signing secret)
+JWT_SECRET_KEY=change_me
+# SECRET_KEY=            # legacy fallback name, prefer JWT_SECRET_KEY
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
+
+# Twitch app credentials (Required for collector/tracking services)
+TWITCH_CLIENT_ID=
+TWITCH_CLIENT_SECRET=
+
 # Database Pool Settings
 DB_POOL_MIN_CONN=2
 DB_POOL_MAX_CONN=20

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -16,6 +16,21 @@ paths-ignore:
   - "*.log"
   - "backend/tests/fixtures/**"
 
+# Known false-positive generators in this codebase (query-filters cannot be
+# scoped per-path, so the rules are excluded outright):
+# - py/uninitialized-local-variable: the Python extractor does not model
+#   PEP 695 type-parameter scoping (`def f[**P, R](...)`), so every generic
+#   decorator in database/core/ and the API composition root raises a bogus
+#   "uninitialized local" error.
+# - py/ineffectual-statement: fires on `...` (Ellipsis) bodies of
+#   typing.Protocol method stubs, the standard spelling for structural ports
+#   in application/.
+query-filters:
+  - exclude:
+      id: py/uninitialized-local-variable
+  - exclude:
+      id: py/ineffectual-statement
+
 # The Python package lives under backend/, not the repo root — a bare
 # "stream_sniper/**" filter matches nothing and CodeQL fails with
 # "could not process any of it".

--- a/backend/stream_sniper/analytics/operations/digest.py
+++ b/backend/stream_sniper/analytics/operations/digest.py
@@ -38,17 +38,24 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Preview or deliver the Stream Sniper scene digest")
     parser.add_argument("--days", type=int, default=7, choices=range(1, 31))
     parser.add_argument("--limit", type=int, default=20)
-    parser.add_argument("--send", action="store_true", help="Deliver to SCENE_DIGEST_WEBHOOK_URL")
+    parser.add_argument("--send", action="store_true", help="Deliver to the configured Discord webhook")
+    # The webhook contract is declared once at this CLI boundary: an explicit
+    # flag wins, with the SCENE_DIGEST_WEBHOOK_URL environment variable as the
+    # deployment default.
+    parser.add_argument(
+        "--webhook-url",
+        default=os.getenv("SCENE_DIGEST_WEBHOOK_URL"),
+        help="Discord webhook destination (default: $SCENE_DIGEST_WEBHOOK_URL)",
+    )
     args = parser.parse_args()
     digest = build_digest(args.days, max(1, min(args.limit, 50)))
     if not args.send:
         print(digest)
         return
-    webhook = os.getenv("SCENE_DIGEST_WEBHOOK_URL")
-    if not webhook:
-        print("SCENE_DIGEST_WEBHOOK_URL is required with --send", file=sys.stderr)
+    if not args.webhook_url:
+        print("--webhook-url (or SCENE_DIGEST_WEBHOOK_URL) is required with --send", file=sys.stderr)
         raise SystemExit(2)
-    deliver_discord(digest, webhook)
+    deliver_discord(digest, args.webhook_url)
     print("Scene digest delivered.")
 
 

--- a/backend/stream_sniper/api/asgi.py
+++ b/backend/stream_sniper/api/asgi.py
@@ -4,8 +4,6 @@ Environment loading and application construction intentionally live here so
 importing the reusable application factory remains side-effect free.
 """
 
-import os
-
 from dotenv import load_dotenv
 from fastapi import FastAPI
 
@@ -18,7 +16,7 @@ def build_production_app() -> FastAPI:
     """Load process configuration and construct the production application."""
     load_dotenv()
     if not is_logging_configured():
-        setup_logging(environment=os.getenv("ENVIRONMENT", "production"))
+        setup_logging(environment="production")
     return create_app(load_config())
 
 

--- a/backend/stream_sniper/api/caching/rollup_version.py
+++ b/backend/stream_sniper/api/caching/rollup_version.py
@@ -15,6 +15,8 @@ with a proper error right after). The sentinel keys behave exactly like the
 pre-versioning cache.
 """
 
+from collections.abc import Callable
+
 from ...database.gateways.analytics.stream_metrics_table_gateway import (
     select_creator_rollup_version_db,
     select_scene_rollup_version_db,
@@ -28,7 +30,7 @@ logger = get_logger(__name__)
 _UNVERSIONED = "unversioned"
 
 
-def _resolve(probe_name: str, probe) -> str:
+def _resolve(probe_name: str, probe: Callable[[], str | None]) -> str:
     try:
         return probe() or _UNVERSIONED
     except Exception:

--- a/backend/stream_sniper/api/caching/rollup_version.py
+++ b/backend/stream_sniper/api/caching/rollup_version.py
@@ -1,0 +1,56 @@
+"""Rollup-version cache-key parts for cross-process invalidation.
+
+The API cache is in-process, but analytics rollups (timeline buckets, emote
+and phrase stats, moments, overlap, creator aggregates) are written by the
+separate collector/tracking process — an entry cached before a rollup would
+otherwise stay stale for its full TTL. Including the relevant rollup version
+(``stream_metrics.computed_at``, exposed as opaque epoch text) in the cache
+key makes every recomputation start a fresh key; superseded entries simply
+age out via TTL and the lazy prune.
+
+Each helper degrades to a constant sentinel instead of raising: a failed
+version probe must never take down an endpoint that could still serve the
+request (and if the database is truly down, the endpoint's main query fails
+with a proper error right after). The sentinel keys behave exactly like the
+pre-versioning cache.
+"""
+
+from ...database.gateways.analytics.stream_metrics_table_gateway import (
+    select_creator_rollup_version_db,
+    select_scene_rollup_version_db,
+    select_stream_creator_rollup_version_db,
+    select_stream_rollup_version_db,
+)
+from ...logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_UNVERSIONED = "unversioned"
+
+
+def _resolve(probe_name: str, probe) -> str:
+    try:
+        return probe() or _UNVERSIONED
+    except Exception:
+        logger.warning("Rollup version probe %s failed; caching without a version part", probe_name)
+        return _UNVERSIONED
+
+
+def stream_rollup_version(stream_id: int) -> str:
+    """Version part for responses derived from one stream's rollup tables."""
+    return _resolve("stream", lambda: select_stream_rollup_version_db(stream_id))
+
+
+def stream_creator_rollup_version(stream_id: int) -> str:
+    """Version part for responses mixing one stream with its creator baseline."""
+    return _resolve("stream_creator", lambda: select_stream_creator_rollup_version_db(stream_id))
+
+
+def creator_rollup_version(creator_id: int) -> str:
+    """Version part for creator-scoped rollup responses (trends, regulars, ...)."""
+    return _resolve("creator", lambda: select_creator_rollup_version_db(creator_id))
+
+
+def scene_rollup_version() -> str:
+    """Version part for scene-wide rollup responses (leaderboard, overlap, ...)."""
+    return _resolve("scene", select_scene_rollup_version_db)

--- a/backend/stream_sniper/api/config.py
+++ b/backend/stream_sniper/api/config.py
@@ -5,8 +5,7 @@ Centralizes all configurable parameters with environment variable support.
 
 import os
 from collections.abc import Mapping
-from dataclasses import asdict, dataclass, field
-from typing import Any
+from dataclasses import dataclass, field
 
 from ..database.core.connection_pool import DatabasePoolConfig, load_database_pool_config
 
@@ -98,17 +97,16 @@ class APIConfig:
     cors_origins: str = "*"
     cors_credentials: bool = True
 
+    # Used only by the Twitch reachability health probe; the collector owns the
+    # full TWITCH_CLIENT_ID/SECRET credential contract (TwitchCredentials.from_env).
+    twitch_client_id: str = ""
+
     cache: CacheConfig = field(default_factory=CacheConfig)
     rate_limit: RateLimitConfig = field(default_factory=RateLimitConfig)
     compression: CompressionConfig = field(default_factory=CompressionConfig)
     monitoring: MonitoringConfig = field(default_factory=MonitoringConfig)
     database: DatabasePoolConfig = field(default_factory=DatabasePoolConfig)
     auth: AuthConfig = field(default_factory=AuthConfig)
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert configuration to dictionary for serialization."""
-
-        return asdict(self)
 
     def validate(self) -> bool:
         """Return whether the configuration satisfies runtime invariants."""
@@ -162,6 +160,7 @@ def load_config(environ: Mapping[str, str] | None = None) -> APIConfig:
         cors_enabled=_bool(env, "CORS_ENABLED", True),
         cors_origins=env.get("CORS_ORIGINS", "*"),
         cors_credentials=_bool(env, "CORS_CREDENTIALS", True),
+        twitch_client_id=env.get("TWITCH_CLIENT_ID", ""),
         cache=CacheConfig(
             enabled=_bool(env, "CACHE_ENABLED", True),
             default_ttl=_int(env, "CACHE_DEFAULT_TTL", 3600),

--- a/backend/stream_sniper/api/features/auth/auth_endpoints.py
+++ b/backend/stream_sniper/api/features/auth/auth_endpoints.py
@@ -18,7 +18,7 @@ from ....database.gateways.identity.user_table_gateway import (
     update_user_password_db,
 )
 from ....identity import USER_ROLE
-from ....logging_config import get_logger
+from ....logging_config import get_logger, sanitize_log_value
 from ...security.auth import (
     authenticate_user,
     create_access_token,
@@ -70,10 +70,10 @@ def register_user(user_data: UserCreateExtended, request: Request, response: Res
             status_code=status.HTTP_400_BAD_REQUEST, detail="User with this username or email already exists"
         ) from None
     except UserCreationError:
-        logger.exception("Self-service registration failed for username %s", user_data.username)
+        logger.exception("Self-service registration failed for username %s", sanitize_log_value(user_data.username))
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create user") from None
 
-    logger.info(f"User registered successfully: {user_data.username}")
+    logger.info("User registered successfully: %s", sanitize_log_value(user_data.username))
     return convert_user_to_response(user)
 
 
@@ -106,7 +106,7 @@ def login(user_credentials: UserLogin, request: Request, response: Response) -> 
         expires_delta=access_token_expires,
     )
 
-    logger.info(f"User logged in successfully: {user.username}")
+    logger.info("User logged in successfully: %s", sanitize_log_value(user.username))
     return Token(access_token=access_token, token_type="bearer")
 
 
@@ -170,7 +170,7 @@ def update_current_user(
     if not updated_user:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve updated user")
 
-    logger.info(f"User updated successfully: {current_user.username}")
+    logger.info("User updated successfully: %s", sanitize_log_value(current_user.username))
     return convert_user_to_response(updated_user)
 
 
@@ -203,5 +203,5 @@ def change_password(
     if not success:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update password")
 
-    logger.info("Account access updated successfully for user id %s", current_user.id)
+    logger.info("Account access updated successfully for user id %s", sanitize_log_value(current_user.id))
     return MessageResponse(message="Password changed successfully")

--- a/backend/stream_sniper/api/features/auth/user_admin_endpoints.py
+++ b/backend/stream_sniper/api/features/auth/user_admin_endpoints.py
@@ -18,7 +18,7 @@ from ....database.gateways.identity.user_table_gateway import (
     update_user_role_db,
 )
 from ....identity import ADMIN_ROLE, UserRole
-from ....logging_config import get_logger
+from ....logging_config import get_logger, sanitize_log_value
 from ...security.auth import get_current_admin_user
 from ...security.auth_models import UserInDB
 from ...security.rate_limiter import limiter
@@ -112,7 +112,12 @@ def update_user_role(
     if not success:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    logger.info(f"User role updated by admin {current_user.username}: user_id={user_id}, new_role={new_role}")
+    logger.info(
+        "User role updated by admin %s: user_id=%s, new_role=%s",
+        sanitize_log_value(current_user.username),
+        user_id,
+        sanitize_log_value(new_role),
+    )
     return _load_user_response(user_id)
 
 
@@ -138,7 +143,7 @@ def activate_user(
     if not success:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    logger.info(f"User activated by admin {current_user.username}: user_id={user_id}")
+    logger.info("User activated by admin %s: user_id=%s", sanitize_log_value(current_user.username), user_id)
     return _load_user_response(user_id)
 
 
@@ -165,7 +170,7 @@ def deactivate_user(
     if not success:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    logger.info(f"User deactivated by admin {current_user.username}: user_id={user_id}")
+    logger.info("User deactivated by admin %s: user_id=%s", sanitize_log_value(current_user.username), user_id)
     return _load_user_response(user_id)
 
 
@@ -195,7 +200,7 @@ def delete_user(
     if not success:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    logger.info(f"User deleted by admin {current_user.username}: user_id={user_id}")
+    logger.info("User deleted by admin %s: user_id=%s", sanitize_log_value(current_user.username), user_id)
     return None
 
 
@@ -268,7 +273,7 @@ def update_user_by_id(
     if not success:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update user")
 
-    logger.info(f"User updated by admin {current_user.username}: user_id={user_id}")
+    logger.info("User updated by admin %s: user_id=%s", sanitize_log_value(current_user.username), user_id)
     return _load_user_response(user_id)
 
 
@@ -352,8 +357,12 @@ def create_user_admin(
             status_code=status.HTTP_400_BAD_REQUEST, detail="User with this username or email already exists"
         ) from None
     except UserCreationError:
-        logger.exception("Admin user creation failed for username %s", user_data.username)
+        logger.exception("Admin user creation failed for username %s", sanitize_log_value(user_data.username))
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create user") from None
 
-    logger.info(f"User created by admin {current_user.username}: {user_data.username}")
+    logger.info(
+        "User created by admin %s: %s",
+        sanitize_log_value(current_user.username),
+        sanitize_log_value(user_data.username),
+    )
     return convert_user_to_response(user)

--- a/backend/stream_sniper/api/features/community/audience_endpoints.py
+++ b/backend/stream_sniper/api/features/community/audience_endpoints.py
@@ -7,6 +7,7 @@ from ....application.community.audience_query import get_audience_movement as qu
 from ....logging_config import get_logger
 from ...caching.cache import CacheTTL
 from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import creator_rollup_version
 from ...dependencies import get_cache
 from ...security.rate_limiter import limiter, rate_limits
 from ...transport.models import RateLimitErrorResponse
@@ -32,7 +33,9 @@ def get_audience_movement(
     """Compare distinct participating chatters across adjacent equal windows."""
     with _AUDIENCE_MOVEMENT_CACHE.record_failures():
         cache = get_cache(request)
-        key, cached = _AUDIENCE_MOVEMENT_CACHE.lookup(cache, response, creator_id, days, limit)
+        key, cached = _AUDIENCE_MOVEMENT_CACHE.lookup(
+            cache, response, creator_id, days, limit, creator_rollup_version(creator_id)
+        )
         if cached is not None:
             return cached
         result = query_audience_movement(creator_id, days, limit)

--- a/backend/stream_sniper/api/features/community/community_endpoints.py
+++ b/backend/stream_sniper/api/features/community/community_endpoints.py
@@ -15,6 +15,7 @@ from ....application.community.models import (
 from ....logging_config import get_logger
 from ...caching.cache import CacheTTL
 from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import scene_rollup_version
 from ...dependencies import get_cache
 from ...security.rate_limiter import limiter, rate_limits
 from ...transport.models import RateLimitErrorResponse
@@ -48,7 +49,7 @@ def get_community_overlap(
     """
     with _OVERLAP_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _OVERLAP_CACHE.lookup(cache, response, limit)
+        cache_key, cached_result = _OVERLAP_CACHE.lookup(cache, response, limit, scene_rollup_version())
         if cached_result is not None:
             return cached_result
 
@@ -77,7 +78,9 @@ def get_creator_neighbors(
     """Get the creators whose audiences most overlap with this creator's."""
     with _NEIGHBORS_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _NEIGHBORS_CACHE.lookup(cache, response, creator_id, metric, limit)
+        cache_key, cached_result = _NEIGHBORS_CACHE.lookup(
+            cache, response, creator_id, metric, limit, scene_rollup_version()
+        )
         if cached_result is not None:
             return cached_result
 

--- a/backend/stream_sniper/api/features/content/moment_endpoints.py
+++ b/backend/stream_sniper/api/features/content/moment_endpoints.py
@@ -16,6 +16,7 @@ from ....database.gateways.content.stream_moment_table_gateway import (
 from ....logging_config import get_logger, sanitize_log_value
 from ...caching.cache import CacheTTL, InProcessCache, invalidate_cache_pattern
 from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import scene_rollup_version
 from ...dependencies import get_cache
 from ...security.auth import get_current_admin_user
 from ...security.auth_models import UserInDB
@@ -67,7 +68,9 @@ def get_moment_queue(
     """
     with _MOMENT_QUEUE_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _MOMENT_QUEUE_CACHE.lookup(cache, response, status, creator_id, limit, offset)
+        cache_key, cached_result = _MOMENT_QUEUE_CACHE.lookup(
+            cache, response, status, creator_id, limit, offset, scene_rollup_version()
+        )
         if cached_result is not None:
             return cached_result
 

--- a/backend/stream_sniper/api/features/content/moment_endpoints.py
+++ b/backend/stream_sniper/api/features/content/moment_endpoints.py
@@ -13,7 +13,7 @@ from ....database.gateways.content.stream_moment_table_gateway import (
     moment_exists_db,
     select_moment_queue_db,
 )
-from ....logging_config import get_logger
+from ....logging_config import get_logger, sanitize_log_value
 from ...caching.cache import CacheTTL, InProcessCache, invalidate_cache_pattern
 from ...caching.model_cache import ModelCachePolicy
 from ...dependencies import get_cache
@@ -139,8 +139,11 @@ def set_moment_review(
     )
     _invalidate_moment_caches(get_cache(request))
     logger.info(
-        f"Moment review set by admin {current_user.username}: "
-        f"stream={stream_id} bucket={bucket_minute} status={body.status}"
+        "Moment review set by admin %s: stream=%s bucket=%s status=%s",
+        sanitize_log_value(current_user.username),
+        stream_id,
+        sanitize_log_value(bucket_minute),
+        sanitize_log_value(body.status),
     )
     return MomentReviewResponse(
         status=body.status,
@@ -176,5 +179,10 @@ def clear_moment_review(
 
     delete_moment_review_db(stream_id, bucket_minute)
     _invalidate_moment_caches(get_cache(request))
-    logger.info(f"Moment review cleared by admin {current_user.username}: stream={stream_id} bucket={bucket_minute}")
+    logger.info(
+        "Moment review cleared by admin %s: stream=%s bucket=%s",
+        sanitize_log_value(current_user.username),
+        stream_id,
+        sanitize_log_value(bucket_minute),
+    )
     return None

--- a/backend/stream_sniper/api/features/content/scene_endpoints.py
+++ b/backend/stream_sniper/api/features/content/scene_endpoints.py
@@ -27,6 +27,7 @@ from ....application.scenes.scene_query import (
 )
 from ...caching.cache import CacheTTL
 from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import scene_rollup_version
 from ...dependencies import get_cache
 from ...security.rate_limiter import limiter, rate_limits
 from ...transport.models import ErrorOrValidationResponse, ErrorResponse, RateLimitErrorResponse
@@ -63,7 +64,9 @@ def get_copypasta_propagation(
     """Return the complete bounded-rollup propagation path for one message text."""
     with _PROPAGATION_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached = _PROPAGATION_CACHE.lookup(cache, response, message_text_id, context_seconds)
+        cache_key, cached = _PROPAGATION_CACHE.lookup(
+            cache, response, message_text_id, context_seconds, scene_rollup_version()
+        )
         if cached is not None:
             return cached
         try:
@@ -118,7 +121,7 @@ def get_scene_leaderboard(
         raise HTTPException(status_code=422, detail="window must be 7 or 30")
     with _LEADERBOARD_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _LEADERBOARD_CACHE.lookup(cache, response, window)
+        cache_key, cached_result = _LEADERBOARD_CACHE.lookup(cache, response, window, scene_rollup_version())
         if cached_result is not None:
             return cached_result
 
@@ -147,7 +150,9 @@ def get_scene_copypastas(
     """Get a page of scene-wide copypastas, sorted by usage, channel spread, or recency."""
     with _COPYPASTAS_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _COPYPASTAS_CACHE.lookup(cache, response, days, creator_id, sort, limit, offset)
+        cache_key, cached_result = _COPYPASTAS_CACHE.lookup(
+            cache, response, days, creator_id, sort, limit, offset, scene_rollup_version()
+        )
         if cached_result is not None:
             return cached_result
 

--- a/backend/stream_sniper/api/features/content/scene_event_endpoints.py
+++ b/backend/stream_sniper/api/features/content/scene_event_endpoints.py
@@ -7,6 +7,7 @@ from ....database.gateways.content.scene_event_table_gateway import select_scene
 from ....logging_config import get_logger
 from ...caching.cache import CacheTTL
 from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import scene_rollup_version
 from ...dependencies import get_cache
 from ...security.rate_limiter import limiter, rate_limits
 from ...transport.models import RateLimitErrorResponse
@@ -34,7 +35,9 @@ def get_scene_pulse(
 ) -> ScenePulse:
     with _SCENE_PULSE_CACHE.record_failures():
         cache = get_cache(request)
-        key, cached = _SCENE_PULSE_CACHE.lookup(cache, response, days, event_type, creator_id, limit, offset)
+        key, cached = _SCENE_PULSE_CACHE.lookup(
+            cache, response, days, event_type, creator_id, limit, offset, scene_rollup_version()
+        )
         if cached is not None:
             return cached
         rows, total = select_scene_events_db(days, event_type or None, creator_id, limit, offset)

--- a/backend/stream_sniper/api/features/creators/analytics_endpoints.py
+++ b/backend/stream_sniper/api/features/creators/analytics_endpoints.py
@@ -17,6 +17,7 @@ from ....application.creators.regulars_query import get_creator_regulars as quer
 from ....logging_config import get_logger
 from ...caching.cache import CacheTTL
 from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import creator_rollup_version
 from ...dependencies import get_cache
 from ...security.rate_limiter import limiter, rate_limits
 from ...transport.models import ErrorResponse, RateLimitErrorResponse
@@ -48,7 +49,9 @@ def get_creator_summary(
     """Get the stable header and lifetime totals for a permanent creator page."""
     with _SUMMARY_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _SUMMARY_CACHE.lookup(cache, response, creator_id)
+        cache_key, cached_result = _SUMMARY_CACHE.lookup(
+            cache, response, creator_id, creator_rollup_version(creator_id)
+        )
         if cached_result is not None:
             return cached_result
         try:
@@ -78,7 +81,9 @@ def get_creator_trends(
     """Get per-stream trend points for a creator's recent streams."""
     with _TRENDS_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _TRENDS_CACHE.lookup(cache, response, creator_id, limit)
+        cache_key, cached_result = _TRENDS_CACHE.lookup(
+            cache, response, creator_id, limit, creator_rollup_version(creator_id)
+        )
         if cached_result is not None:
             return cached_result
 
@@ -111,7 +116,7 @@ def get_creator_regulars(
     with _REGULARS_CACHE.record_failures():
         cache = get_cache(request)
         cache_key, cached_result = _REGULARS_CACHE.lookup(
-            cache, response, creator_id, sort, dir, min_streams, limit, include_bots
+            cache, response, creator_id, sort, dir, min_streams, limit, include_bots, creator_rollup_version(creator_id)
         )
         if cached_result is not None:
             return cached_result

--- a/backend/stream_sniper/api/features/creators/creator_endpoints.py
+++ b/backend/stream_sniper/api/features/creators/creator_endpoints.py
@@ -7,6 +7,7 @@ from ....database.gateways.identity.creator_table_gateway import select_creator_
 from ....logging_config import get_logger
 from ...caching.cache import CacheTTL
 from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import creator_rollup_version
 from ...dependencies import get_cache
 from ...security.rate_limiter import limiter, rate_limits
 from ...transport.models import RateLimitErrorResponse
@@ -71,7 +72,9 @@ def get_creator_top_chatters(
     """Get the most active chatters across a creator's streams."""
     with _TOP_CHATTERS_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _TOP_CHATTERS_CACHE.lookup(cache, response, creator_id, limit)
+        cache_key, cached_result = _TOP_CHATTERS_CACHE.lookup(
+            cache, response, creator_id, limit, creator_rollup_version(creator_id)
+        )
         if cached_result is not None:
             return cached_result.root
 

--- a/backend/stream_sniper/api/features/operations/operations_endpoints.py
+++ b/backend/stream_sniper/api/features/operations/operations_endpoints.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Depends, Request, Response
 
-from ....logging_config import get_logger
+from ....logging_config import get_logger, sanitize_log_value
 from ...caching.cache import InProcessCache
 from ...config import APIConfig
 from ...dependencies import get_cache, get_config, get_health_checker, get_metrics_collector
@@ -202,7 +202,7 @@ def flush_cache(
     current_user: UserInDB = Depends(get_current_admin_user),
 ) -> CacheFlushResponse:
     cache.flush_all()
-    logger.info("Cache flushed by admin user id %s", current_user.id)
+    logger.info("Cache flushed by admin user id %s", sanitize_log_value(current_user.id))
     return CacheFlushResponse(message="Cache flushed successfully", timestamp=datetime.now().isoformat() + "Z")
 
 

--- a/backend/stream_sniper/api/features/operations/operations_endpoints.py
+++ b/backend/stream_sniper/api/features/operations/operations_endpoints.py
@@ -10,7 +10,7 @@ from ...caching.cache import InProcessCache
 from ...config import APIConfig
 from ...dependencies import get_cache, get_config, get_health_checker, get_metrics_collector
 from ...observability.health import HealthChecker
-from ...observability.health import HealthStatus as HealthStatusEnum
+from ...observability.health_contracts import HealthStatus as HealthStatusEnum
 from ...observability.monitoring import MetricsCollector, collect_monitoring_snapshot
 from ...security.auth import get_current_admin_user
 from ...security.auth_models import UserInDB

--- a/backend/stream_sniper/api/features/streams/compare_endpoints.py
+++ b/backend/stream_sniper/api/features/streams/compare_endpoints.py
@@ -10,6 +10,7 @@ from ....application.streams.compare_query import (
 from ....logging_config import get_logger
 from ...caching.cache import CacheTTL
 from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import stream_rollup_version
 from ...dependencies import get_cache
 from ...security.rate_limiter import limiter, rate_limits
 from ...transport.models import ErrorOrValidationResponse, ErrorResponse, RateLimitErrorResponse
@@ -39,7 +40,9 @@ def compare_streams(
         raise HTTPException(status_code=422, detail="stream_ids must be unique")
     with _STREAM_COMPARE_CACHE.record_failures():
         cache = get_cache(request)
-        key, cached = _STREAM_COMPARE_CACHE.lookup(cache, response, *stream_ids)
+        key, cached = _STREAM_COMPARE_CACHE.lookup(
+            cache, response, *stream_ids, *(stream_rollup_version(stream_id) for stream_id in stream_ids)
+        )
         if cached is not None:
             return cached
 

--- a/backend/stream_sniper/api/features/streams/stream_endpoints.py
+++ b/backend/stream_sniper/api/features/streams/stream_endpoints.py
@@ -28,6 +28,7 @@ from ....database.gateways.streams.stream_table_gateway import (
 from ....logging_config import get_logger
 from ...caching.cache import CacheTTL, InProcessCache
 from ...caching.model_cache import ModelCachePolicy, record_cache_failures
+from ...caching.rollup_version import stream_rollup_version
 from ...dependencies import get_cache
 from ...observability.monitoring import record_cache_operation
 from ...security.rate_limiter import limiter, rate_limits
@@ -204,7 +205,9 @@ def get_stream_chatters(
     """Get all chatters who participated in a stream."""
     with _STREAM_CHATTERS_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _STREAM_CHATTERS_CACHE.lookup(cache, response, stream_id)
+        cache_key, cached_result = _STREAM_CHATTERS_CACHE.lookup(
+            cache, response, stream_id, stream_rollup_version(stream_id)
+        )
         if cached_result is not None:
             return cached_result.root
 
@@ -236,7 +239,9 @@ def get_stream(
     """Get comprehensive analytics for a stream."""
     with _STREAM_DETAILS_CACHE.record_failures():
         cache = get_cache(request)
-        analytics_cache_key, cached_analytics = _STREAM_DETAILS_CACHE.lookup(cache, response, stream_id)
+        analytics_cache_key, cached_analytics = _STREAM_DETAILS_CACHE.lookup(
+            cache, response, stream_id, stream_rollup_version(stream_id)
+        )
         if cached_analytics is not None:
             return cached_analytics
 

--- a/backend/stream_sniper/api/features/streams/stream_insight_endpoints.py
+++ b/backend/stream_sniper/api/features/streams/stream_insight_endpoints.py
@@ -11,6 +11,7 @@ from ....database.gateways.streams.stream_table_gateway import select_stream_men
 from ....logging_config import get_logger
 from ...caching.cache import CacheTTL
 from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import creator_rollup_version, stream_rollup_version
 from ...dependencies import get_cache
 from ...security.rate_limiter import limiter, rate_limits
 from ...transport.export_utils import csv_response
@@ -39,7 +40,9 @@ _CREATOR_EMOTES_CACHE = ModelCachePolicy("creator_emotes", CacheTTL.STREAM_ANALY
 
 def _load_stream_mentions(request: Request, response: Response, stream_id: int, limit: int) -> StreamMentions:
     cache = get_cache(request)
-    cache_key, cached_result = _MENTIONS_CACHE.lookup(cache, response, stream_id, limit)
+    cache_key, cached_result = _MENTIONS_CACHE.lookup(
+        cache, response, stream_id, limit, stream_rollup_version(stream_id)
+    )
     if cached_result is not None:
         return cached_result
 
@@ -85,7 +88,9 @@ def get_stream_mentions(
 
 def _load_stream_emotes(request: Request, response: Response, stream_id: int, limit: int) -> StreamEmotes:
     cache = get_cache(request)
-    cache_key, cached_result = _STREAM_EMOTES_CACHE.lookup(cache, response, stream_id, limit)
+    cache_key, cached_result = _STREAM_EMOTES_CACHE.lookup(
+        cache, response, stream_id, limit, stream_rollup_version(stream_id)
+    )
     if cached_result is not None:
         return cached_result
 
@@ -127,7 +132,9 @@ def get_stream_emotes(
 
 def _load_stream_phrases(request: Request, response: Response, stream_id: int, limit: int) -> StreamPhrases:
     cache = get_cache(request)
-    cache_key, cached_result = _PHRASES_CACHE.lookup(cache, response, stream_id, limit)
+    cache_key, cached_result = _PHRASES_CACHE.lookup(
+        cache, response, stream_id, limit, stream_rollup_version(stream_id)
+    )
     if cached_result is not None:
         return cached_result
 
@@ -228,7 +235,9 @@ def get_creator_emotes(
     """Empty when the creator has no emote rollups yet — always 200, never 404."""
     with _CREATOR_EMOTES_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _CREATOR_EMOTES_CACHE.lookup(cache, response, creator_id, limit)
+        cache_key, cached_result = _CREATOR_EMOTES_CACHE.lookup(
+            cache, response, creator_id, limit, creator_rollup_version(creator_id)
+        )
         if cached_result is not None:
             return cached_result
 

--- a/backend/stream_sniper/api/features/streams/stream_report_endpoints.py
+++ b/backend/stream_sniper/api/features/streams/stream_report_endpoints.py
@@ -18,6 +18,7 @@ from ....application.streams.report_query import (
 from ....logging_config import get_logger
 from ...caching.cache import CacheTTL
 from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import stream_creator_rollup_version
 from ...dependencies import get_cache
 from ...security.auth import get_current_user
 from ...security.auth_models import UserInDB
@@ -61,7 +62,9 @@ def get_stream_report(
     """
     with _REPORT_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _REPORT_CACHE.lookup(cache, response, stream_id, lookback)
+        cache_key, cached_result = _REPORT_CACHE.lookup(
+            cache, response, stream_id, lookback, stream_creator_rollup_version(stream_id)
+        )
         if cached_result is not None:
             return cached_result
 

--- a/backend/stream_sniper/api/features/streams/timeline_endpoints.py
+++ b/backend/stream_sniper/api/features/streams/timeline_endpoints.py
@@ -7,6 +7,7 @@ from ....application.streams.timeline_query import get_stream_timeline as query_
 from ....logging_config import get_logger
 from ...caching.cache import CacheTTL
 from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import stream_rollup_version
 from ...dependencies import get_cache
 from ...security.rate_limiter import limiter, rate_limits
 from ...transport.models import RateLimitErrorResponse
@@ -43,7 +44,7 @@ def get_stream_timeline(
     """
     with _TIMELINE_CACHE.record_failures():
         cache = get_cache(request)
-        cache_key, cached_result = _TIMELINE_CACHE.lookup(cache, response, stream_id)
+        cache_key, cached_result = _TIMELINE_CACHE.lookup(cache, response, stream_id, stream_rollup_version(stream_id))
         if cached_result is not None:
             return cached_result
 

--- a/backend/stream_sniper/api/features/tracking/tracking_job_endpoints.py
+++ b/backend/stream_sniper/api/features/tracking/tracking_job_endpoints.py
@@ -25,7 +25,7 @@ from stream_sniper.application.tracking.models import (
 )
 from stream_sniper.collector.twitch_api import TwitchConfigurationError, TwitchUpstreamError
 
-from ....logging_config import get_logger
+from ....logging_config import get_logger, sanitize_log_value
 from ...dependencies import get_twitch_client
 from ...security.auth import get_current_admin_user
 from ...security.auth_models import UserInDB
@@ -107,7 +107,7 @@ async def trigger_processing(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Twitch integration unavailable"
         ) from error
     except TwitchUpstreamError as error:
-        logger.exception("Failed to list VODs for %s", twitch_username)
+        logger.exception("Failed to list VODs for %s", sanitize_log_value(twitch_username))
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Failed to list VODs from Twitch",
@@ -132,8 +132,11 @@ async def trigger_processing(
         )
 
     logger.info(
-        f"Manual processing queued by admin {current_user.username}: "
-        f"streamer_id={streamer_id}, job_id={outcome.job_id}, vod={twitch_vod_id}"
+        "Manual processing queued by admin %s: streamer_id=%s, job_id=%s, vod=%s",
+        sanitize_log_value(current_user.username),
+        streamer_id,
+        outcome.job_id,
+        twitch_vod_id,
     )
     return ProcessingTriggerResponse(
         outcome="queued",
@@ -169,7 +172,7 @@ async def cancel_job(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
     except ProcessingJobConflictError as error:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(error)) from error
-    logger.info(f"Job {job_id} cancellation requested by admin {current_user.username}")
+    logger.info("Job %s cancellation requested by admin %s", job_id, sanitize_log_value(current_user.username))
     return MessageResponse(message="Job cancellation requested")
 
 
@@ -198,5 +201,5 @@ async def retry_job(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
     except ProcessingJobConflictError as error:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(error)) from error
-    logger.info(f"Job {job_id} queued for retry by admin {current_user.username}")
+    logger.info("Job %s queued for retry by admin %s", job_id, sanitize_log_value(current_user.username))
     return MessageResponse(message="Job queued for retry")

--- a/backend/stream_sniper/api/features/tracking/tracking_streamer_endpoints.py
+++ b/backend/stream_sniper/api/features/tracking/tracking_streamer_endpoints.py
@@ -24,7 +24,7 @@ from ....database.gateways.tracking.tracked_streamers_table_gateway import (
     select_tracked_streamers_db,
     update_tracked_streamer_db,
 )
-from ....logging_config import get_logger
+from ....logging_config import get_logger, sanitize_log_value
 from ...caching.cache import CacheTTL
 from ...dependencies import get_cache, get_twitch_client
 from ...security.auth import get_current_admin_user
@@ -136,13 +136,17 @@ async def add_tracked_streamer(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Twitch integration unavailable"
         ) from error
     except (TwitchProfileLookupError, TwitchUpstreamError) as error:
-        logger.exception("Twitch profile lookup failed for %s", streamer_data.twitch_username)
+        logger.exception("Twitch profile lookup failed for %s", sanitize_log_value(streamer_data.twitch_username))
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Failed to contact Twitch") from error
     except TrackedStreamerCreationError as error:
-        logger.exception("Tracked streamer creation failed for %s", streamer_data.twitch_username)
+        logger.exception("Tracked streamer creation failed for %s", sanitize_log_value(streamer_data.twitch_username))
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
 
-    logger.info(f"Tracked streamer created by admin {current_user.username}: {streamer_data.twitch_username}")
+    logger.info(
+        "Tracked streamer created by admin %s: %s",
+        sanitize_log_value(current_user.username),
+        sanitize_log_value(streamer_data.twitch_username),
+    )
     return convert_tracked_streamer_to_response(streamer)
 
 
@@ -196,7 +200,7 @@ async def search_twitch_channels(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Twitch integration unavailable"
         ) from error
     except TwitchUpstreamError as error:
-        logger.exception("Error searching Twitch channels for '%s'", query)
+        logger.exception("Error searching Twitch channels for '%s'", sanitize_log_value(query))
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Failed to search Twitch channels",
@@ -304,7 +308,9 @@ def update_tracked_streamer(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve updated streamer"
         )
 
-    logger.info(f"Tracked streamer updated by admin {current_user.username}: streamer_id={streamer_id}")
+    logger.info(
+        "Tracked streamer updated by admin %s: streamer_id=%s", sanitize_log_value(current_user.username), streamer_id
+    )
     return convert_tracked_streamer_to_response(updated_streamer)
 
 
@@ -342,5 +348,7 @@ def remove_tracked_streamer(
     if not success:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to remove streamer")
 
-    logger.info(f"Tracked streamer removed by admin {current_user.username}: streamer_id={streamer_id}")
+    logger.info(
+        "Tracked streamer removed by admin %s: streamer_id=%s", sanitize_log_value(current_user.username), streamer_id
+    )
     return None

--- a/backend/stream_sniper/api/observability/health.py
+++ b/backend/stream_sniper/api/observability/health.py
@@ -441,7 +441,7 @@ class HealthChecker:
     def _probe_twitch_api(self) -> ProbeResult:
         url = TWITCH_USERS_API_URL
         headers = {
-            "Client-ID": os.getenv("TWITCH_CLIENT_ID", "test"),
+            "Client-ID": self.config.twitch_client_id or "test",
             "User-Agent": "StreamSniper/1.0",
         }
         try:

--- a/backend/stream_sniper/api/observability/health.py
+++ b/backend/stream_sniper/api/observability/health.py
@@ -1,14 +1,16 @@
-"""Dependency probes, health snapshots, and monitoring renderers."""
+"""Dependency probing: collect health snapshots from live system dependencies.
+
+Contracts live in ``health_contracts``; JSON/Prometheus rendering lives in
+``health_renderers``. This module owns the I/O: database, cache, rate-limiter,
+and Twitch probes plus system-resource sampling.
+"""
 
 import logging
 import os
 import platform
 import time
-from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
+from collections.abc import Callable, Sequence
 from datetime import datetime
-from enum import Enum
-from typing import Any, NotRequired, TypedDict
 
 import psutil  # type: ignore[import-untyped]
 import requests
@@ -19,294 +21,28 @@ from ...database.core.connection_pool import get_active_pool
 from ..caching.cache import InProcessCache
 from ..config import APIConfig
 from ..security.rate_limiter import get_rate_limit_stats
+from .health_contracts import (
+    BasicHealthPayload,
+    ComponentHealth,
+    DetailedHealthPayload,
+    HealthProbe,
+    HealthSnapshot,
+    HealthStatus,
+    ProbeResult,
+    SystemResources,
+    iso_z,
+    overall_health_status,
+)
+from .health_renderers import (
+    MILLISECONDS_PER_SECOND,
+    detailed_health_payload,
+    render_prometheus,
+)
 
 logger = logging.getLogger(__name__)
-MILLISECONDS_PER_SECOND = 1_000
 BYTES_PER_MEBIBYTE = 1_024 * 1_024
 BYTES_PER_GIBIBYTE = 1_024**3
 TWITCH_USERS_API_URL = "https://api.twitch.tv/helix/users"
-
-
-class ComponentHealthPayload(TypedDict):
-    status: str
-    message: str
-    response_time_ms: float
-    details: dict[str, Any]
-    last_check: str
-
-
-class ExternalApisPayload(TypedDict):
-    twitch: ComponentHealthPayload
-
-
-class MemoryResourcePayload(TypedDict):
-    percent: float
-    available_mb: float
-    used_mb: float
-    total_mb: float
-
-
-class DiskResourcePayload(TypedDict):
-    percent: float
-    free_gb: float
-    total_gb: float
-
-
-class SystemResourcesPayload(TypedDict):
-    cpu_percent: float
-    memory: MemoryResourcePayload
-    disk: DiskResourcePayload
-    load_average: list[float] | None
-    uptime_seconds: float
-
-
-class DetailedSystemPayload(TypedDict):
-    platform: str
-    python_version: str
-    cpu_count: int | None
-    resources: SystemResourcesPayload
-
-
-class DetailedHealthPayload(TypedDict):
-    status: str
-    timestamp: str
-    version: str
-    uptime_seconds: float
-    components: dict[str, ComponentHealthPayload | ExternalApisPayload]
-    system: DetailedSystemPayload
-    error: NotRequired[str]
-
-
-class BasicDatabaseHealthPayload(TypedDict):
-    status: str
-    healthy: bool
-    response_time_ms: float
-
-
-class BasicHealthPayload(TypedDict):
-    status: str
-    timestamp: str
-    version: str
-    uptime_seconds: float
-    database: BasicDatabaseHealthPayload
-    error: NotRequired[str]
-
-
-class HealthStatus(Enum):
-    """Health status levels for components and the aggregate system."""
-
-    HEALTHY = "healthy"
-    DEGRADED = "degraded"
-    UNHEALTHY = "unhealthy"
-    CRITICAL = "critical"
-    UNKNOWN = "unknown"
-
-
-@dataclass(frozen=True)
-class ProbeResult:
-    """Dependency-specific classification before timing metadata is attached."""
-
-    status: HealthStatus
-    message: str
-    details: Mapping[str, Any]
-
-
-@dataclass(frozen=True)
-class HealthProbe:
-    """A named dependency check and its status when the check raises."""
-
-    name: str
-    check: Callable[[], ProbeResult]
-    failure_status: HealthStatus = HealthStatus.UNHEALTHY
-
-
-@dataclass(frozen=True)
-class ComponentHealth:
-    """Timed health result for one registered component."""
-
-    name: str
-    status: HealthStatus
-    message: str
-    details: Mapping[str, Any]
-    response_time_ms: float
-    last_check: datetime
-
-    def to_dict(self) -> ComponentHealthPayload:
-        """Serialize the component once for every JSON consumer."""
-        return {
-            "status": self.status.value,
-            "message": self.message,
-            "response_time_ms": self.response_time_ms,
-            "details": dict(self.details),
-            "last_check": _iso_z(self.last_check),
-        }
-
-
-@dataclass(frozen=True)
-class SystemResources:
-    """System resource utilization captured with a health snapshot."""
-
-    cpu_percent: float
-    memory_percent: float
-    memory_available_mb: float
-    memory_used_mb: float
-    memory_total_mb: float
-    disk_percent: float
-    disk_free_gb: float
-    disk_total_gb: float
-    load_average: tuple[float, float, float] | None
-    uptime_seconds: float
-
-    def to_dict(self) -> SystemResourcesPayload:
-        return {
-            "cpu_percent": self.cpu_percent,
-            "memory": {
-                "percent": self.memory_percent,
-                "available_mb": self.memory_available_mb,
-                "used_mb": self.memory_used_mb,
-                "total_mb": self.memory_total_mb,
-            },
-            "disk": {
-                "percent": self.disk_percent,
-                "free_gb": self.disk_free_gb,
-                "total_gb": self.disk_total_gb,
-            },
-            "load_average": list(self.load_average) if self.load_average else None,
-            "uptime_seconds": self.uptime_seconds,
-        }
-
-
-@dataclass(frozen=True)
-class HealthSnapshot:
-    """One policy-neutral observation shared by every detailed renderer."""
-
-    checked_at: datetime
-    version: str
-    application_uptime_seconds: float
-    components: Mapping[str, ComponentHealth]
-    resources: SystemResources
-    platform_name: str
-    python_version: str
-    cpu_count: int | None
-
-
-_STATUS_PRIORITY = {
-    HealthStatus.HEALTHY: 0,
-    HealthStatus.UNKNOWN: 1,
-    HealthStatus.DEGRADED: 2,
-    HealthStatus.UNHEALTHY: 3,
-    HealthStatus.CRITICAL: 4,
-}
-
-_PROMETHEUS_STATUS = {
-    HealthStatus.HEALTHY: 1,
-    HealthStatus.DEGRADED: 0.75,
-    HealthStatus.UNHEALTHY: 0.5,
-    HealthStatus.CRITICAL: 0,
-    HealthStatus.UNKNOWN: -1,
-}
-
-
-def overall_health_status(components: Mapping[str, ComponentHealth]) -> HealthStatus:
-    """Reduce component statuses without coupling probes to endpoint policy."""
-    if not components:
-        return HealthStatus.UNKNOWN
-    return max(
-        (component.status for component in components.values()),
-        key=_STATUS_PRIORITY.__getitem__,
-    )
-
-
-def detailed_health_payload(snapshot: HealthSnapshot) -> DetailedHealthPayload:
-    """Render the detailed JSON contract from an already-collected snapshot."""
-    component_payloads = {name: component.to_dict() for name, component in snapshot.components.items()}
-    twitch = component_payloads.pop("twitch_api", None)
-    serialized: dict[str, ComponentHealthPayload | ExternalApisPayload] = dict(component_payloads)
-    if twitch is not None:
-        serialized["external_apis"] = {"twitch": twitch}
-    return {
-        "status": overall_health_status(snapshot.components).value,
-        "timestamp": _iso_z(snapshot.checked_at),
-        "version": snapshot.version,
-        "uptime_seconds": snapshot.application_uptime_seconds,
-        "components": serialized,
-        "system": {
-            "platform": snapshot.platform_name,
-            "python_version": snapshot.python_version,
-            "cpu_count": snapshot.cpu_count,
-            "resources": snapshot.resources.to_dict(),
-        },
-    }
-
-
-def render_prometheus(snapshot: HealthSnapshot) -> str:
-    """Render one snapshot in Prometheus text exposition format."""
-    timestamp_ms = int(snapshot.checked_at.timestamp() * MILLISECONDS_PER_SECOND)
-    lines = [
-        "# HELP stream_sniper_component_health Health status of system components",
-        "# TYPE stream_sniper_component_health gauge",
-    ]
-    for name, component in snapshot.components.items():
-        lines.append(
-            f'stream_sniper_component_health{{component="{name}"}} '
-            f"{_PROMETHEUS_STATUS[component.status]} {timestamp_ms}"
-        )
-    lines.extend(
-        [
-            "",
-            "# HELP stream_sniper_component_response_time_ms Component health-check duration",
-            "# TYPE stream_sniper_component_response_time_ms gauge",
-        ]
-    )
-    for name, component in snapshot.components.items():
-        lines.append(
-            f'stream_sniper_component_response_time_ms{{component="{name}"}} '
-            f"{component.response_time_ms} {timestamp_ms}"
-        )
-    resources = snapshot.resources
-    lines.extend(
-        [
-            "",
-            "# HELP stream_sniper_system_cpu_percent Current CPU usage percentage",
-            "# TYPE stream_sniper_system_cpu_percent gauge",
-            f"stream_sniper_system_cpu_percent {resources.cpu_percent} {timestamp_ms}",
-            "",
-            "# HELP stream_sniper_system_memory_percent Current memory usage percentage",
-            "# TYPE stream_sniper_system_memory_percent gauge",
-            f"stream_sniper_system_memory_percent {resources.memory_percent} {timestamp_ms}",
-            "",
-            "# HELP stream_sniper_system_memory_mb Memory usage in megabytes",
-            "# TYPE stream_sniper_system_memory_mb gauge",
-            f'stream_sniper_system_memory_mb{{type="available"}} {resources.memory_available_mb} {timestamp_ms}',
-            f'stream_sniper_system_memory_mb{{type="used"}} {resources.memory_used_mb} {timestamp_ms}',
-            f'stream_sniper_system_memory_mb{{type="total"}} {resources.memory_total_mb} {timestamp_ms}',
-            "",
-            "# HELP stream_sniper_system_disk_percent Current disk usage percentage",
-            "# TYPE stream_sniper_system_disk_percent gauge",
-            f"stream_sniper_system_disk_percent {resources.disk_percent} {timestamp_ms}",
-            "",
-            "# HELP stream_sniper_system_disk_gb Disk usage in gigabytes",
-            "# TYPE stream_sniper_system_disk_gb gauge",
-            f'stream_sniper_system_disk_gb{{type="free"}} {resources.disk_free_gb} {timestamp_ms}',
-            f'stream_sniper_system_disk_gb{{type="total"}} {resources.disk_total_gb} {timestamp_ms}',
-            "",
-            "# HELP stream_sniper_uptime_seconds Application uptime in seconds",
-            "# TYPE stream_sniper_uptime_seconds gauge",
-            f"stream_sniper_uptime_seconds {snapshot.application_uptime_seconds} {timestamp_ms}",
-        ]
-    )
-    if resources.load_average is not None:
-        lines.extend(
-            [
-                "",
-                "# HELP stream_sniper_system_load_average System load average",
-                "# TYPE stream_sniper_system_load_average gauge",
-                f'stream_sniper_system_load_average{{period="1m"}} {resources.load_average[0]} {timestamp_ms}',
-                f'stream_sniper_system_load_average{{period="5m"}} {resources.load_average[1]} {timestamp_ms}',
-                f'stream_sniper_system_load_average{{period="15m"}} {resources.load_average[2]} {timestamp_ms}',
-            ]
-        )
-    return "\n".join(lines) + "\n"
 
 
 class HealthChecker:
@@ -490,7 +226,7 @@ class HealthChecker:
         checked_at = self._now()
         return database.status, {
             "status": database.status.value,
-            "timestamp": _iso_z(checked_at),
+            "timestamp": iso_z(checked_at),
             "version": self.config.version,
             "uptime_seconds": round((checked_at - self.start_time).total_seconds(), 0),
             "database": {
@@ -515,7 +251,3 @@ class HealthChecker:
                 "# TYPE stream_sniper_metrics_error gauge\n"
                 f"stream_sniper_metrics_error 1 {error_time}\n"
             )
-
-
-def _iso_z(value: datetime) -> str:
-    return value.isoformat() + "Z"

--- a/backend/stream_sniper/api/observability/health_contracts.py
+++ b/backend/stream_sniper/api/observability/health_contracts.py
@@ -1,0 +1,199 @@
+"""Health-domain contracts: status vocabulary, probe records, and payload shapes.
+
+Policy-neutral data owned by the observability package: probes produce these
+records, renderers (``health_renderers``) serialize them, and the checker
+(``health``) orchestrates both. Nothing here touches I/O.
+"""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, NotRequired, TypedDict
+
+
+class ComponentHealthPayload(TypedDict):
+    status: str
+    message: str
+    response_time_ms: float
+    details: dict[str, Any]
+    last_check: str
+
+
+class ExternalApisPayload(TypedDict):
+    twitch: ComponentHealthPayload
+
+
+class MemoryResourcePayload(TypedDict):
+    percent: float
+    available_mb: float
+    used_mb: float
+    total_mb: float
+
+
+class DiskResourcePayload(TypedDict):
+    percent: float
+    free_gb: float
+    total_gb: float
+
+
+class SystemResourcesPayload(TypedDict):
+    cpu_percent: float
+    memory: MemoryResourcePayload
+    disk: DiskResourcePayload
+    load_average: list[float] | None
+    uptime_seconds: float
+
+
+class DetailedSystemPayload(TypedDict):
+    platform: str
+    python_version: str
+    cpu_count: int | None
+    resources: SystemResourcesPayload
+
+
+class DetailedHealthPayload(TypedDict):
+    status: str
+    timestamp: str
+    version: str
+    uptime_seconds: float
+    components: dict[str, ComponentHealthPayload | ExternalApisPayload]
+    system: DetailedSystemPayload
+    error: NotRequired[str]
+
+
+class BasicDatabaseHealthPayload(TypedDict):
+    status: str
+    healthy: bool
+    response_time_ms: float
+
+
+class BasicHealthPayload(TypedDict):
+    status: str
+    timestamp: str
+    version: str
+    uptime_seconds: float
+    database: BasicDatabaseHealthPayload
+    error: NotRequired[str]
+
+
+class HealthStatus(Enum):
+    """Health status levels for components and the aggregate system."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+    CRITICAL = "critical"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Dependency-specific classification before timing metadata is attached."""
+
+    status: HealthStatus
+    message: str
+    details: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class HealthProbe:
+    """A named dependency check and its status when the check raises."""
+
+    name: str
+    check: Callable[[], ProbeResult]
+    failure_status: HealthStatus = HealthStatus.UNHEALTHY
+
+
+@dataclass(frozen=True)
+class ComponentHealth:
+    """Timed health result for one registered component."""
+
+    name: str
+    status: HealthStatus
+    message: str
+    details: Mapping[str, Any]
+    response_time_ms: float
+    last_check: datetime
+
+    def to_dict(self) -> ComponentHealthPayload:
+        """Serialize the component once for every JSON consumer."""
+        return {
+            "status": self.status.value,
+            "message": self.message,
+            "response_time_ms": self.response_time_ms,
+            "details": dict(self.details),
+            "last_check": iso_z(self.last_check),
+        }
+
+
+@dataclass(frozen=True)
+class SystemResources:
+    """System resource utilization captured with a health snapshot."""
+
+    cpu_percent: float
+    memory_percent: float
+    memory_available_mb: float
+    memory_used_mb: float
+    memory_total_mb: float
+    disk_percent: float
+    disk_free_gb: float
+    disk_total_gb: float
+    load_average: tuple[float, float, float] | None
+    uptime_seconds: float
+
+    def to_dict(self) -> SystemResourcesPayload:
+        return {
+            "cpu_percent": self.cpu_percent,
+            "memory": {
+                "percent": self.memory_percent,
+                "available_mb": self.memory_available_mb,
+                "used_mb": self.memory_used_mb,
+                "total_mb": self.memory_total_mb,
+            },
+            "disk": {
+                "percent": self.disk_percent,
+                "free_gb": self.disk_free_gb,
+                "total_gb": self.disk_total_gb,
+            },
+            "load_average": list(self.load_average) if self.load_average else None,
+            "uptime_seconds": self.uptime_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class HealthSnapshot:
+    """One policy-neutral observation shared by every detailed renderer."""
+
+    checked_at: datetime
+    version: str
+    application_uptime_seconds: float
+    components: Mapping[str, ComponentHealth]
+    resources: SystemResources
+    platform_name: str
+    python_version: str
+    cpu_count: int | None
+
+
+_STATUS_PRIORITY = {
+    HealthStatus.HEALTHY: 0,
+    HealthStatus.UNKNOWN: 1,
+    HealthStatus.DEGRADED: 2,
+    HealthStatus.UNHEALTHY: 3,
+    HealthStatus.CRITICAL: 4,
+}
+
+
+def overall_health_status(components: Mapping[str, ComponentHealth]) -> HealthStatus:
+    """Reduce component statuses without coupling probes to endpoint policy."""
+    if not components:
+        return HealthStatus.UNKNOWN
+    return max(
+        (component.status for component in components.values()),
+        key=_STATUS_PRIORITY.__getitem__,
+    )
+
+
+def iso_z(value: datetime) -> str:
+    """Render a naive UTC datetime in the health payloads' ISO-with-Z shape."""
+    return value.isoformat() + "Z"

--- a/backend/stream_sniper/api/observability/health_renderers.py
+++ b/backend/stream_sniper/api/observability/health_renderers.py
@@ -1,0 +1,113 @@
+"""Render collected health snapshots into the JSON and Prometheus contracts."""
+
+from .health_contracts import (
+    ComponentHealthPayload,
+    DetailedHealthPayload,
+    ExternalApisPayload,
+    HealthSnapshot,
+    HealthStatus,
+    iso_z,
+    overall_health_status,
+)
+
+MILLISECONDS_PER_SECOND = 1_000
+
+_PROMETHEUS_STATUS = {
+    HealthStatus.HEALTHY: 1,
+    HealthStatus.DEGRADED: 0.75,
+    HealthStatus.UNHEALTHY: 0.5,
+    HealthStatus.CRITICAL: 0,
+    HealthStatus.UNKNOWN: -1,
+}
+
+
+def detailed_health_payload(snapshot: HealthSnapshot) -> DetailedHealthPayload:
+    """Render the detailed JSON contract from an already-collected snapshot."""
+    component_payloads = {name: component.to_dict() for name, component in snapshot.components.items()}
+    twitch = component_payloads.pop("twitch_api", None)
+    serialized: dict[str, ComponentHealthPayload | ExternalApisPayload] = dict(component_payloads)
+    if twitch is not None:
+        serialized["external_apis"] = {"twitch": twitch}
+    return {
+        "status": overall_health_status(snapshot.components).value,
+        "timestamp": iso_z(snapshot.checked_at),
+        "version": snapshot.version,
+        "uptime_seconds": snapshot.application_uptime_seconds,
+        "components": serialized,
+        "system": {
+            "platform": snapshot.platform_name,
+            "python_version": snapshot.python_version,
+            "cpu_count": snapshot.cpu_count,
+            "resources": snapshot.resources.to_dict(),
+        },
+    }
+
+
+def render_prometheus(snapshot: HealthSnapshot) -> str:
+    """Render one snapshot in Prometheus text exposition format."""
+    timestamp_ms = int(snapshot.checked_at.timestamp() * MILLISECONDS_PER_SECOND)
+    lines = [
+        "# HELP stream_sniper_component_health Health status of system components",
+        "# TYPE stream_sniper_component_health gauge",
+    ]
+    for name, component in snapshot.components.items():
+        lines.append(
+            f'stream_sniper_component_health{{component="{name}"}} '
+            f"{_PROMETHEUS_STATUS[component.status]} {timestamp_ms}"
+        )
+    lines.extend(
+        [
+            "",
+            "# HELP stream_sniper_component_response_time_ms Component health-check duration",
+            "# TYPE stream_sniper_component_response_time_ms gauge",
+        ]
+    )
+    for name, component in snapshot.components.items():
+        lines.append(
+            f'stream_sniper_component_response_time_ms{{component="{name}"}} '
+            f"{component.response_time_ms} {timestamp_ms}"
+        )
+    resources = snapshot.resources
+    lines.extend(
+        [
+            "",
+            "# HELP stream_sniper_system_cpu_percent Current CPU usage percentage",
+            "# TYPE stream_sniper_system_cpu_percent gauge",
+            f"stream_sniper_system_cpu_percent {resources.cpu_percent} {timestamp_ms}",
+            "",
+            "# HELP stream_sniper_system_memory_percent Current memory usage percentage",
+            "# TYPE stream_sniper_system_memory_percent gauge",
+            f"stream_sniper_system_memory_percent {resources.memory_percent} {timestamp_ms}",
+            "",
+            "# HELP stream_sniper_system_memory_mb Memory usage in megabytes",
+            "# TYPE stream_sniper_system_memory_mb gauge",
+            f'stream_sniper_system_memory_mb{{type="available"}} {resources.memory_available_mb} {timestamp_ms}',
+            f'stream_sniper_system_memory_mb{{type="used"}} {resources.memory_used_mb} {timestamp_ms}',
+            f'stream_sniper_system_memory_mb{{type="total"}} {resources.memory_total_mb} {timestamp_ms}',
+            "",
+            "# HELP stream_sniper_system_disk_percent Current disk usage percentage",
+            "# TYPE stream_sniper_system_disk_percent gauge",
+            f"stream_sniper_system_disk_percent {resources.disk_percent} {timestamp_ms}",
+            "",
+            "# HELP stream_sniper_system_disk_gb Disk usage in gigabytes",
+            "# TYPE stream_sniper_system_disk_gb gauge",
+            f'stream_sniper_system_disk_gb{{type="free"}} {resources.disk_free_gb} {timestamp_ms}',
+            f'stream_sniper_system_disk_gb{{type="total"}} {resources.disk_total_gb} {timestamp_ms}',
+            "",
+            "# HELP stream_sniper_uptime_seconds Application uptime in seconds",
+            "# TYPE stream_sniper_uptime_seconds gauge",
+            f"stream_sniper_uptime_seconds {snapshot.application_uptime_seconds} {timestamp_ms}",
+        ]
+    )
+    if resources.load_average is not None:
+        lines.extend(
+            [
+                "",
+                "# HELP stream_sniper_system_load_average System load average",
+                "# TYPE stream_sniper_system_load_average gauge",
+                f'stream_sniper_system_load_average{{period="1m"}} {resources.load_average[0]} {timestamp_ms}',
+                f'stream_sniper_system_load_average{{period="5m"}} {resources.load_average[1]} {timestamp_ms}',
+                f'stream_sniper_system_load_average{{period="15m"}} {resources.load_average[2]} {timestamp_ms}',
+            ]
+        )
+    return "\n".join(lines) + "\n"

--- a/backend/stream_sniper/database/core/connection_pool.py
+++ b/backend/stream_sniper/database/core/connection_pool.py
@@ -58,9 +58,7 @@ class DatabasePoolConfig:
     command_timeout: int = 60
 
 
-def load_database_pool_config(
-    environ: Mapping[str, str] | None = None, *, require: bool = True
-) -> DatabasePoolConfig:
+def load_database_pool_config(environ: Mapping[str, str] | None = None, *, require: bool = True) -> DatabasePoolConfig:
     """Build a pool configuration at an executable composition boundary.
 
     With ``require=True`` (CLI/service entry points) missing credentials raise

--- a/backend/stream_sniper/database/gateways/analytics/stream_chatter_stats_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/analytics/stream_chatter_stats_table_gateway.py
@@ -71,7 +71,7 @@ def select_stream_ids_for_chatters_db(
     return [int(row[0]) for row in cursor.fetchall()]
 
 
-def _replace_time_buckets(cursor: Cursor, params: dict[str, int]) -> None:
+def _replace_time_buckets(cursor: Cursor, params: dict[str, int | list[int]]) -> None:
     """Replace per-minute message, chatter, subscriber, and emote buckets."""
     cursor.execute("DELETE FROM stream_time_bucket WHERE stream_id = %(sid)s", params)
     cursor.execute(
@@ -95,7 +95,13 @@ def _replace_time_buckets(cursor: Cursor, params: dict[str, int]) -> None:
     )
 
 
-def _replace_stream_chatter_stats(cursor: Cursor, params: dict[str, int]) -> None:
+def _select_stream_chatter_ids(cursor: Cursor, params: dict[str, int | list[int]]) -> list[int]:
+    """Chatters currently recorded for the stream (before a rollup replace)."""
+    cursor.execute("SELECT chatter_id FROM stream_chatter_stats WHERE stream_id = %(sid)s", params)
+    return [int(row[0]) for row in cursor.fetchall()]
+
+
+def _replace_stream_chatter_stats(cursor: Cursor, params: dict[str, int | list[int]]) -> None:
     """Replace per-chatter aggregates for the stream."""
     cursor.execute("DELETE FROM stream_chatter_stats WHERE stream_id = %(sid)s", params)
     cursor.execute(
@@ -111,7 +117,7 @@ def _replace_stream_chatter_stats(cursor: Cursor, params: dict[str, int]) -> Non
     )
 
 
-def _replace_stream_metrics(cursor: Cursor, params: dict[str, int]) -> None:
+def _replace_stream_metrics(cursor: Cursor, params: dict[str, int | list[int]]) -> None:
     """Replace the single stream summary row from the preceding phase tables."""
     cursor.execute("DELETE FROM stream_metrics WHERE stream_id = %(sid)s", params)
     cursor.execute(
@@ -174,8 +180,17 @@ def _replace_stream_metrics(cursor: Cursor, params: dict[str, int]) -> None:
     )
 
 
-def _upsert_creator_chatter_stats(cursor: Cursor, params: dict[str, int]) -> None:
-    """Refresh creator aggregates for chatters touched by the stream."""
+def _upsert_creator_chatter_stats(cursor: Cursor, params: dict[str, int | list[int]]) -> None:
+    """Refresh creator aggregates for chatters touched by the stream.
+
+    The refresh set is the union of the stream's current chatters and the
+    chatters recorded before the replace (``%(prev)s``): if a re-collection or
+    cleanup removed a chatter from this stream, their creator-level aggregates
+    are recomputed from the remaining streams instead of staying stale forever.
+    Chatters with no remaining rows for the creator produce no INSERT row (the
+    LATERAL first/last-seen lookups are empty); those are handled by
+    ``_delete_orphaned_creator_chatter_stats``.
+    """
     cursor.execute(
         """
         INSERT INTO creator_chatter_stats (
@@ -189,7 +204,11 @@ def _upsert_creator_chatter_stats(cursor: Cursor, params: dict[str, int]) -> Non
             fs.stream_id, fs.start,
             ls.stream_id, ls.start,
             now()
-        FROM (SELECT DISTINCT chatter_id FROM stream_chatter_stats WHERE stream_id = %(sid)s) t
+        FROM (
+            SELECT chatter_id FROM stream_chatter_stats WHERE stream_id = %(sid)s
+            UNION
+            SELECT unnest(%(prev)s::int[])
+        ) t
         CROSS JOIN LATERAL (
             SELECT count(*)::int AS streams_attended,
                    COALESCE(sum(scs.message_count), 0)::bigint AS total_messages
@@ -224,7 +243,30 @@ def _upsert_creator_chatter_stats(cursor: Cursor, params: dict[str, int]) -> Non
     )
 
 
-def _replace_stream_emote_stats(cursor: Cursor, params: dict[str, int]) -> None:
+def _delete_orphaned_creator_chatter_stats(cursor: Cursor, params: dict[str, int | list[int]]) -> None:
+    """Drop creator aggregates for previous chatters with no remaining streams.
+
+    Complements ``_upsert_creator_chatter_stats``: a chatter removed from this
+    stream by a re-collection who attended no other stream of the creator would
+    otherwise keep a stale creator_chatter_stats row forever.
+    """
+    cursor.execute(
+        """
+        DELETE FROM creator_chatter_stats ccs
+        WHERE ccs.creator_id = %(cid)s
+          AND ccs.chatter_id = ANY(%(prev)s::int[])
+          AND NOT EXISTS (
+              SELECT 1
+              FROM stream_chatter_stats scs
+              JOIN stream s ON s.id = scs.stream_id
+              WHERE scs.chatter_id = ccs.chatter_id AND s.creator_id = %(cid)s
+          )
+        """,
+        params,
+    )
+
+
+def _replace_stream_emote_stats(cursor: Cursor, params: dict[str, int | list[int]]) -> None:
     """Replace case-sensitive, name-deduplicated per-stream emote usage."""
     cursor.execute("DELETE FROM stream_emote_stats WHERE stream_id = %(sid)s", params)
     cursor.execute(
@@ -257,10 +299,12 @@ def recompute_stream_rollup_db(
     creator_id: int,
 ) -> None:
     """Recompute the SQL rollup phases atomically and idempotently."""
-    params = {"sid": stream_id, "cid": creator_id}
+    params: dict[str, int | list[int]] = {"sid": stream_id, "cid": creator_id}
     _replace_time_buckets(cursor, params)
+    params["prev"] = _select_stream_chatter_ids(cursor, params)
     _replace_stream_chatter_stats(cursor, params)
     _replace_stream_metrics(cursor, params)
     _upsert_creator_chatter_stats(cursor, params)
+    _delete_orphaned_creator_chatter_stats(cursor, params)
     _replace_stream_emote_stats(cursor, params)
     connection.commit()

--- a/backend/stream_sniper/database/gateways/analytics/stream_metrics_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/analytics/stream_metrics_table_gateway.py
@@ -39,6 +39,76 @@ def select_stream_metrics_db(
 
 
 @with_cursor
+def select_stream_rollup_version_db(
+    cursor: Cursor,
+    stream_id: int,
+) -> str | None:
+    """Opaque rollup version for one stream (``None`` until first rollup).
+
+    Used as a cache-key part so API responses derived from this stream's
+    rollup tables invalidate when the collector/tracking process recomputes
+    them. Epoch text keeps full precision; the value is never rendered.
+    """
+    cursor.execute(
+        "SELECT EXTRACT(EPOCH FROM computed_at)::text FROM stream_metrics WHERE stream_id = %s",
+        (stream_id,),
+    )
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
+@with_cursor
+def select_stream_creator_rollup_version_db(
+    cursor: Cursor,
+    stream_id: int,
+) -> str | None:
+    """Latest rollup version across all streams of the given stream's creator.
+
+    Covers responses that mix one stream with a creator-wide baseline
+    (e.g. the stream report card): a rollup of ANY sibling stream changes
+    the baseline, so the version must move with the whole creator.
+    """
+    cursor.execute(
+        """
+        SELECT EXTRACT(EPOCH FROM max(sm.computed_at))::text
+        FROM stream_metrics sm
+        JOIN stream s ON s.id = sm.stream_id
+        WHERE s.creator_id = (SELECT creator_id FROM stream WHERE id = %s)
+        """,
+        (stream_id,),
+    )
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
+@with_cursor
+def select_creator_rollup_version_db(
+    cursor: Cursor,
+    creator_id: int,
+) -> str | None:
+    """Latest rollup version across all streams of one creator."""
+    cursor.execute(
+        """
+        SELECT EXTRACT(EPOCH FROM max(sm.computed_at))::text
+        FROM stream_metrics sm
+        JOIN stream s ON s.id = sm.stream_id
+        WHERE s.creator_id = %s
+        """,
+        (creator_id,),
+    )
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
+@with_cursor
+def select_scene_rollup_version_db(cursor: Cursor) -> str | None:
+    """Latest rollup version across the whole scene (all streams)."""
+    cursor.execute("SELECT EXTRACT(EPOCH FROM max(computed_at))::text FROM stream_metrics")
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
+@with_cursor
 def select_stream_header_db(
     cursor: Cursor,
     stream_id: int,

--- a/backend/stream_sniper/logging_config.py
+++ b/backend/stream_sniper/logging_config.py
@@ -9,7 +9,6 @@ import contextvars
 import json
 import logging
 import logging.handlers
-import os
 import sys
 import time
 import uuid
@@ -213,7 +212,9 @@ class LoggingConfig:
         correlation_id_enabled: bool = True,
     ):
 
-        self.environment = environment or os.getenv("ENVIRONMENT", "development")
+        # Executable entry points pass the environment explicitly (asgi/server/cli/
+        # tracking/live/analytics); no implicit environment-variable fallback.
+        self.environment = environment or "development"
         self.log_level = self._parse_log_level(log_level)
         self.log_dir = Path(log_dir) if log_dir else Path.cwd() / "logs"
         self.enable_file_logging = enable_file_logging

--- a/backend/stream_sniper/logging_config.py
+++ b/backend/stream_sniper/logging_config.py
@@ -368,6 +368,15 @@ def setup_logging(environment: str | None = None, **kwargs: Unpack[LoggingOption
     return _logging_config.configure_logging()
 
 
+def sanitize_log_value(value: object) -> str:
+    """Flatten a user-supplied value for safe log interpolation.
+
+    Escapes CR/LF so request-controlled strings (usernames, search queries,
+    titles) cannot forge additional log lines (CodeQL py/log-injection).
+    """
+    return str(value).replace("\r", "\\r").replace("\n", "\\n")
+
+
 def get_logger(name: str | None = None) -> logging.Logger:
     """Get a logger without mutating process logging state."""
     if name is None:

--- a/backend/tests/unit/analytics/test_rollup_outcomes.py
+++ b/backend/tests/unit/analytics/test_rollup_outcomes.py
@@ -120,11 +120,18 @@ def test_missing_rollup_target_is_an_explicit_skip(monkeypatch, row, reason):
 
 def test_sql_rollup_phases_share_one_cursor_and_commit(monkeypatch):
     calls: list[str] = []
+    monkeypatch.setattr(
+        gateway,
+        "_select_stream_chatter_ids",
+        lambda cursor, params: calls.append(f"_select_stream_chatter_ids:{id(cursor)}:{params['sid']}:{params['cid']}")
+        or [],
+    )
     for name in (
         "_replace_time_buckets",
         "_replace_stream_chatter_stats",
         "_replace_stream_metrics",
         "_upsert_creator_chatter_stats",
+        "_delete_orphaned_creator_chatter_stats",
         "_replace_stream_emote_stats",
     ):
         monkeypatch.setattr(
@@ -139,9 +146,11 @@ def test_sql_rollup_phases_share_one_cursor_and_commit(monkeypatch):
 
     assert [call.split(":", 1)[0] for call in calls] == [
         "_replace_time_buckets",
+        "_select_stream_chatter_ids",
         "_replace_stream_chatter_stats",
         "_replace_stream_metrics",
         "_upsert_creator_chatter_stats",
+        "_delete_orphaned_creator_chatter_stats",
         "_replace_stream_emote_stats",
     ]
     assert {call.split(":")[1] for call in calls} == {str(id(cursor))}
@@ -150,6 +159,7 @@ def test_sql_rollup_phases_share_one_cursor_and_commit(monkeypatch):
 
 def test_sql_rollup_does_not_commit_after_a_phase_failure(monkeypatch):
     monkeypatch.setattr(gateway, "_replace_time_buckets", lambda _cursor, _params: None)
+    monkeypatch.setattr(gateway, "_select_stream_chatter_ids", lambda _cursor, _params: [])
 
     def fail_phase(_cursor, _params) -> None:
         raise RuntimeError("phase failed")

--- a/backend/tests/unit/api/test_creator_analytics.py
+++ b/backend/tests/unit/api/test_creator_analytics.py
@@ -314,9 +314,10 @@ class TestCreatorRegularsEndpoint:
 
         assert response.status_code == 200
         mock_regulars.assert_called_once_with(5, 2, 50, sort="attendance", direction="desc", include_bots=True)
-        # include_bots participates in the regulars cache key (True suffix).
+        # include_bots participates in the regulars cache key (before the
+        # trailing rollup-version part).
         assert any(
-            call.args and call.args[0] == "creator_regulars" and call.args[-1] is True
+            call.args and call.args[0] == "creator_regulars" and call.args[-2] is True
             for call in cache.generate_key.call_args_list
         )
 
@@ -336,7 +337,7 @@ class TestCreatorRegularsEndpoint:
         assert response.status_code == 200
         mock_regulars.assert_called_once_with(5, 2, 50, sort="attendance", direction="desc", include_bots=False)
         assert any(
-            call.args and call.args[0] == "creator_regulars" and call.args[-1] is False
+            call.args and call.args[0] == "creator_regulars" and call.args[-2] is False
             for call in cache.generate_key.call_args_list
         )
 

--- a/backend/tests/unit/api/test_health_snapshot.py
+++ b/backend/tests/unit/api/test_health_snapshot.py
@@ -7,14 +7,16 @@ import pytest
 
 from stream_sniper.api.caching.cache import InProcessCache
 from stream_sniper.api.config import APIConfig
-from stream_sniper.api.observability.health import (
-    HealthChecker,
+from stream_sniper.api.observability.health import HealthChecker
+from stream_sniper.api.observability.health_contracts import (
     HealthProbe,
     HealthStatus,
     ProbeResult,
     SystemResources,
-    detailed_health_payload,
     overall_health_status,
+)
+from stream_sniper.api.observability.health_renderers import (
+    detailed_health_payload,
     render_prometheus,
 )
 

--- a/backend/tests/unit/api/test_rollup_version.py
+++ b/backend/tests/unit/api/test_rollup_version.py
@@ -1,0 +1,36 @@
+"""Rollup-version cache-key helpers: passthrough, sentinel, and resilience."""
+
+import pytest
+
+from stream_sniper.api.caching import rollup_version
+
+
+@pytest.mark.parametrize(
+    ("helper", "gateway_name", "args"),
+    [
+        (rollup_version.stream_rollup_version, "select_stream_rollup_version_db", (42,)),
+        (rollup_version.stream_creator_rollup_version, "select_stream_creator_rollup_version_db", (42,)),
+        (rollup_version.creator_rollup_version, "select_creator_rollup_version_db", (7,)),
+    ],
+)
+def test_version_passes_through_gateway_value(monkeypatch, helper, gateway_name, args):
+    monkeypatch.setattr(rollup_version, gateway_name, lambda _id: "1752756000.123456")
+    assert helper(*args) == "1752756000.123456"
+
+
+def test_scene_version_passes_through_gateway_value(monkeypatch):
+    monkeypatch.setattr(rollup_version, "select_scene_rollup_version_db", lambda: "1752756000.5")
+    assert rollup_version.scene_rollup_version() == "1752756000.5"
+
+
+def test_missing_rollup_yields_the_unversioned_sentinel(monkeypatch):
+    monkeypatch.setattr(rollup_version, "select_stream_rollup_version_db", lambda _id: None)
+    assert rollup_version.stream_rollup_version(42) == "unversioned"
+
+
+def test_probe_failure_degrades_to_the_sentinel_instead_of_raising(monkeypatch):
+    def boom(_id):
+        raise RuntimeError("database unavailable")
+
+    monkeypatch.setattr(rollup_version, "select_creator_rollup_version_db", boom)
+    assert rollup_version.creator_rollup_version(7) == "unversioned"

--- a/backend/tests/unit/test_package_contracts.py
+++ b/backend/tests/unit/test_package_contracts.py
@@ -57,7 +57,7 @@ def test_api_infrastructure_has_explicit_package_ownership() -> None:
     backend_root = Path(__file__).parents[2]
     api_root = backend_root / "stream_sniper/api"
     expected_modules = {
-        "caching": {"__init__.py", "cache.py", "cache_warmup.py", "model_cache.py"},
+        "caching": {"__init__.py", "cache.py", "cache_warmup.py", "model_cache.py", "rollup_version.py"},
         "observability": {"__init__.py", "health.py", "monitoring.py"},
         "security": {"__init__.py", "auth.py", "auth_models.py", "rate_limiter.py"},
         "transport": {"__init__.py", "export_utils.py", "models.py"},

--- a/backend/tests/unit/test_package_contracts.py
+++ b/backend/tests/unit/test_package_contracts.py
@@ -58,7 +58,7 @@ def test_api_infrastructure_has_explicit_package_ownership() -> None:
     api_root = backend_root / "stream_sniper/api"
     expected_modules = {
         "caching": {"__init__.py", "cache.py", "cache_warmup.py", "model_cache.py", "rollup_version.py"},
-        "observability": {"__init__.py", "health.py", "monitoring.py"},
+        "observability": {"__init__.py", "health.py", "health_contracts.py", "health_renderers.py", "monitoring.py"},
         "security": {"__init__.py", "auth.py", "auth_models.py", "rate_limiter.py"},
         "transport": {"__init__.py", "export_utils.py", "models.py"},
     }


### PR DESCRIPTION
Implements every open stream-sniper item from the improvements backlog.

## Fixes
- **Cross-process cache invalidation**: rollup-derived cache keys now embed an opaque version from `stream_metrics.computed_at` (per-stream / per-creator / creator-of-stream / scene-wide) via `api/caching/rollup_version.py`. Recomputation by the collector/tracking process starts a fresh key; superseded entries age out via TTL. Version probes degrade to an `unversioned` sentinel instead of raising.
- **Stale `creator_chatter_stats`**: `recompute_stream_rollup_db` snapshots the stream's previous chatters, refreshes the union, and prunes rows for chatters with no remaining streams for the creator.
- **CodeQL py/log-injection (22 alerts)**: new `sanitize_log_value` escapes CR/LF; applied at every flagged endpoint log site.
- **CodeQL false positives (19 alerts)**: query-filters exclude `py/uninitialized-local-variable` (PEP 695 scoping) and `py/ineffectual-statement` (Protocol `...` stubs); open alerts dismissed.

## Refactors
- `observability/health.py` (521 lines) split into `health_contracts.py` / `health_renderers.py` / `health.py` (checker).
- Env-read consolidation: asgi hardcodes `production`, `LoggingConfig` drops its `ENVIRONMENT` fallback, digest declares `--webhook-url` at the CLI boundary, health probe reads `TWITCH_CLIENT_ID` via `APIConfig`.
- Dead `APIConfig.to_dict()` deleted; `.env.example` documents required JWT/Twitch vars.

## Verification
- Full unit suite green; ruff + mypy clean.
- Live scratch-Postgres run: register 201/duplicate 400, rollup refresh+prune, version selects, MISS→HIT on 5 versioned endpoints.

No migrations.