### PR TITLE
Set metadataBase so og:image URLs resolve to the prod domain

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,6 +4,10 @@ import { Providers } from './providers'
 import LegacyHashRedirect from '@/components/layout/LegacyHashRedirect'
 
 export const metadata: Metadata = {
+  // Absolute-URL base for social metadata (og:image et al.). Without it, Next
+  // resolves the generated opengraph-image routes against http://localhost:3000
+  // in the standalone prod container, which breaks every social unfurl.
+  metadataBase: new URL('https://stream-sniper.slanycukr.com'),
   title: 'Stream Sniper',
   description: 'Twitch stream analytics dashboard',
 }


### PR DESCRIPTION
Follow-up to #51. On prod, the page meta tags advertised `og:image = http://localhost:3000/...` because the standalone container has no `metadataBase` — Next's fallback. The OG routes themselves render fine (verified: image/png, 60–93KB, 0.2–0.4s on the Pi); only the absolute URL crawlers see was wrong, which breaks every social unfurl.

One line: `metadataBase: new URL('https://stream-sniper.slanycukr.com')` in the root layout metadata.

Verified: `tsc --noEmit` + `next build` green.

https://claude.ai/code/session_0199uX11DFnKqLPVbB2gaAhE