### PR TITLE
Fix all five Codex review findings on PR #49

### DIFF
--- a/backend/stream_sniper/api/caching/cache.py
+++ b/backend/stream_sniper/api/caching/cache.py
@@ -22,6 +22,12 @@ logger = logging.getLogger(__name__)
 # so short-TTL/high-churn keys (e.g. search autocomplete) can't accumulate.
 _PRUNE_THRESHOLD = 1000
 
+# Hard ceiling on LIVE entries. Public cache-miss surfaces (scene search accepts
+# arbitrary query strings) would otherwise let clients grow the store without
+# bound until TTLs expire — real memory pressure on the Pi. When an insert would
+# exceed this, the soonest-to-expire entries are evicted first.
+_MAX_LIVE_ENTRIES = 2000
+
 
 class CacheStatsPayload(TypedDict):
     enabled: bool
@@ -79,8 +85,21 @@ class InProcessCache:
         with self._lock:
             if len(self._store) >= _PRUNE_THRESHOLD:
                 self._prune_expired(now)
+            if len(self._store) >= _MAX_LIVE_ENTRIES:
+                self._evict_soonest_expiring(len(self._store) - _MAX_LIVE_ENTRIES + 1)
             self._store[key] = (now + ttl, serialized)
         return True
+
+    def _evict_soonest_expiring(self, count: int) -> None:
+        """Evict the ``count`` live entries closest to expiry. Caller holds the lock.
+
+        Soonest-to-expire is the cheapest reasonable victim policy here: it favors
+        keeping long-TTL analytics entries over short-TTL churn (search pages),
+        which is exactly the split we want under a cache-filling client.
+        """
+        victims = sorted(self._store.items(), key=lambda item: item[1][0])[:count]
+        for key, _ in victims:
+            self._store.pop(key, None)
 
     def delete(self, key: str) -> bool:
         with self._lock:

--- a/backend/stream_sniper/application/chatters/passport_query.py
+++ b/backend/stream_sniper/application/chatters/passport_query.py
@@ -8,6 +8,7 @@ stream_chatter_stats rollup (debut, most-active-stream milestone). Returns
 
 from stream_sniper.database.gateways.analytics.stream_chatter_stats_table_gateway import (
     select_chatter_debut_db,
+    select_chatter_message_time_bounds_db,
     select_chatter_most_active_stream_db,
 )
 from stream_sniper.database.gateways.chat.chatter_table_gateway import select_chatter_profile_db
@@ -34,14 +35,16 @@ def get_chatter_passport(chatter_id: int) -> ChatterPassport | None:
     loyalty_rows = select_chatter_loyalty_db(chatter_id)
 
     total_messages = sum(row.message_count for row in loyalty_rows)
-    first_seens = [row.first_seen for row in loyalty_rows if row.first_seen is not None]
-    last_seens = [row.last_seen for row in loyalty_rows if row.last_seen is not None]
+    # Lifetime bounds come from actual MESSAGE times (stream_chatter_stats), not the
+    # creator_chatter_stats first/last_seen_at columns — those record attended-stream
+    # START times and would contradict the debut card for late-arriving chatters.
+    time_bounds = select_chatter_message_time_bounds_db(chatter_id)
     totals = PassportTotals(
         messages=total_messages,
         streams_attended=sum(row.streams_attended for row in loyalty_rows),
         creators_visited=len(loyalty_rows),
-        first_seen=min(first_seens) if first_seens else None,
-        last_seen=max(last_seens) if last_seens else None,
+        first_seen=time_bounds.first_message_time,
+        last_seen=time_bounds.last_message_time,
     )
 
     loyalty = [PassportLoyalty.from_row(row, total_messages=total_messages) for row in loyalty_rows]

--- a/backend/stream_sniper/database/gateways/analytics/records.py
+++ b/backend/stream_sniper/database/gateways/analytics/records.py
@@ -127,3 +127,13 @@ class ChatterActiveStreamRow(NamedTuple):
     title: str
     creator_display_name: str
     message_count: int
+
+
+class ChatterTimeBoundsRow(NamedTuple):
+    """Lifetime first/last MESSAGE times for a chatter, from the stream_chatter_stats rollup.
+
+    Message times, not stream-start times — a chatter whose first message landed three
+    hours into a stream is first seen at that message, not at the stream's start."""
+
+    first_message_time: str | None
+    last_message_time: str | None

--- a/backend/stream_sniper/database/gateways/analytics/stream_chatter_stats_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/analytics/stream_chatter_stats_table_gateway.py
@@ -5,7 +5,7 @@ from psycopg2.extensions import cursor as Cursor
 
 from ...core.decorators import with_cursor, with_cursor_connection
 from ...core.wire_format import to_char_wire
-from .records import ChatterActiveStreamRow, ChatterDebutRow
+from .records import ChatterActiveStreamRow, ChatterDebutRow, ChatterTimeBoundsRow
 
 
 @with_cursor
@@ -132,6 +132,35 @@ def select_chatter_most_active_stream_db(
     )
     row = cursor.fetchone()
     return ChatterActiveStreamRow(*row) if row is not None else None
+
+
+@with_cursor
+def select_chatter_message_time_bounds_db(
+    cursor: Cursor,
+    chatter_id: int,
+) -> ChatterTimeBoundsRow:
+    """Lifetime first/last MESSAGE times for a chatter, from the rollup only.
+
+    Aggregates first_message_time/last_message_time across the chatter's
+    stream_chatter_stats rows (indexed by stream_chatter_stats_chatter_idx) —
+    actual message times, unlike creator_chatter_stats.first_seen_at/last_seen_at
+    which record attended-stream START times. Fields are None when the chatter has
+    no recorded message times.
+    """
+    cursor.execute(
+        f"""
+        SELECT
+            {to_char_wire("min(scs.first_message_time)")},
+            {to_char_wire("max(scs.last_message_time)")}
+        FROM stream_chatter_stats scs
+        WHERE scs.chatter_id = %s
+        """,
+        (chatter_id,),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return ChatterTimeBoundsRow(first_message_time=None, last_message_time=None)
+    return ChatterTimeBoundsRow(first_message_time=row[0], last_message_time=row[1])
 
 
 def _replace_time_buckets(cursor: Cursor, params: dict[str, int | list[int]]) -> None:

--- a/backend/stream_sniper/database/gateways/chat/message_search_gateway.py
+++ b/backend/stream_sniper/database/gateways/chat/message_search_gateway.py
@@ -5,13 +5,16 @@ Match semantics are identical everywhere and mirror revision 0017's index:
     stream_sniper.f_unaccent(lower(mt.text)) LIKE
         '%' || stream_sniper.f_unaccent(lower(%s)) || '%'
 
-Every query runs a two-step plan to stay index-friendly on a large message table:
+The paginated page query runs a two-step plan to stay index-friendly on a large
+message table:
 
   1. Resolve matching text ids from message_text via the GIN trigram index, capped
-     at ``_MATCH_TEXT_CAP`` ids. The dedup table is ~134k rows, so the cap only bites
-     for extremely common substrings.
-  2. Join those ids into message (backed by message_text_id_time_idx) for the actual
-     hits / counts / per-day buckets.
+     at ``_MATCH_TEXT_CAP`` ids WITHIN the requested creator/time scope. The dedup
+     table is ~134k rows, so the cap only bites for extremely common substrings.
+  2. Join those ids into message (backed by message_text_id_time_idx) for the hits.
+
+The origin (``select_first_messages_db``) and frequency queries run UNCAPPED
+against the full LIKE match — single bounded scans whose results must be exact.
 
 User input is treated as a literal substring: LIKE wildcards (``%``, ``_``) and the
 escape char (``\\``) are neutralized with an explicit ``ESCAPE '\\'`` clause.
@@ -97,26 +100,46 @@ def _matching_text_ids(
     cursor: Cursor,
     query: str,
     *,
-    newest_first: bool = True,
+    creator_id: int | None = None,
+    days: int | None = None,
     cap: int = _MATCH_TEXT_CAP,
 ) -> list[int]:
     """Step 1: deduplicated-text ids whose text matches, capped, via the trgm index.
 
-    Ordered by mt.id so the cap is deterministic: ``newest_first=True`` keeps the most
-    recently first-seen texts (search pages advertise newest-first), ``False`` keeps
-    the earliest first-seen texts (origin tracing needs the oldest candidates).
+    The cap is applied AFTER any creator/time scoping (via an indexed EXISTS probe
+    into message), so a creator-scoped search for an ultra-common term can never
+    lose that creator's matches to the global cap. Ordered ``mt.id DESC`` so the
+    capped set is deterministic and biased toward recently first-seen texts,
+    matching the newest-first contract of the paginated search.
 
     Runs on the caller's cursor (NOT independently decorated) so the two-step plan
     holds a single pooled connection per request instead of nesting a second checkout.
     """
-    direction = "DESC" if newest_first else "ASC"
+    conditions = [_LIKE_MATCH]
+    params: list[object] = [_escape_like(query)]
+    scope: list[str] = []
+    scope_params: list[object] = []
+    if creator_id is not None:
+        scope.append("s.creator_id = %s")
+        scope_params.append(creator_id)
+    if days is not None:
+        scope.append("m.time >= (now() AT TIME ZONE 'UTC') - (%s * interval '1 day')")
+        scope_params.append(days)
+    if scope:
+        conditions.append(
+            "EXISTS (SELECT 1 FROM message m JOIN stream s ON s.id = m.stream_id\n"
+            f"        WHERE m.message_text_id = mt.id AND {' AND '.join(scope)})"
+        )
+        params.extend(scope_params)
+
+    params.append(cap)
     cursor.execute(
         "SELECT mt.id\n"
         "FROM message_text mt\n"
-        f"WHERE {_LIKE_MATCH}\n"
-        f"ORDER BY mt.id {direction}\n"
+        f"WHERE {' AND '.join(conditions)}\n"
+        "ORDER BY mt.id DESC\n"
         "LIMIT %s",
-        (_escape_like(query), cap),
+        tuple(params),
     )
     return [row[0] for row in cursor.fetchall()]
 
@@ -134,9 +157,11 @@ def search_messages_db(
 
     Fetches ``limit + 1`` rows; the caller trims to ``limit`` and reads has_more off
     the overflow row. When a term matches more than ``_MATCH_TEXT_CAP`` distinct
-    texts, results cover the most recently first-seen texts (deterministic cap).
+    texts WITHIN the requested scope, results cover the most recently first-seen
+    texts (deterministic cap; the creator/days filters are pushed into the cap
+    query so scoped searches never lose matches to globally-common texts).
     """
-    text_ids = _matching_text_ids(cursor, query, newest_first=True)
+    text_ids = _matching_text_ids(cursor, query, creator_id=creator_id, days=days)
     if not text_ids:
         return [], False
 
@@ -172,35 +197,35 @@ def select_first_messages_db(
 ) -> FirstMatchResult:
     """Earliest overall hit, earliest per-creator debuts (<=8), and total match count.
 
-    The candidate set keeps the EARLIEST first-seen matching texts (``mt.id ASC``), so
-    ``first`` is exact even past the cap: if 5000 matching texts predate a candidate's
-    text, each of those texts was first used in an earlier matching message, so the true
-    origin necessarily lies within the capped set. Per-creator debuts for creators whose
-    earliest match uses a text outside the cap are an approximation. ``total_matches``
-    is an exact uncapped count (single aggregate, no sort).
+    All three run UNCAPPED against the full LIKE match (the planner does its own
+    two-step: GIN bitmap scan on message_text, then the message_text_id btree into
+    message), so ``first``, the per-creator debuts, and ``total_matches`` are exact —
+    no dependence on the text-id cap or on message_text.id tracking chronology
+    (backfilled VODs can create old messages with high text ids). Cost is one
+    bounded scan of the matching messages per query, same class as the count, and
+    the endpoint result is TTL-cached.
     """
-    text_ids = _matching_text_ids(cursor, query, newest_first=False)
-    if not text_ids:
-        return FirstMatchResult(first=None, by_creator=[], total_matches=0)
-
-    scope = ["m.message_text_id = ANY(%s)"]
-    scope_params: list[object] = [text_ids]
+    conditions = [_LIKE_MATCH]
+    params: list[object] = [_escape_like(query)]
     if creator_id is not None:
-        scope.append("s.creator_id = %s")
-        scope_params.append(creator_id)
-    where = " AND ".join(scope)
+        conditions.append("s.creator_id = %s")
+        params.append(creator_id)
+    where = " AND ".join(conditions)
 
-    # Earliest matching message overall.
+    # Earliest matching message overall (top-1 over the matched set — no sort spill).
     cursor.execute(
         f"SELECT {_HIT_COLUMNS}\n"
         f"{_HIT_JOINS}\n"
         f"WHERE {where}\n"
         "ORDER BY m.time ASC, m.id ASC\n"
         "LIMIT 1",
-        tuple(scope_params),
+        tuple(params),
     )
     first_row = cursor.fetchone()
     first = SearchHitRow(*first_row) if first_row is not None else None
+
+    if first is None:
+        return FirstMatchResult(first=None, by_creator=[], total_matches=0)
 
     # Earliest matching message per creator, then the 8 oldest of those debuts.
     cursor.execute(
@@ -213,24 +238,18 @@ def select_first_messages_db(
         # Column 2 is the ISO time string from _HIT_COLUMNS; order debuts oldest-first.
         "ORDER BY 2 ASC\n"
         "LIMIT %s",
-        tuple(scope_params) + (_BY_CREATOR_LIMIT,),
+        tuple(params) + (_BY_CREATOR_LIMIT,),
     )
     by_creator = [SearchHitRow(*row) for row in cursor.fetchall()]
 
-    # Total matching messages — uncapped: joins the full LIKE match instead of the
-    # capped text-id set so the headline count is exact for common terms too.
-    count_conditions = [_LIKE_MATCH]
-    count_params: list[object] = [_escape_like(query)]
-    if creator_id is not None:
-        count_conditions.append("s.creator_id = %s")
-        count_params.append(creator_id)
+    # Total matching messages, exact.
     cursor.execute(
         "SELECT count(*)\n"
         "FROM message m\n"
         "JOIN stream s ON s.id = m.stream_id\n"
         "JOIN message_text mt ON mt.id = m.message_text_id\n"
-        f"WHERE {' AND '.join(count_conditions)}",
-        tuple(count_params),
+        f"WHERE {where}",
+        tuple(params),
     )
     count_row = cursor.fetchone()
     total_matches = int(count_row[0]) if count_row is not None else 0
@@ -251,16 +270,16 @@ def select_term_frequency_db(
     every bucket — including the oldest — covers a FULL day, matching the API's
     zero-filled date range exactly (a rolling ``now() - days`` bound would truncate
     the oldest bucket mid-day).
-    """
-    text_ids = _matching_text_ids(cursor, query, newest_first=True)
-    if not text_ids:
-        return []
 
+    Runs UNCAPPED against the full LIKE match (like ``select_first_messages_db``)
+    so counts are exact for common terms too — a single bounded aggregate, cached
+    at the endpoint.
+    """
     conditions = [
-        "m.message_text_id = ANY(%s)",
+        _LIKE_MATCH,
         "m.time >= date_trunc('day', now() AT TIME ZONE 'UTC') - ((%s - 1) * interval '1 day')",
     ]
-    params: list[object] = [text_ids, days]
+    params: list[object] = [_escape_like(query), days]
     if creator_id is not None:
         conditions.append("s.creator_id = %s")
         params.append(creator_id)
@@ -269,6 +288,7 @@ def select_term_frequency_db(
         "SELECT TO_CHAR(date_trunc('day', m.time), 'YYYY-MM-DD') AS day, count(*)\n"
         "FROM message m\n"
         "JOIN stream s ON s.id = m.stream_id\n"
+        "JOIN message_text mt ON mt.id = m.message_text_id\n"
         f"WHERE {' AND '.join(conditions)}\n"
         "GROUP BY day\n"
         "ORDER BY day ASC",

--- a/backend/stream_sniper/utils/discord.py
+++ b/backend/stream_sniper/utils/discord.py
@@ -4,6 +4,15 @@ import requests
 
 
 def deliver_discord(markdown: str, webhook_url: str) -> None:
-    """POST a markdown payload to a Discord webhook, truncated to Discord's limit."""
-    response = requests.post(webhook_url, json={"content": markdown[:2000]}, timeout=15)
+    """POST a markdown payload to a Discord webhook, truncated to Discord's limit.
+
+    ``allowed_mentions: {"parse": []}`` is mandatory: the content embeds untrusted
+    text (stream titles, scene-event summaries), and without it a crafted
+    ``<@user-id>`` / ``@everyone`` in a Twitch title would actually ping people.
+    """
+    response = requests.post(
+        webhook_url,
+        json={"content": markdown[:2000], "allowed_mentions": {"parse": []}},
+        timeout=15,
+    )
     response.raise_for_status()

--- a/backend/tests/unit/api/test_cache.py
+++ b/backend/tests/unit/api/test_cache.py
@@ -153,3 +153,24 @@ def test_cache_operation_facade_rejects_unknown_operations():
             record_cache_operation("unknown", "streams")  # type: ignore[arg-type]
     finally:
         exit_metrics_scope(token)
+
+
+def test_live_entry_ceiling_evicts_soonest_expiring(monkeypatch):
+    """The store never exceeds _MAX_LIVE_ENTRIES; victims are soonest-to-expire."""
+    c = make_cache()
+    monkeypatch.setattr(cache_module, "_PRUNE_THRESHOLD", 5)
+    monkeypatch.setattr(cache_module, "_MAX_LIVE_ENTRIES", 10)
+    t = [1000.0]
+    monkeypatch.setattr(cache_module.time, "time", lambda: t[0])
+
+    # Fill to the ceiling with ascending TTLs (k0 expires first, k9 last).
+    for i in range(10):
+        c.set(f"k{i}", i, ttl=100 + i)
+    assert len(c._store) == 10
+
+    # One more insert evicts exactly the soonest-expiring live entry (k0).
+    c.set("overflow", "v", ttl=500)
+    assert len(c._store) == 10
+    assert c.get("k0") is None
+    assert c.get("k1") == 1
+    assert c.get("overflow") == "v"

--- a/backend/tests/unit/application/test_chatter_passport_query.py
+++ b/backend/tests/unit/application/test_chatter_passport_query.py
@@ -5,16 +5,19 @@ from stream_sniper.application.chatters.passport_query import get_chatter_passpo
 from stream_sniper.database.gateways.analytics.records import (
     ChatterActiveStreamRow,
     ChatterDebutRow,
+    ChatterTimeBoundsRow,
 )
 from stream_sniper.database.gateways.chat.records import ChatterProfileRow
 from stream_sniper.database.gateways.creators.records import ChatterLoyaltyRow
 
 
-def _patch(monkeypatch, *, profile, loyalty, debut, active) -> None:
+def _patch(monkeypatch, *, profile, loyalty, debut, active, time_bounds=None) -> None:
+    bounds = time_bounds if time_bounds is not None else ChatterTimeBoundsRow(None, None)
     monkeypatch.setattr(passport_query, "select_chatter_profile_db", lambda _cid: profile)
     monkeypatch.setattr(passport_query, "select_chatter_loyalty_db", lambda _cid: loyalty)
     monkeypatch.setattr(passport_query, "select_chatter_debut_db", lambda _cid: debut)
     monkeypatch.setattr(passport_query, "select_chatter_most_active_stream_db", lambda _cid: active)
+    monkeypatch.setattr(passport_query, "select_chatter_message_time_bounds_db", lambda _cid: bounds)
 
 
 def test_unknown_chatter_returns_none(monkeypatch) -> None:
@@ -33,6 +36,9 @@ def test_assembles_totals_loyalty_and_shares(monkeypatch) -> None:
         loyalty=loyalty,
         debut=ChatterDebutRow(7, "First Stream", "Homie", "2024-01-01T20:00:00"),
         active=ChatterActiveStreamRow(11, "Big One", "Homie", 350),
+        # Message-time bounds intentionally differ from the loyalty rows' stream-start
+        # first/last_seen: totals must reflect MESSAGE times (the debut, not stream start).
+        time_bounds=ChatterTimeBoundsRow("2024-01-01T20:00:00", "2024-06-01T13:37:00"),
     )
 
     result = get_chatter_passport(42)
@@ -45,8 +51,11 @@ def test_assembles_totals_loyalty_and_shares(monkeypatch) -> None:
     assert result.totals.messages == 1000
     assert result.totals.streams_attended == 15
     assert result.totals.creators_visited == 2
-    assert result.totals.first_seen == "2024-01-01T00:00:00"
-    assert result.totals.last_seen == "2024-06-01T00:00:00"
+    # From message-time bounds, NOT the loyalty rows' stream-start columns:
+    # first_seen equals the debut message time even though the attended stream
+    # started earlier ("2024-01-01T00:00:00" in the loyalty row).
+    assert result.totals.first_seen == "2024-01-01T20:00:00"
+    assert result.totals.last_seen == "2024-06-01T13:37:00"
 
     # loyalty preserves gateway order (messages desc) and computes share = messages / totals.messages
     assert [entry.creator_id for entry in result.loyalty] == [5, 9]
@@ -90,7 +99,7 @@ def test_empty_corpus_yields_zero_share_and_null_milestones(monkeypatch) -> None
     assert result.chatter.is_bot is None
 
 
-def test_null_seen_timestamps_are_ignored_in_totals(monkeypatch) -> None:
+def test_totals_seen_come_from_message_time_bounds(monkeypatch) -> None:
     loyalty = [
         ChatterLoyaltyRow(5, "a", "A", 100, 2, None, None),
         ChatterLoyaltyRow(9, "b", "B", 50, 1, "2024-03-01T00:00:00", "2024-03-02T00:00:00"),
@@ -101,11 +110,12 @@ def test_null_seen_timestamps_are_ignored_in_totals(monkeypatch) -> None:
         loyalty=loyalty,
         debut=None,
         active=None,
+        time_bounds=ChatterTimeBoundsRow("2024-03-01T18:05:00", "2024-03-02T02:10:00"),
     )
 
     result = get_chatter_passport(1)
     assert result is not None
-    assert result.totals.first_seen == "2024-03-01T00:00:00"
-    assert result.totals.last_seen == "2024-03-02T00:00:00"
+    assert result.totals.first_seen == "2024-03-01T18:05:00"
+    assert result.totals.last_seen == "2024-03-02T02:10:00"
     assert result.chatter.is_bot is True
     assert result.chatter.bot_reason == "known-bot"

--- a/frontend/components/scene/SearchFirstCard.tsx
+++ b/frontend/components/scene/SearchFirstCard.tsx
@@ -44,6 +44,11 @@ const SearchFirstCard = ({ data, query }: SearchFirstCardProps) => (
           <span className="search-first-total-unit"> matches</span>
         </span>
       </div>
+      {/* The origin is deliberately all-time: it ignores the page's time-window
+          filter, which only scopes the results list and sparkline below. */}
+      <p className="text-muted mono search-first-scope-note">
+        all-time · ignores the time window filter
+      </p>
       {data.first ? (
         <HitLine hit={data.first} query={query} rank="1st" />
       ) : (

--- a/frontend/styles/_scene.scss
+++ b/frontend/styles/_scene.scss
@@ -476,6 +476,13 @@
     margin-bottom: 0.4rem;
 }
 
+.search-first-scope-note {
+    font-size: 0.68rem;
+    letter-spacing: 0.06em;
+    color: $gray-500;
+    margin: -0.35rem 0 0.55rem;
+}
+
 /* result rows */
 .search-results {
     margin-top: 1rem;


### PR DESCRIPTION
Follow-up to #49. Codex (GPT) reviewed the merged PR and confirmed five findings; this fixes all of them:

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 1 | High | 5000-text-id cap applied before creator/time filters; origin tracing relied on `message_text.id` ≈ chronology | Cap now applied after scoping (indexed `EXISTS` pushdown); `/search/first` + `/search/frequency` run **uncapped/exact** against the full LIKE match |
| 2 | Medium | In-process cache had no live-entry bound — public search could grow it until OOM | Hard ceiling (2000 live entries), soonest-to-expire eviction on overflow + unit test |
| 3 | Medium | Webhook content could ping arbitrary Discord users via `<@id>` in a Twitch title | `allowed_mentions: {"parse": []}` on every webhook post (alerts + digest) |
| 4 | Medium | Passport `first_seen`/`last_seen` were attended-stream **start** times, contradicting the debut card | New `stream_chatter_stats` message-time-bounds gateway; totals now use actual message times |
| 5 | Low | UI time filter silently didn't scope "Who said it first" | Card labeled `all-time · ignores the time window filter` |

No migration. Verified: 558 backend tests + mypy + ruff clean; 275 frontend tests + typecheck + build; every fixed behavior exercised end-to-end on a seeded scratch Postgres 17 (creator-scoped search/first/frequency correctness, passport message-time bounds vs stream start).