### PR TITLE
Error-message overhaul: close leak paths, plain-language copy everywhere

### DIFF
--- a/backend/stream_sniper/api/features/auth/auth_endpoints.py
+++ b/backend/stream_sniper/api/features/auth/auth_endpoints.py
@@ -67,11 +67,11 @@ def register_user(user_data: UserCreateExtended, request: Request, response: Res
         user = create_user(user_data.username, user_data.email, user_data.password, role=USER_ROLE)
     except UserAlreadyExistsError:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="User with this username or email already exists"
+            status_code=status.HTTP_400_BAD_REQUEST, detail="That username or email is already taken. Try a different one."
         ) from None
     except UserCreationError:
         logger.exception("Self-service registration failed for username %s", sanitize_log_value(user_data.username))
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create user") from None
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not create the account because of a server problem. Try again in a moment.") from None
 
     logger.info("User registered successfully: %s", sanitize_log_value(user_data.username))
     return convert_user_to_response(user)
@@ -156,7 +156,7 @@ def update_current_user(
     current_user: UserInDB = Depends(get_current_user),
 ) -> UserResponse:
     if not user_update.email:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid fields to update")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nothing to save — change at least one field first.")
 
     success = update_user_db(
         current_user.id,
@@ -164,11 +164,11 @@ def update_current_user(
     )
 
     if not success:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update user")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not save the changes because of a server problem. Try again in a moment.")
 
     updated_user = select_user_by_id_db(current_user.id)
     if not updated_user:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve updated user")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="The changes may not have been saved because of a server problem. Refresh and try again.")
 
     logger.info("User updated successfully: %s", sanitize_log_value(current_user.username))
     return convert_user_to_response(updated_user)
@@ -201,7 +201,7 @@ def change_password(
     success = update_user_password_db(current_user.id, new_password_hash)
 
     if not success:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update password")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not change the password because of a server problem. Try again in a moment.")
 
     logger.info("Account access updated successfully for user id %s", sanitize_log_value(current_user.id))
     return MessageResponse(message="Password changed successfully")

--- a/backend/stream_sniper/api/features/auth/user_admin_endpoints.py
+++ b/backend/stream_sniper/api/features/auth/user_admin_endpoints.py
@@ -55,7 +55,7 @@ def _reject_self_lockout(
 def _load_user_response(user_id: int) -> UserResponse:
     user = select_user_by_id_db(user_id)
     if user is None:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve updated user")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="The changes may not have been saved because of a server problem. Refresh and try again.")
     return convert_user_to_response(user)
 
 
@@ -261,7 +261,7 @@ def update_user_by_id(
     )
 
     if not user_update.email and user_update.role is None and user_update.is_active is None:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid fields to update")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nothing to save — change at least one field first.")
 
     success = update_user_db(
         user_id,
@@ -271,7 +271,7 @@ def update_user_by_id(
     )
 
     if not success:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update user")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not save the changes because of a server problem. Try again in a moment.")
 
     logger.info("User updated by admin %s: user_id=%s", sanitize_log_value(current_user.username), user_id)
     return _load_user_response(user_id)
@@ -354,11 +354,11 @@ def create_user_admin(
         )
     except UserAlreadyExistsError:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="User with this username or email already exists"
+            status_code=status.HTTP_400_BAD_REQUEST, detail="That username or email is already taken. Try a different one."
         ) from None
     except UserCreationError:
         logger.exception("Admin user creation failed for username %s", sanitize_log_value(user_data.username))
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create user") from None
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not create the account because of a server problem. Try again in a moment.") from None
 
     logger.info(
         "User created by admin %s: %s",

--- a/backend/stream_sniper/api/features/tracking/tracking_job_endpoints.py
+++ b/backend/stream_sniper/api/features/tracking/tracking_job_endpoints.py
@@ -104,13 +104,13 @@ async def trigger_processing(
     except TwitchConfigurationError as error:
         logger.exception("Twitch integration is not configured")
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Twitch integration unavailable"
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Twitch lookups aren't available right now because the server's Twitch access isn't configured. Contact the administrator."
         ) from error
     except TwitchUpstreamError as error:
         logger.exception("Failed to list VODs for %s", sanitize_log_value(twitch_username))
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Failed to list VODs from Twitch",
+            detail="Could not fetch recent VODs from Twitch. Try again in a moment.",
         ) from error
 
     outcome = await asyncio.to_thread(enqueue_first_uncollected_vod, streamer_id, videos)
@@ -157,7 +157,7 @@ async def trigger_processing(
         401: {"model": ErrorResponse, "description": "Authentication required"},
         403: {"model": ErrorResponse, "description": "Admin role required"},
         404: {"model": ErrorResponse, "description": "Job not found"},
-        409: {"model": ErrorResponse, "description": "Job is already terminal"},
+        409: {"model": ErrorResponse, "description": "Job already finished"},
         429: {"model": RateLimitErrorResponse, "description": "Rate limit exceeded"},
         500: {"model": ErrorResponse, "description": "Processing-job persistence failed"},
     },

--- a/backend/stream_sniper/api/features/tracking/tracking_models.py
+++ b/backend/stream_sniper/api/features/tracking/tracking_models.py
@@ -46,7 +46,7 @@ class TrackedStreamerUpdate(BaseModel):
     @classmethod
     def reject_null_flags(cls, value: object) -> object:
         if value is None:
-            raise ValueError("Boolean updates cannot be null")
+            raise ValueError("is_active and processing_enabled must be true or false")
         return value
 
 

--- a/backend/stream_sniper/api/features/tracking/tracking_streamer_endpoints.py
+++ b/backend/stream_sniper/api/features/tracking/tracking_streamer_endpoints.py
@@ -133,14 +133,17 @@ async def add_tracked_streamer(
     except TwitchConfigurationError as error:
         logger.exception("Twitch integration is not configured")
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Twitch integration unavailable"
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Twitch lookups aren't available right now because the server's Twitch access isn't configured. Contact the administrator."
         ) from error
     except (TwitchProfileLookupError, TwitchUpstreamError) as error:
         logger.exception("Twitch profile lookup failed for %s", sanitize_log_value(streamer_data.twitch_username))
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Failed to contact Twitch") from error
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Could not reach Twitch. Try again in a moment.") from error
     except TrackedStreamerCreationError as error:
         logger.exception("Tracked streamer creation failed for %s", sanitize_log_value(streamer_data.twitch_username))
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(error)) from error
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not add the streamer because of a server problem. Try again in a moment.",
+        ) from error
 
     logger.info(
         "Tracked streamer created by admin %s: %s",
@@ -197,13 +200,13 @@ async def search_twitch_channels(
     except TwitchConfigurationError as error:
         logger.exception("Twitch integration is not configured")
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Twitch integration unavailable"
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Twitch lookups aren't available right now because the server's Twitch access isn't configured. Contact the administrator."
         ) from error
     except TwitchUpstreamError as error:
         logger.exception("Error searching Twitch channels for '%s'", sanitize_log_value(query))
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Failed to search Twitch channels",
+            detail="Could not search Twitch right now. Try again in a moment.",
         ) from error
 
     result = [
@@ -288,7 +291,7 @@ def update_tracked_streamer(
 
     supplied_fields = streamer_update.model_fields_set
     if not supplied_fields:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid fields to update")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nothing to save — change at least one field first.")
 
     success = update_tracked_streamer_db(
         streamer_id,
@@ -300,12 +303,12 @@ def update_tracked_streamer(
     )
 
     if not success:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update streamer")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not save the streamer changes because of a server problem. Try again in a moment.")
 
     updated_streamer = select_tracked_streamer_by_id_db(streamer_id)
     if not updated_streamer:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve updated streamer"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="The change may not have been saved because of a server problem. Refresh and try again."
         )
 
     logger.info(
@@ -346,7 +349,7 @@ def remove_tracked_streamer(
     success = delete_tracked_streamer_db(streamer_id)
 
     if not success:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to remove streamer")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Could not remove the streamer because of a server problem. Try again in a moment.")
 
     logger.info(
         "Tracked streamer removed by admin %s: streamer_id=%s", sanitize_log_value(current_user.username), streamer_id

--- a/backend/stream_sniper/api/observability/health.py
+++ b/backend/stream_sniper/api/observability/health.py
@@ -107,7 +107,7 @@ class HealthChecker:
             result = ProbeResult(
                 status=probe.failure_status,
                 message=f"{probe.name.replace('_', ' ').title()} check failed",
-                details={"error": str(exc)},
+                details={"error": "Unexpected failure. See server logs for details."},
             )
         duration_ms = round(
             (self._monotonic() - started) * MILLISECONDS_PER_SECOND,

--- a/backend/stream_sniper/api/security/auth.py
+++ b/backend/stream_sniper/api/security/auth.py
@@ -35,7 +35,7 @@ security = HTTPBearer()
 class AuthenticationError(HTTPException):
     """Custom authentication error"""
 
-    def __init__(self, detail: str = "Could not validate credentials"):
+    def __init__(self, detail: str = "Your session is invalid or has expired. Please log in again."):
         super().__init__(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=detail,
@@ -132,7 +132,7 @@ def get_current_user(
     if user is None:
         raise AuthenticationError()
     if not user.is_active:
-        raise AuthenticationError("User account is disabled")
+        raise AuthenticationError("This account has been deactivated. Contact an administrator to restore access.")
     return user
 
 
@@ -140,6 +140,6 @@ def get_current_admin_user(current_user: UserInDB = Depends(get_current_user)) -
     """Get current user and verify they have admin role"""
     if current_user.role != ADMIN_ROLE:
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions. Admin role required."
+            status_code=status.HTTP_403_FORBIDDEN, detail="You need administrator access to do this."
         )
     return current_user

--- a/backend/stream_sniper/application/tracking/job_admin.py
+++ b/backend/stream_sniper/application/tracking/job_admin.py
@@ -48,7 +48,7 @@ def request_processing_job_cancellation(job_id: int) -> None:
     if select_processing_job_by_id_db(job_id) is None:
         raise ProcessingJobNotFoundError(job_id)
     if not request_processing_job_cancellation_db(job_id):
-        raise ProcessingJobConflictError("Job is already terminal")
+        raise ProcessingJobConflictError("This job has already finished, so it can't be cancelled.")
 
 
 def retry_processing_job(job_id: int) -> None:
@@ -56,6 +56,6 @@ def retry_processing_job(job_id: int) -> None:
     if job is None:
         raise ProcessingJobNotFoundError(job_id)
     if job.status != JOB_STATUS_FAILED:
-        raise ProcessingJobConflictError("Only failed jobs can be retried")
+        raise ProcessingJobConflictError("Only failed jobs can be retried.")
     if not retry_failed_processing_job_db(job_id):
-        raise ProcessingJobConflictError("Job state changed before retry")
+        raise ProcessingJobConflictError("The job changed before the retry could start. Refresh and try again.")

--- a/backend/tests/unit/api/test_auth.py
+++ b/backend/tests/unit/api/test_auth.py
@@ -219,7 +219,7 @@ def test_registration_logs_persistence_failure_without_exposing_it() -> None:
         )
 
     assert response.status_code == 500
-    assert response.json() == {"detail": "Failed to create user"}
+    assert response.json() == {"detail": "Could not create the account because of a server problem. Try again in a moment."}
     assert "database detail" not in response.text
     log_exception.assert_called_once_with("Self-service registration failed for username %s", "new_viewer")
 

--- a/backend/tests/unit/api/test_health_snapshot.py
+++ b/backend/tests/unit/api/test_health_snapshot.py
@@ -83,7 +83,7 @@ def test_probe_exception_is_timed_and_classified_by_registry_policy() -> None:
 
     assert component.status is HealthStatus.CRITICAL
     assert component.response_time_ms == 10.0
-    assert component.details == {"error": "offline"}
+    assert component.details == {"error": "Unexpected failure. See server logs for details."}
     assert overall_health_status({"database": component}) is HealthStatus.CRITICAL
 
 

--- a/backend/tests/unit/api/test_tracking_streamer_update.py
+++ b/backend/tests/unit/api/test_tracking_streamer_update.py
@@ -70,7 +70,7 @@ def test_empty_patch_is_rejected() -> None:
         response = _client().put("/admin/tracking/streamers/7", json={})
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "No valid fields to update"
+    assert response.json()["detail"] == "Nothing to save — change at least one field first."
 
 
 @pytest.mark.parametrize("field", ["is_active", "processing_enabled"])

--- a/backend/tests/unit/api/test_user_admin_endpoints.py
+++ b/backend/tests/unit/api/test_user_admin_endpoints.py
@@ -67,7 +67,7 @@ def test_admin_creation_logs_persistence_failure_without_exposing_it() -> None:
         )
 
     assert response.status_code == 500
-    assert response.json() == {"detail": "Failed to create user"}
+    assert response.json() == {"detail": "Could not create the account because of a server problem. Try again in a moment."}
     assert "database detail" not in response.text
     log_exception.assert_called_once_with("Admin user creation failed for username %s", "new_operator")
 

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+export default function Error({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
   return (
     <div className="container mt-5">
       <div className="alert alert-danger" role="alert">
         <h4 className="alert-heading">Something went wrong</h4>
-        <p>{error.message || 'An unexpected error occurred.'}</p>
+        <p>This page hit an unexpected problem. Try again, or reload the page if it keeps happening.</p>
         <button className="btn btn-outline-danger" onClick={() => reset()}>Try again</button>
       </div>
     </div>

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+export default function GlobalError({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
   return (
     <html lang="en">
       <body className="dark">
         <div className="container mt-5">
           <div className="alert alert-danger" role="alert">
             <h4 className="alert-heading">Something went wrong</h4>
-            <p>{error.message || 'An unexpected error occurred.'}</p>
+            <p>The app hit an unexpected problem. Try again, or reload the page if it keeps happening.</p>
             <button className="btn btn-outline-danger" onClick={() => reset()}>Try again</button>
           </div>
         </div>

--- a/frontend/components/creator/TrendsPanel.jsx
+++ b/frontend/components/creator/TrendsPanel.jsx
@@ -134,8 +134,8 @@ const TrendsPanel = ({ creatorId }) => {
                             aria-hidden="true" />
                         <p className="empty-title">Metrics not yet computed</p>
                         <p className="empty-hint">
-                            Run the rollup backfill (<span className="mono">stream-sniper-rollup --all --force</span>)
-                            to populate per-stream trends for this creator.
+                            Trends for this creator haven’t been computed yet.
+                            They’ll appear after the next analytics run.
                         </p>
                     </div>
                 </Card.Body>

--- a/frontend/components/moments/MomentQueue.jsx
+++ b/frontend/components/moments/MomentQueue.jsx
@@ -2,7 +2,7 @@ import MomentCard from './MomentCard'
 import Pagination from '@/components/common/pagination/Pagination'
 
 const EMPTY_HINT = {
-    all: 'No chat spikes have been enriched yet. Run the rollup backfill to populate the queue.',
+    all: 'No highlights detected yet. Moments appear here after streams are processed.',
     pending: 'Nothing awaiting review — every surfaced moment has been triaged.',
     bookmarked: 'No bookmarked moments yet. Bookmark spikes worth clipping to collect them here.',
     rejected: 'No rejected moments.',

--- a/frontend/components/scene/CopypastaResults.jsx
+++ b/frontend/components/scene/CopypastaResults.jsx
@@ -25,9 +25,8 @@ const CopypastaResults = ({
                 <span className="empty-scope" aria-hidden="true" />
                 <p className="empty-title">No copypasta yet</p>
                 <p className="empty-hint">
-                    Nothing has been rolled up for this filter yet. Run{' '}
-                    <span className="mono">stream-sniper-rollup --all --force</span>{' '}
-                    to populate the library.
+                    No copypasta matches this filter yet. Entries appear after
+                    streams are processed.
                 </p>
             </div>
         )

--- a/frontend/hooks/stream/replay/useStreamReplayController.js
+++ b/frontend/hooks/stream/replay/useStreamReplayController.js
@@ -116,8 +116,8 @@ export const useStreamReplayController = streamId => {
                 setJumpToTs({ ts: targetTs, nonce: Date.now() })
             } else {
                 const message = outcome.status === 'exhausted'
-                    ? 'Replay target is farther than the current load budget. Select the timeline point again to continue loading.'
-                    : 'Replay target is unavailable in the recorded chat history.'
+                    ? 'That point is further back than the chat loaded so far. Select it again to keep loading.'
+                    : "That point isn't in the recorded chat history."
                 setJumpFailure(toUiFailure(new Error(message), message))
             }
         } catch (jumpError) {

--- a/frontend/lib/auth/session.js
+++ b/frontend/lib/auth/session.js
@@ -7,6 +7,8 @@ export class SessionStorageError extends Error {
         super(`Unable to ${operation} stored authentication session`, { cause })
         this.name = 'SessionStorageError'
         this.operation = operation
+        // Message is written for end users; normalizeApiError may render it.
+        this.userFacing = true
     }
 }
 

--- a/frontend/test/errorUtils.test.ts
+++ b/frontend/test/errorUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeApiError } from '@/utils/errorUtils'
+import { normalizeApiError, uiError } from '@/utils/errorUtils'
 
 const responseError = (status: number, data: unknown) => ({
   message: `Request failed with status ${status}`,
@@ -25,20 +25,71 @@ describe('normalizeApiError', () => {
     expect(normalized.message).toBe('Field is required; Value is invalid')
   })
 
+  it('strips the FastAPI "Value error, " prefix from validator messages', () => {
+    const normalized = normalizeApiError(responseError(422, {
+      detail: [{ msg: 'Value error, Invalid email format' }],
+    }))
+
+    expect(normalized.message).toBe('Invalid email format')
+  })
+
   it('supports legacy message and error payloads through the same contract', () => {
     expect(normalizeApiError(responseError(400, { message: 'Bad message' })).message).toBe('Bad message')
     expect(normalizeApiError(responseError(400, { error: 'Bad error' })).message).toBe('Bad error')
   })
 
-  it('uses native messages and safe fallbacks', () => {
-    expect(normalizeApiError(new Error('Native failure'), 'Fallback').message).toBe('Native failure')
+  it('sanitizes native error messages down to the fallback', () => {
+    expect(normalizeApiError(new Error('stats.system_status.failed_jobs must be a finite number'), 'Fallback').message).toBe('Fallback')
     expect(normalizeApiError({}, 'Fallback').message).toBe('Fallback')
+  })
+
+  it('surfaces messages from errors explicitly marked user-facing', () => {
+    expect(normalizeApiError(uiError('This link is invalid.'), 'Fallback').message).toBe('This link is invalid.')
   })
 
   it('uses the categorized HTTP fallback before a generic Axios message', () => {
     expect(normalizeApiError(responseError(403, {})).message).toBe(
-      'You are not authorized to access this resource.',
+      "You don't have permission to do this.",
     )
+  })
+
+  it('replaces raw rate-limit payloads with friendly copy', () => {
+    const normalized = normalizeApiError(responseError(429, { error: 'Rate limit exceeded: 5 per 1 minute' }))
+
+    expect(normalized.message).toBe("You're doing that too fast. Wait a moment and try again.")
+    expect(normalized.retryAfterSeconds).toBeNull()
+  })
+
+  it('surfaces the Retry-After duration on rate-limit responses', () => {
+    const normalized = normalizeApiError({
+      message: 'Request failed with status 429',
+      response: {
+        status: 429,
+        data: { error: 'Rate limit exceeded: 5 per 1 minute' },
+        headers: { 'retry-after': '30' },
+      },
+    })
+
+    expect(normalized.message).toBe("You're doing that too fast. Try again in 30 seconds.")
+    expect(normalized.retryAfterSeconds).toBe(30)
+  })
+
+  it('ignores non-numeric Retry-After values', () => {
+    const normalized = normalizeApiError({
+      message: 'Request failed with status 429',
+      response: {
+        status: 429,
+        data: {},
+        headers: { 'retry-after': 'Fri, 18 Jul 2026 00:00:00 GMT' },
+      },
+    })
+
+    expect(normalized.message).toBe("You're doing that too fast. Wait a moment and try again.")
+    expect(normalized.retryAfterSeconds).toBeNull()
+  })
+
+  it('does not attach retryAfterSeconds outside 429 responses', () => {
+    expect(normalizeApiError(responseError(500, {})).retryAfterSeconds).toBeNull()
   })
 
   it.each([408, 425, 429, 500, 503])('marks transient HTTP %s failures retryable', (status) => {

--- a/frontend/test/streamInsights.test.tsx
+++ b/frontend/test/streamInsights.test.tsx
@@ -164,7 +164,7 @@ describe('stream actions', () => {
   })
 
   it('exposes authenticated exports and surfaces normalized download failures', async () => {
-    mocks.downloadStreamInsightCsv.mockRejectedValue(new Error('network down'))
+    mocks.downloadStreamInsightCsv.mockRejectedValue({ response: { status: 502, data: { detail: 'network down' } } })
     render(<StreamDownloadMenu streamId={42} title="Launch" />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Export data for Launch' }))

--- a/frontend/test/streamerTrackingPagination.test.tsx
+++ b/frontend/test/streamerTrackingPagination.test.tsx
@@ -99,7 +99,7 @@ describe('StreamerTracking pagination', () => {
   })
 
   it('normalizes mutation failures at the tracking boundary', async () => {
-    updateStreamer.mutateAsync.mockRejectedValue(new Error('update offline'))
+    updateStreamer.mutateAsync.mockRejectedValue({ response: { status: 500, data: { detail: 'update offline' } } })
     hooks.useTrackedStreamers.mockReturnValue({
       data: { items: [streamer], total: 1, pageIndex: 0, pageSize: 20, pageCount: 1 },
       error: null,

--- a/frontend/test/userManagementActions.test.tsx
+++ b/frontend/test/userManagementActions.test.tsx
@@ -99,7 +99,7 @@ describe('UserManagement action lifecycle', () => {
   })
 
   it('keeps a failed delete dialog open', async () => {
-    deleteUser.mutateAsync.mockRejectedValue(new Error('delete offline'))
+    deleteUser.mutateAsync.mockRejectedValue({ response: { status: 500, data: { detail: 'delete offline' } } })
     render(<UserManagement />)
 
     fireEvent.click(screen.getByRole('button', { name: 'delete user' }))

--- a/frontend/utils/errorUtils.js
+++ b/frontend/utils/errorUtils.js
@@ -1,11 +1,13 @@
 // @ts-check
 
 const ERROR_MESSAGES = {
-    NETWORK_ERROR: 'Network error occurred. Please check your connection.',
-    API_ERROR: 'Server error occurred. Please try again later.',
-    NOT_FOUND: 'The requested resource was not found.',
-    UNAUTHORIZED: 'You are not authorized to access this resource.',
+    NETWORK_ERROR: "Can't reach the server. Check your connection and try again.",
+    API_ERROR: 'The server hit a problem. Try again in a moment.',
+    NOT_FOUND: "That page or item doesn't exist. It may have been removed.",
+    UNAUTHENTICATED: 'Your session has expired or is invalid. Log in again to continue.',
+    FORBIDDEN: "You don't have permission to do this.",
     VALIDATION_ERROR: 'Please check your input and try again.',
+    RATE_LIMITED: "You're doing that too fast. Wait a moment and try again.",
     UNKNOWN_ERROR: 'An unexpected error occurred.',
 }
 
@@ -21,7 +23,7 @@ export const ERROR_TYPES = Object.freeze({
 })
 
 /** @typedef {'network'|'validation'|'authentication'|'authorization'|'not_found'|'server'|'client'|'unknown'} ErrorType */
-/** @typedef {{message:string, type:ErrorType, status:number|null, retryable:boolean, detail:unknown}} NormalizedApiError */
+/** @typedef {{message:string, type:ErrorType, status:number|null, retryable:boolean, retryAfterSeconds:number|null, detail:unknown}} NormalizedApiError */
 /** @typedef {{error:unknown, normalized:NormalizedApiError}} UiFailure */
 
 /** @param {unknown} value @returns {Record<string, unknown>|null} */
@@ -49,6 +51,8 @@ const detailMessage = detail => {
     const messages = detail
         .map(item => nonEmptyString(asRecord(item)?.msg) || nonEmptyString(item))
         .filter(Boolean)
+        // FastAPI prefixes custom validator messages with "Value error, ".
+        .map(message => /** @type {string} */ (message).replace(/^Value error, /, ''))
     return messages.length ? messages.join('; ') : null
 }
 
@@ -73,6 +77,18 @@ const isNetworkFailure = (status, code, message) => (
     )
 )
 
+/**
+ * Read a Retry-After header as whole seconds (numeric form only — the
+ * HTTP-date form is ignored). Axios lowercases response header names.
+ * @param {unknown} headers
+ * @returns {number|null}
+ */
+const retryAfterSecondsFrom = headers => {
+    const raw = asRecord(headers)?.['retry-after']
+    const seconds = typeof raw === 'number' ? raw : Number.parseInt(String(raw ?? ''), 10)
+    return Number.isFinite(seconds) && seconds >= 0 ? seconds : null
+}
+
 /** @param {ErrorType} type @param {number|null} status */
 const isRetryable = (type, status) => (
     type === ERROR_TYPES.NETWORK
@@ -88,13 +104,23 @@ const isRetryable = (type, status) => (
 const fallbackMessage = (type, fallback) => ({
     [ERROR_TYPES.NETWORK]: ERROR_MESSAGES.NETWORK_ERROR,
     [ERROR_TYPES.VALIDATION]: ERROR_MESSAGES.VALIDATION_ERROR,
-    [ERROR_TYPES.AUTHENTICATION]: ERROR_MESSAGES.UNAUTHORIZED,
-    [ERROR_TYPES.AUTHORIZATION]: ERROR_MESSAGES.UNAUTHORIZED,
+    [ERROR_TYPES.AUTHENTICATION]: ERROR_MESSAGES.UNAUTHENTICATED,
+    [ERROR_TYPES.AUTHORIZATION]: ERROR_MESSAGES.FORBIDDEN,
     [ERROR_TYPES.NOT_FOUND]: ERROR_MESSAGES.NOT_FOUND,
     [ERROR_TYPES.SERVER]: ERROR_MESSAGES.API_ERROR,
     [ERROR_TYPES.CLIENT]: fallback,
     [ERROR_TYPES.UNKNOWN]: fallback,
 }[type] || fallback)
+
+/**
+ * Create an Error whose message is written for end users and safe to render.
+ * `normalizeApiError` only surfaces `.message` from errors marked this way —
+ * unmarked native errors (TypeErrors, contract guards, library failures) fall
+ * back to sanitized copy instead.
+ * @param {string} message
+ * @returns {Error & {userFacing: true}}
+ */
+export const uiError = message => Object.assign(new Error(message), { userFacing: /** @type {const} */ (true) })
 
 /**
  * Normalize Axios, FastAPI, and native failures once at the UI boundary.
@@ -117,12 +143,21 @@ export const normalizeApiError = (error, fallback = ERROR_MESSAGES.UNKNOWN_ERROR
     const categorizedFallback = status !== null || network
         ? fallbackMessage(type, fallback)
         : null
-    const message = detailMessage(detail)
+    const retryAfterSeconds = status === 429 ? retryAfterSecondsFrom(response?.headers) : null
+    const rateLimitedMessage = status !== 429
+        ? null
+        : retryAfterSeconds
+            ? `You're doing that too fast. Try again in ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'}.`
+            : ERROR_MESSAGES.RATE_LIMITED
+    // Only errors explicitly marked user-facing may surface their raw message;
+    // everything else (TypeErrors, contract guards, library errors) is sanitized.
+    const userFacingMessage = source?.userFacing === true ? nativeMessage : null
+    const message = rateLimitedMessage
+        || userFacingMessage
+        || detailMessage(detail)
         || nonEmptyString(payload?.message)
         || nonEmptyString(payload?.error)
         || categorizedFallback
-        || nativeMessage
-        || nonEmptyString(error)
         || fallbackMessage(type, fallback)
 
     return {
@@ -130,6 +165,7 @@ export const normalizeApiError = (error, fallback = ERROR_MESSAGES.UNKNOWN_ERROR
         type,
         status,
         retryable: isRetryable(type, status),
+        retryAfterSeconds,
         detail,
     }
 }

--- a/frontend/views/community/Community.jsx
+++ b/frontend/views/community/Community.jsx
@@ -60,12 +60,7 @@ const Community = () => {
                 loadingText="Loading community overlap..."
                 isEmpty={value => !((value?.creators?.length > 0) && (value?.pairs?.length > 0))}
                 emptyTitle="No overlap computed yet"
-                emptyHint={(
-                    <>
-                        Run the rollup backfill (<span className="mono">stream-sniper-rollup --all --force</span>)
-                        to populate cross-creator audience overlap.
-                    </>
-                )}
+                emptyHint="Audience overlap hasn’t been computed yet. It’ll appear after the next analytics run."
             >
                 {value => (
                     <CommunityOverlapPanels

--- a/frontend/views/creator/CreatorDossier.jsx
+++ b/frontend/views/creator/CreatorDossier.jsx
@@ -7,6 +7,7 @@ import { useSceneCopypastas } from '@/hooks/scene/useSceneCopypastaQueries'
 import CreatorDossierOverview from '@/components/creator/CreatorDossierOverview'
 import CreatorSignatureCards from '@/components/creator/CreatorSignatureCards'
 import ErrorAlert from '@/components/common/error/ErrorAlert'
+import { uiError } from '@/utils/errorUtils'
 import QueryState from '@/components/common/QueryState'
 import RegularsPanel from '@/components/creator/RegularsPanel'
 import TrendsPanel from '@/components/creator/TrendsPanel'
@@ -18,7 +19,7 @@ const CreatorDossier = ({ creatorId }) => {
     const copypastasQuery = useSceneCopypastas({ creatorId, sort: 'usage', pageSize: 5 })
 
     if (!Number.isInteger(creatorId) || creatorId <= 0) {
-        return <ErrorAlert title="Invalid creator" error={new Error('Creator ID must be a positive integer.')} />
+        return <ErrorAlert title="Invalid creator" error={uiError('This creator link is invalid. Go back and pick a creator from the list.')} />
     }
 
     return (

--- a/frontend/views/scene/CopypastaPropagation.jsx
+++ b/frontend/views/scene/CopypastaPropagation.jsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { Card } from 'react-bootstrap'
 import { useCopypastaPropagation } from '@/hooks/scene/useSceneCopypastaQueries'
 import ErrorAlert from '@/components/common/error/ErrorAlert'
+import { uiError } from '@/utils/errorUtils'
 import QueryState from '@/components/common/QueryState'
 
 const stamp = value => value ? value.replace('T', ' ').slice(0, 16) : '--'
@@ -11,7 +12,7 @@ const stamp = value => value ? value.replace('T', ' ').slice(0, 16) : '--'
 const CopypastaPropagation = ({ messageTextId }) => {
     const query = useCopypastaPropagation(messageTextId)
     if (!Number.isInteger(messageTextId) || messageTextId <= 0) {
-        return <ErrorAlert title="Invalid copypasta" error={new Error('Copypasta ID must be positive.')} />
+        return <ErrorAlert title="Invalid copypasta" error={uiError('This copypasta link is invalid. Go back and pick one from the library.')} />
     }
 
     return (

--- a/frontend/views/scene/ScenePulse.jsx
+++ b/frontend/views/scene/ScenePulse.jsx
@@ -96,7 +96,7 @@ const ScenePulse = () => {
                             No events yet
                         </p>
                         <p className="empty-hint">
-                            Re-run stream rollups to populate deterministic scene events.
+                            Scene events appear here after streams are processed.
                         </p>
                     </div>
                 )}

--- a/frontend/views/stream/Stream.jsx
+++ b/frontend/views/stream/Stream.jsx
@@ -7,6 +7,7 @@ import { useStreamTimeline } from '@/hooks/stream/timeline/useStreamTimelineQuer
 import { useStreamReplayController } from '@/hooks/stream/replay/useStreamReplayController'
 import QueryState from '@/components/common/QueryState'
 import ErrorAlert from '@/components/common/error/ErrorAlert'
+import { uiError } from '@/utils/errorUtils'
 import StreamInfoCard from '@/components/stream/StreamInfoCard'
 import StreamDownloadMenu from '@/components/stream/StreamDownloadMenu'
 import StreamTimeline from '@/components/stream/timeline/StreamTimeline'
@@ -55,7 +56,7 @@ const Stream = ({ streamId }) => {
             loadingCard
             emptyState={(
                 <ErrorAlert
-                    error={new Error('The stream response did not contain stream data.')}
+                    error={uiError("This stream couldn't be displayed. Refresh the page to try again.")}
                     title="Stream unavailable"
                 />
             )}


### PR DESCRIPTION
## Summary
Audits and rewrites every user-visible error message across the API and frontend (65-row audit; full CSV kept locally as `error-message-audit.csv`).

**Leak paths closed (highest impact)**
- `app/error.tsx` / `global-error.tsx` no longer render raw `error.message`
- `normalizeApiError` no longer surfaces native `Error` messages (contract-guard `TypeError`s naming internal field paths across ~347 sites now fall back to contextual copy); intentional client-side copy opts in via new `uiError()` marker
- `/health/detailed` probe failures no longer embed `str(exc)` in the response
- Tracked-streamer creation 500 no longer returns internal `str(error)` ("Creator insert returned no identifier")

**Copy rewrites**
- Auth: "Could not validate credentials" → "Your session is invalid or has expired. Please log in again." (+ disabled-account, admin-required, duplicate-register, no-fields, and DB-failure messages with recovery steps)
- Tracking: job-conflict literals ("Job is already terminal") → user-facing sentences; Twitch 502/503 copy with retry hints
- Frontend fallbacks: 401/403 split, plain-language network/server/404 copy, 429 → "You're doing that too fast. Try again in N seconds." (parses `Retry-After`, per Codex review)
- Ops CLI commands (`stream-sniper-rollup --all --force`) removed from 5 user-facing empty-state hints
- FastAPI "Value error, " prefix stripped from rendered validator messages

## Test evidence
- Backend: 526 unit tests pass, ruff clean
- Frontend: 249 vitest pass, tsc + checkJS boundaries + eslint clean, prod build passes, Playwright e2e 3/3
- Live verification: error states exercised in a real browser against a scratch-DB API (bad login, duplicate register, 404, induced render error with zero message leakage, backend-down fallback, empty states) plus wire-level curl checks (deactivated account, job conflicts, Twitch-unconfigured 503, 422 shapes)

No DB migrations.