### PR TITLE
Fix live chat ingestion: rebind the pool for chat-thread gateway calls

### DIFF
--- a/backend/stream_sniper/collector/live/live_message_sink.py
+++ b/backend/stream_sniper/collector/live/live_message_sink.py
@@ -1,9 +1,16 @@
 """Bounded, asynchronous sink from Twitch IRC events to canonical message rows."""
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
+from typing import Any
 
+from ...database.core.connection_pool import (
+    DatabaseConnectionPool,
+    enter_pool_scope,
+    exit_pool_scope,
+    peek_active_pool,
+)
 from ...database.gateways.chat.chatter_table_gateway import find_or_insert_chatter_id_db
 from ...database.gateways.chat.live_chat_table_gateway import (
     LiveMessageRow,
@@ -59,6 +66,23 @@ class LiveMessageSink:
         self._flush_lock = asyncio.Lock()
         self._channel_locks: dict[str, asyncio.Lock] = {}
         self._finalized_sessions: dict[str, int] = {}
+        # twitchAPI's chat client invokes message callbacks on its own thread, whose
+        # context never saw the service entrypoint's pool binding (ContextVars do not
+        # cross thread boundaries). Capture the pool here — the sink is constructed
+        # inside the service's database runtime — and re-bind it around every
+        # worker-thread gateway call. None (unit tests) falls back to the ambient
+        # context so gateway monkeypatching keeps working unchanged.
+        self._pool: DatabaseConnectionPool | None = peek_active_pool()
+
+    def _call_with_pool(self, gateway: Callable[..., Any], /, *args: Any) -> Any:
+        """Run a gateway call with the captured pool bound in the worker thread."""
+        if self._pool is None:
+            return gateway(*args)
+        token = enter_pool_scope(self._pool)
+        try:
+            return gateway(*args)
+        finally:
+            exit_pool_scope(token)
 
     def _channel_lock(self, channel: str) -> asyncio.Lock:
         return self._channel_locks.setdefault(channel, asyncio.Lock())
@@ -76,6 +100,7 @@ class LiveMessageSink:
         if current and current[0] == twitch_stream_session_id:
             return current[1]
         stream_id_raw = await asyncio.to_thread(
+            self._call_with_pool,
             ensure_live_stream_db,
             channel,
             twitch_stream_session_id,
@@ -92,7 +117,7 @@ class LiveMessageSink:
     async def _resolve_chatter_id(self, nick: str) -> int:
         chatter_id = self._chatters.get(nick)
         if chatter_id is None:
-            chatter_id = await asyncio.to_thread(find_or_insert_chatter_id_db, nick)
+            chatter_id = await asyncio.to_thread(self._call_with_pool, find_or_insert_chatter_id_db, nick)
             if chatter_id is None:
                 raise RuntimeError(f"Chatter persistence returned no ID for {nick}")
             self._chatters[nick] = chatter_id
@@ -101,7 +126,7 @@ class LiveMessageSink:
     async def _resolve_text_id(self, text: str) -> int:
         text_id = self._texts.get(text)
         if text_id is None:
-            text_id = await asyncio.to_thread(find_or_insert_message_text_id_db, text)
+            text_id = await asyncio.to_thread(self._call_with_pool, find_or_insert_message_text_id_db, text)
             if text_id is None:
                 raise RuntimeError("Message-text persistence returned no ID")
             self._texts[text] = text_id
@@ -169,7 +194,7 @@ class LiveMessageSink:
                 return 0
             batch, self._items = self._items, []
             try:
-                await asyncio.to_thread(bulk_insert_live_messages_db, batch)
+                await asyncio.to_thread(self._call_with_pool, bulk_insert_live_messages_db, batch)
             except Exception as error:
                 self._items = batch + self._items
                 logger.exception(f"Live message flush failed; retained {len(batch)} rows")
@@ -183,7 +208,7 @@ class LiveMessageSink:
             if current is None:
                 return None
             await self.flush()
-            await asyncio.to_thread(finalize_live_stream_db, current[1], ended_at)
+            await asyncio.to_thread(self._call_with_pool, finalize_live_stream_db, current[1], ended_at)
             self._streams.pop(channel, None)
             self._finalized_sessions[channel] = current[0]
             return current[1]

--- a/backend/stream_sniper/database/core/connection_pool.py
+++ b/backend/stream_sniper/database/core/connection_pool.py
@@ -273,6 +273,16 @@ def get_active_pool() -> DatabaseConnectionPool:
     return active
 
 
+def peek_active_pool() -> DatabaseConnectionPool | None:
+    """Return the currently bound pool, or None when the scope is unbound.
+
+    For components that capture the pool at construction time so they can re-bind
+    it on threads whose context never saw the entrypoint's binding (ContextVars do
+    not cross thread boundaries — e.g. third-party callback threads).
+    """
+    return _active_pool.get()
+
+
 @contextmanager
 def database_runtime(config: DatabasePoolConfig | None = None) -> Iterator[DatabaseConnectionPool]:
     """Own one explicitly configured pool for a command or service lifetime."""

--- a/backend/tests/unit/collector/test_live_message_sink.py
+++ b/backend/tests/unit/collector/test_live_message_sink.py
@@ -185,3 +185,58 @@ async def test_finalize_serializes_terminal_flush_against_stale_messages(monkeyp
     assert [row[-1] for row in written] == ["accepted"]
     assert finalized == [(77, None)]
     assert sink._items == []
+
+
+@pytest.mark.asyncio
+async def test_ingest_rebinds_captured_pool_for_worker_thread_gateways(monkeypatch):
+    """Gateways must see the sink's captured pool even when the calling context is unbound.
+
+    twitchAPI chat callbacks arrive on the chat client's own thread, whose context never
+    saw the service entrypoint's pool binding (ContextVars do not cross threads). The sink
+    captures the pool at construction and re-binds it around each worker-thread gateway
+    call — without that, every live message dies with "No database pool is bound".
+    """
+    from stream_sniper.database.core.connection_pool import (
+        enter_pool_scope,
+        exit_pool_scope,
+        get_active_pool,
+    )
+
+    sentinel_pool = object()
+    seen_pools = []
+
+    def recording(result):
+        def gateway(*_args):
+            seen_pools.append(get_active_pool())
+            return result
+
+        return gateway
+
+    monkeypatch.setattr(sink_module, "ensure_live_stream_db", recording(77))
+    monkeypatch.setattr(sink_module, "find_or_insert_chatter_id_db", recording(8))
+    monkeypatch.setattr(sink_module, "find_or_insert_message_text_id_db", recording(9))
+    monkeypatch.setattr(sink_module, "bulk_insert_live_messages_db", recording(None))
+
+    # Construct inside a bound scope (the service does this under database_runtime()),
+    # then drop the binding to model the chat thread's pristine context.
+    token = enter_pool_scope(sentinel_pool)  # type: ignore[arg-type]
+    try:
+        sink = LiveMessageSink(buffer_size=10)
+    finally:
+        exit_pool_scope(token)
+
+    assert await sink.ingest_message(_message(), _stream()) is True
+    await sink.flush()
+
+    # ensure_stream + chatter + text + bulk insert all saw the captured pool.
+    assert len(seen_pools) == 4
+    assert all(pool is sentinel_pool for pool in seen_pools)
+
+
+@pytest.mark.asyncio
+async def test_sink_without_captured_pool_calls_gateways_in_ambient_context(monkeypatch):
+    """No pool at construction (unit-test reality) → gateways run unwrapped."""
+    monkeypatch.setattr(sink_module, "ensure_live_stream_db", lambda *args: 77)
+    sink = LiveMessageSink(buffer_size=10)
+    assert sink._pool is None
+    assert await sink.ensure_stream("somestreamer", _stream()) == 77


### PR DESCRIPTION
**Prod live-chat capture has been silently broken since the PR #46 deploy** — found while scoping the Moment Radar. `docker logs stream-sniper-live` shows every message failing with `RuntimeError: No database pool is bound to the current runtime` from `live_message_sink._ensure_stream`.

Root cause: twitchAPI's chat client runs message callbacks on its own thread. The pool is bound via a ContextVar inside the service's `@async_database_entrypoint`, and ContextVars don't cross thread boundaries — so `get_active_pool()` in the callback path always raises. The service's own main-loop tasks (`_flush_loop`, `_status_loop`, channel sync) run in the bound context and kept working, which is why the container looked healthy while ingesting zero messages.

Fix (single-owner, at the DB boundary): `LiveMessageSink` captures the pool at construction (it's built inside the service's database runtime) and re-binds it around each worker-thread gateway call (`_call_with_pool`). All five `asyncio.to_thread(gateway…)` sites route through it. A `None` capture (unit tests) falls back to the ambient context, so existing gateway monkeypatching is untouched. Adds public `peek_active_pool()` beside `get_active_pool()`.

Regression test models the exact failure: sink constructed under a bound scope, binding dropped, then asserts all four ingest-path gateways observe the captured pool (fails with `RuntimeError` on the old code).

Verified: 625 backend unit tests, ruff, mypy — clean.

https://claude.ai/code/session_0199uX11DFnKqLPVbB2gaAhE