### PR TITLE
Sweep zombie live-stream rows + VOD-metadata end repair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         working-directory: backend
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -71,7 +71,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -175,7 +175,7 @@ jobs:
       JWT_SECRET_KEY: ci-test-secret
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python 3.14
       uses: actions/setup-python@v5
@@ -203,7 +203,7 @@ jobs:
     needs: [lint, test]
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -255,7 +255,7 @@ jobs:
         working-directory: backend
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -285,7 +285,7 @@ jobs:
         working-directory: frontend
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Node.js 22
       uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -121,7 +121,7 @@ jobs:
     needs: build-and-push
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       JWT_SECRET_KEY: ci-test-secret
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -57,7 +57,7 @@ jobs:
       tag_name: ${{ steps.get_tag.outputs.tag_name }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -115,7 +115,7 @@ jobs:
     needs: create-release
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python 3.14
       uses: actions/setup-python@v5
@@ -162,7 +162,7 @@ jobs:
             image: collector
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -208,7 +208,7 @@ jobs:
       id-token: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python 3.14
       uses: actions/setup-python@v5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: backend
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python 3.14
       uses: actions/setup-python@v5
@@ -124,7 +124,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -188,7 +188,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/backend/stream_sniper/collector/archived/twitch_vod_chat_downloader.py
+++ b/backend/stream_sniper/collector/archived/twitch_vod_chat_downloader.py
@@ -90,14 +90,16 @@ class TwitchVodChatDownloader:
                         video.twitch_stream_session_id,
                     )
                     if reconciled is not None and reconciled[1]:
-                        # The VOD's end extended a provisional (swept-zombie) end, so every
-                        # duration-derived rollup metric is stale — recompute in place.
+                        # The stream's rollup disagrees with its (possibly just-repaired)
+                        # end — recompute. The staleness flag is durable (metrics vs the
+                        # stream row), so a failure here is retried the next time this VOD
+                        # is discovered; log and move on.
                         stream_id = reconciled[0]
-                        self.logger.info("VOD %s repaired stream %s end; recomputing rollup", video.twitch_vod_id, stream_id)
+                        self.logger.info("VOD %s: stream %s rollup is stale; recomputing", video.twitch_vod_id, stream_id)
                         try:
                             compute_stream_rollup(stream_id).require_success()
                         except Exception:
-                            self.logger.exception("Rollup recompute failed for repaired stream %s", stream_id)
+                            self.logger.exception("Rollup recompute failed for stream %s; will retry on rediscovery", stream_id)
                     continue
 
             discovery_mode = getattr(self, "_requested_vod_id", None) is None

--- a/backend/stream_sniper/collector/archived/twitch_vod_chat_downloader.py
+++ b/backend/stream_sniper/collector/archived/twitch_vod_chat_downloader.py
@@ -2,8 +2,9 @@
 
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 
+from ...analytics.rollups.rollup_engine import compute_stream_rollup
 from ...database.gateways.chat.live_chat_table_gateway import (
     reconcile_live_stream_vod_db,
     select_live_stream_by_session_db,
@@ -11,7 +12,23 @@ from ...database.gateways.chat.live_chat_table_gateway import (
 from ...database.gateways.streams.stream_table_gateway import stream_exists_by_twitch_vod_id_db
 from ...logging_config import get_logger
 from ..twitch_api import ArchivedVideo, SyncTwitchClient
+from .archived_stream import _stopped_at
 from .twitch_archived_chat import ArchivedChatMessage, TwitchArchivedChatClient
+
+
+def _vod_ended_at(video: ArchivedVideo) -> datetime | None:
+    """The VOD's authoritative session end (created_at + duration) as a naive-UTC datetime.
+
+    None when Twitch's duration string is missing/unparseable — reconciliation then simply
+    keeps the recorded end.
+    """
+    try:
+        ended_at = _stopped_at(video.created_at, video.duration)
+    except ValueError:
+        return None
+    if ended_at.tzinfo is not None:
+        ended_at = ended_at.astimezone(UTC).replace(tzinfo=None)
+    return ended_at
 
 
 @dataclass(frozen=True)
@@ -61,16 +78,26 @@ class TwitchVodChatDownloader:
             if video.twitch_stream_session_id:
                 captured = select_live_stream_by_session_db(video.twitch_stream_session_id)
                 if captured and captured[1]:
-                    reconcile_live_stream_vod_db(
+                    reconciled = reconcile_live_stream_vod_db(
                         video.twitch_stream_session_id,
                         video.twitch_vod_id,
                         video.thumbnail_url,
+                        _vod_ended_at(video),
                     )
                     self.logger.info(
                         "Skipping VOD %s; session %s was captured live",
                         video.twitch_vod_id,
                         video.twitch_stream_session_id,
                     )
+                    if reconciled is not None and reconciled[1]:
+                        # The VOD's end extended a provisional (swept-zombie) end, so every
+                        # duration-derived rollup metric is stale — recompute in place.
+                        stream_id = reconciled[0]
+                        self.logger.info("VOD %s repaired stream %s end; recomputing rollup", video.twitch_vod_id, stream_id)
+                        try:
+                            compute_stream_rollup(stream_id).require_success()
+                        except Exception:
+                            self.logger.exception("Rollup recompute failed for repaired stream %s", stream_id)
                     continue
 
             discovery_mode = getattr(self, "_requested_vod_id", None) is None

--- a/backend/stream_sniper/collector/live/live_chat_collector.py
+++ b/backend/stream_sniper/collector/live/live_chat_collector.py
@@ -11,7 +11,10 @@ from twitchAPI.twitch import Twitch
 from twitchAPI.type import AuthScope
 
 from ...analytics.rollups.rollup_engine import compute_stream_rollup
-from ...database.gateways.chat.live_chat_table_gateway import sweep_stale_live_sessions_db
+from ...database.gateways.chat.live_chat_table_gateway import (
+    finalize_stale_live_session_db,
+    select_stale_live_sessions_db,
+)
 from ...database.gateways.identity.creator_table_gateway import find_or_insert_creator_id_db, select_creator_id_db
 from ...database.gateways.tracking.tracked_streamers_table_gateway import select_active_tracked_streamers_db
 from ...logging_config import get_logger
@@ -208,22 +211,39 @@ class LiveChatCollector:
     async def _sweep_stale_sessions(self) -> None:
         """Finalize zombie live rows (no message + no viewer sample for the stale window).
 
-        Self-healing for restart leaks: the swept rows never got a live finalize, so they
-        also never got a rollup — enqueue one per swept stream through the same retrying
-        path finalized streams use. Sweep failures are logged and swallowed: a broken
-        sweep must never take down live capture.
+        Self-healing for restart leaks. Each candidate is confirmed dead before finalizing:
+        a session the sink is actively capturing is skipped, and so is any channel Twitch
+        still reports live with the same session id — with the check failing CLOSED (a
+        Twitch error skips the candidate; it will be retried on the next sweep). Swept rows
+        never got a live finalize, so they also never got a rollup — enqueue one per swept
+        stream through the same retrying path finalized streams use. Sweep failures are
+        logged and swallowed: a broken sweep must never take down live capture.
         """
         try:
-            swept = await asyncio.to_thread(sweep_stale_live_sessions_db, _STALE_SESSION_HOURS)
+            candidates = await asyncio.to_thread(select_stale_live_sessions_db, _STALE_SESSION_HOURS)
         except Exception:
             logger.exception("Stale live-session sweep failed")
             return
-        if not swept:
-            return
-        logger.info("Swept %s stale live session(s): %s", len(swept), swept)
-        for stream_id in swept:
-            self._pending_rollups.setdefault(stream_id, 0)
-            await self._attempt_rollup(stream_id)
+        for candidate in candidates:
+            channel = candidate.creator_nick.lower()
+            if self.sink.active_twitch_session_id(channel) == candidate.twitch_stream_session_id:
+                continue  # this collector is still capturing the session
+            try:
+                stream = await self._stream_for(channel)
+                if stream is not None and int(stream.id) == candidate.twitch_stream_session_id:
+                    logger.info("Skipping sweep of stream=%s; Twitch reports it still live", candidate.stream_id)
+                    continue
+                finalized = await asyncio.to_thread(finalize_stale_live_session_db, candidate.stream_id)
+            except Exception:
+                # Fail closed: without a definitive "session is dead" answer, keep the row
+                # open and let a later sweep retry.
+                logger.exception("Stale-session sweep skipped stream=%s", candidate.stream_id)
+                continue
+            if not finalized:
+                continue  # a concurrent real finalize won the race
+            logger.info("Swept stale live session stream=%s", candidate.stream_id)
+            self._pending_rollups.setdefault(candidate.stream_id, 0)
+            await self._attempt_rollup(candidate.stream_id)
 
     async def _reconcile_stream_sessions(self) -> None:
         """Sync rooms, finalize ended sessions, and record rollup outcomes once."""

--- a/backend/stream_sniper/collector/live/live_chat_collector.py
+++ b/backend/stream_sniper/collector/live/live_chat_collector.py
@@ -11,6 +11,7 @@ from twitchAPI.twitch import Twitch
 from twitchAPI.type import AuthScope
 
 from ...analytics.rollups.rollup_engine import compute_stream_rollup
+from ...database.gateways.chat.live_chat_table_gateway import sweep_stale_live_sessions_db
 from ...database.gateways.identity.creator_table_gateway import find_or_insert_creator_id_db, select_creator_id_db
 from ...database.gateways.tracking.tracked_streamers_table_gateway import select_active_tracked_streamers_db
 from ...logging_config import get_logger
@@ -21,6 +22,16 @@ from .secure_files import write_private_text
 
 logger = get_logger(__name__)
 _MAX_ROLLUP_ATTEMPTS = 5
+
+# A live-captured row with no chat message AND no viewer sample for this long is a zombie
+# (its session died while the service was down — the reconcile loop only finalizes channels
+# in the sink's in-memory map, so restarts leak rows). Conservative on purpose: no live
+# stream in the tracked scene is silent on both signals for 12 hours, and the viewer-sample
+# guard alone keeps any genuinely-live tracked stream open.
+_STALE_SESSION_HOURS = 12
+# The sweep runs at startup (clearing leaks from the last downtime) and then hourly — the
+# status loop ticks every 60s, so re-sweep every 60 ticks.
+_SWEEP_EVERY_TICKS = 60
 
 
 def _read_token(path: str) -> str:
@@ -101,6 +112,10 @@ class LiveChatCollector:
             raise RuntimeError("Chat initialization did not produce a client")
         self._running = True
         chat.start()
+        # Clear zombies leaked by the previous downtime BEFORE capture resumes: sessions
+        # that ended while the service was down are invisible to the reconcile loop (it
+        # only finalizes channels in the sink's in-memory map).
+        await self._sweep_stale_sessions()
         await self._sync_channels()
         tasks = [
             asyncio.create_task(self._flush_loop()),
@@ -182,9 +197,33 @@ class LiveChatCollector:
             await self.sink.flush()
 
     async def _status_loop(self) -> None:
+        ticks = 0
         while self._running:
             await asyncio.sleep(60)
+            ticks += 1
+            if ticks % _SWEEP_EVERY_TICKS == 0:
+                await self._sweep_stale_sessions()
             await self._reconcile_stream_sessions()
+
+    async def _sweep_stale_sessions(self) -> None:
+        """Finalize zombie live rows (no message + no viewer sample for the stale window).
+
+        Self-healing for restart leaks: the swept rows never got a live finalize, so they
+        also never got a rollup — enqueue one per swept stream through the same retrying
+        path finalized streams use. Sweep failures are logged and swallowed: a broken
+        sweep must never take down live capture.
+        """
+        try:
+            swept = await asyncio.to_thread(sweep_stale_live_sessions_db, _STALE_SESSION_HOURS)
+        except Exception:
+            logger.exception("Stale live-session sweep failed")
+            return
+        if not swept:
+            return
+        logger.info("Swept %s stale live session(s): %s", len(swept), swept)
+        for stream_id in swept:
+            self._pending_rollups.setdefault(stream_id, 0)
+            await self._attempt_rollup(stream_id)
 
     async def _reconcile_stream_sessions(self) -> None:
         """Sync rooms, finalize ended sessions, and record rollup outcomes once."""

--- a/backend/stream_sniper/database/gateways/chat/live_chat_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/chat/live_chat_table_gateway.py
@@ -103,6 +103,53 @@ def finalize_live_stream_db(
     connection.commit()
 
 
+@with_cursor_connection
+def sweep_stale_live_sessions_db(
+    cursor: Cursor,
+    connection: Connection,
+    stale_after_hours: int,
+) -> list[int]:
+    """Finalize live-captured stream rows whose session died while the service was down.
+
+    The reconcile loop only finalizes channels in the sink's in-memory map, so a restart
+    mid-capture leaks the row as a permanent zombie (``"end"`` stuck NULL,
+    ``live_capture_complete`` false — which also blocks VOD reconciliation). This sweep
+    closes any open live-captured row with no sign of life for ``stale_after_hours``:
+    no chat message AND no viewer sample for the same Twitch session (the sample guard
+    keeps a genuinely-live-but-silent tracked stream open). ``"end"`` is set to the last
+    message time (the best estimate of when capture actually stopped; stream start when
+    no messages exist) and ``live_capture_complete`` flips true so the VOD path can
+    reconcile. Returns the swept stream ids so the caller can enqueue their rollups.
+    """
+    cursor.execute(
+        """
+        UPDATE stream_sniper.stream s
+        SET "end" = COALESCE(
+                (SELECT max(m.time) FROM stream_sniper.message m WHERE m.stream_id = s.id),
+                s.start),
+            live_capture_complete = true,
+            message_count = (SELECT count(*) FROM stream_sniper.message m WHERE m.stream_id = s.id)
+        WHERE s."end" IS NULL
+          AND s.twitch_stream_session_id IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM stream_sniper.message m
+              WHERE m.stream_id = s.id
+                AND m.time >= (now() AT TIME ZONE 'UTC') - (%(stale)s * interval '1 hour')
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM stream_sniper.stream_viewer_sample svs
+              WHERE svs.twitch_stream_session_id = s.twitch_stream_session_id
+                AND svs.sampled_at >= now() - (%(stale)s * interval '1 hour')
+          )
+        RETURNING s.id
+        """,
+        {"stale": stale_after_hours},
+    )
+    swept = [int(row[0]) for row in cursor.fetchall()]
+    connection.commit()
+    return swept
+
+
 @with_cursor
 def select_live_stream_by_session_db(
     cursor: Cursor,

--- a/backend/stream_sniper/database/gateways/chat/live_chat_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/chat/live_chat_table_gateway.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Sequence
 from datetime import datetime
+from typing import NamedTuple
 
 from psycopg2.extensions import connection as Connection
 from psycopg2.extensions import cursor as Cursor
@@ -103,32 +104,35 @@ def finalize_live_stream_db(
     connection.commit()
 
 
-@with_cursor_connection
-def sweep_stale_live_sessions_db(
+class StaleLiveSessionRow(NamedTuple):
+    """One open live-captured stream row with no recent sign of life (sweep candidate)."""
+
+    stream_id: int
+    twitch_stream_session_id: int
+    creator_nick: str
+
+
+@with_cursor
+def select_stale_live_sessions_db(
     cursor: Cursor,
-    connection: Connection,
     stale_after_hours: int,
-) -> list[int]:
-    """Finalize live-captured stream rows whose session died while the service was down.
+) -> list[StaleLiveSessionRow]:
+    """Return open live-captured rows whose session shows no sign of life (sweep candidates).
 
     The reconcile loop only finalizes channels in the sink's in-memory map, so a restart
     mid-capture leaks the row as a permanent zombie (``"end"`` stuck NULL,
-    ``live_capture_complete`` false — which also blocks VOD reconciliation). This sweep
-    closes any open live-captured row with no sign of life for ``stale_after_hours``:
-    no chat message AND no viewer sample for the same Twitch session (the sample guard
-    keeps a genuinely-live-but-silent tracked stream open). ``"end"`` is set to the last
-    message time (the best estimate of when capture actually stopped; stream start when
-    no messages exist) and ``live_capture_complete`` flips true so the VOD path can
-    reconcile. Returns the swept stream ids so the caller can enqueue their rollups.
+    ``live_capture_complete`` false — which also blocks VOD reconciliation). A candidate is
+    an open live-captured row with no chat message AND no viewer sample for the same Twitch
+    session for ``stale_after_hours`` (the sample guard keeps a genuinely-live-but-silent
+    tracked stream out of the list). Read-only: the collector confirms each candidate's
+    session is really dead (sink state + a live Twitch lookup, failing closed) before
+    finalizing it with ``finalize_stale_live_session_db``.
     """
     cursor.execute(
         """
-        UPDATE stream_sniper.stream s
-        SET "end" = COALESCE(
-                (SELECT max(m.time) FROM stream_sniper.message m WHERE m.stream_id = s.id),
-                s.start),
-            live_capture_complete = true,
-            message_count = (SELECT count(*) FROM stream_sniper.message m WHERE m.stream_id = s.id)
+        SELECT s.id, s.twitch_stream_session_id, c.nick
+        FROM stream_sniper.stream s
+        JOIN stream_sniper.creator c ON c.id = s.creator_id
         WHERE s."end" IS NULL
           AND s.twitch_stream_session_id IS NOT NULL
           AND NOT EXISTS (
@@ -141,13 +145,43 @@ def sweep_stale_live_sessions_db(
               WHERE svs.twitch_stream_session_id = s.twitch_stream_session_id
                 AND svs.sampled_at >= now() - (%(stale)s * interval '1 hour')
           )
-        RETURNING s.id
         """,
         {"stale": stale_after_hours},
     )
-    swept = [int(row[0]) for row in cursor.fetchall()]
+    return [StaleLiveSessionRow(int(row[0]), int(row[1]), row[2]) for row in cursor.fetchall()]
+
+
+@with_cursor_connection
+def finalize_stale_live_session_db(
+    cursor: Cursor,
+    connection: Connection,
+    stream_id: int,
+) -> bool:
+    """Finalize one confirmed-dead zombie row; returns False if it was already closed.
+
+    ``"end"`` is set to the last message time — a PROVISIONAL estimate (capture stopped at
+    service shutdown, possibly before the stream ended; stream start when no messages
+    exist). ``reconcile_live_stream_vod_db`` later repairs it from the VOD's authoritative
+    metadata. ``live_capture_complete`` flips true so that VOD reconciliation can happen at
+    all. The ``"end" IS NULL`` guard makes the call race-safe against a concurrent real
+    finalize.
+    """
+    cursor.execute(
+        """
+        UPDATE stream_sniper.stream s
+        SET "end" = COALESCE(
+                (SELECT max(m.time) FROM stream_sniper.message m WHERE m.stream_id = s.id),
+                s.start),
+            live_capture_complete = true,
+            message_count = (SELECT count(*) FROM stream_sniper.message m WHERE m.stream_id = s.id)
+        WHERE s.id = %s AND s."end" IS NULL
+        RETURNING s.id
+        """,
+        (stream_id,),
+    )
+    finalized = cursor.fetchone() is not None
     connection.commit()
-    return swept
+    return finalized
 
 
 @with_cursor
@@ -170,17 +204,32 @@ def reconcile_live_stream_vod_db(
     twitch_stream_session_id: int,
     twitch_vod_id: int,
     thumbnail_url: str | None,
-) -> int | None:
-    """Attach the later VOD id to its live row so Twitch deep-links remain valid."""
+    vod_ended_at: datetime | None = None,
+) -> tuple[int, bool] | None:
+    """Attach the later VOD id to its live row and repair a provisional ``"end"``.
+
+    ``vod_ended_at`` (VOD created_at + duration) is the authoritative session end. It only
+    ever EXTENDS the recorded end (``GREATEST``): a swept zombie's provisional last-message
+    estimate is corrected forward, while an accurately live-finalized end is left alone
+    (Postgres ``GREATEST`` ignores a NULL argument). Returns ``(stream_id, end_changed)``
+    so the caller can recompute duration-derived rollups when the end moved, or ``None``
+    when no completed live capture exists for the session.
+    """
     cursor.execute(
         """
-        UPDATE stream_sniper.stream
-        SET twitch_id = %s, thumbnail_url = COALESCE(%s, thumbnail_url)
-        WHERE twitch_stream_session_id = %s AND live_capture_complete
-        RETURNING id
+        UPDATE stream_sniper.stream s
+        SET twitch_id = %s,
+            thumbnail_url = COALESCE(%s, thumbnail_url),
+            "end" = GREATEST(s."end", %s)
+        FROM (
+            SELECT id, "end" AS previous_end FROM stream_sniper.stream
+            WHERE twitch_stream_session_id = %s AND live_capture_complete
+        ) previous
+        WHERE s.id = previous.id
+        RETURNING s.id, s."end" IS DISTINCT FROM previous.previous_end
         """,
-        (twitch_vod_id, thumbnail_url, twitch_stream_session_id),
+        (twitch_vod_id, thumbnail_url, vod_ended_at, twitch_stream_session_id),
     )
     row = cursor.fetchone()
     connection.commit()
-    return int(row[0]) if row else None
+    return (int(row[0]), bool(row[1])) if row else None

--- a/backend/stream_sniper/database/gateways/chat/live_chat_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/chat/live_chat_table_gateway.py
@@ -197,6 +197,12 @@ def select_live_stream_by_session_db(
     return cursor.fetchone()
 
 
+# A VOD end only repairs the recorded end when it extends it by more than this. Normal
+# live-finalized ends differ from VOD metadata by trailing seconds; repairing those would
+# flag every stream's rollup stale for no analytical gain. Swept zombies are off by hours.
+_END_REPAIR_MIN_SECONDS = 300
+
+
 @with_cursor_connection
 def reconcile_live_stream_vod_db(
     cursor: Cursor,
@@ -209,26 +215,43 @@ def reconcile_live_stream_vod_db(
     """Attach the later VOD id to its live row and repair a provisional ``"end"``.
 
     ``vod_ended_at`` (VOD created_at + duration) is the authoritative session end. It only
-    ever EXTENDS the recorded end (``GREATEST``): a swept zombie's provisional last-message
-    estimate is corrected forward, while an accurately live-finalized end is left alone
-    (Postgres ``GREATEST`` ignores a NULL argument). Returns ``(stream_id, end_changed)``
-    so the caller can recompute duration-derived rollups when the end moved, or ``None``
-    when no completed live capture exists for the session.
+    ever EXTENDS the recorded end, and only when the gap exceeds ``_END_REPAIR_MIN_SECONDS``
+    (a swept zombie's provisional last-message estimate is hours short; a normal live
+    finalize is seconds off and left alone).
+
+    Returns ``(stream_id, rollup_stale)`` — or ``None`` when no completed live capture
+    exists for the session. ``rollup_stale`` is DURABLE, not an end-moved flag: it is true
+    whenever ``stream_metrics`` is missing or its ``duration_seconds`` disagrees with the
+    (post-repair) ``"end" - start`` — mirroring the rollup's own formula — so a rollup
+    recompute that fails transiently is retried on every later VOD rediscovery until one
+    succeeds, instead of being lost to a one-shot end-changed signal.
     """
     cursor.execute(
         """
         UPDATE stream_sniper.stream s
-        SET twitch_id = %s,
-            thumbnail_url = COALESCE(%s, thumbnail_url),
-            "end" = GREATEST(s."end", %s)
-        FROM (
-            SELECT id, "end" AS previous_end FROM stream_sniper.stream
-            WHERE twitch_stream_session_id = %s AND live_capture_complete
-        ) previous
-        WHERE s.id = previous.id
-        RETURNING s.id, s."end" IS DISTINCT FROM previous.previous_end
+        SET twitch_id = %(vod_id)s,
+            thumbnail_url = COALESCE(%(thumb)s, thumbnail_url),
+            "end" = CASE
+                WHEN %(vod_end)s::timestamp > s."end" + (%(min_gap)s * interval '1 second')
+                THEN %(vod_end)s::timestamp
+                ELSE s."end"
+            END
+        WHERE s.twitch_stream_session_id = %(session_id)s AND s.live_capture_complete
+        RETURNING s.id,
+            NOT EXISTS (
+                SELECT 1 FROM stream_sniper.stream_metrics sm
+                WHERE sm.stream_id = s.id
+                  AND sm.duration_seconds IS NOT DISTINCT FROM
+                      GREATEST(EXTRACT(EPOCH FROM (s."end" - s.start))::int, 0)
+            )
         """,
-        (twitch_vod_id, thumbnail_url, vod_ended_at, twitch_stream_session_id),
+        {
+            "vod_id": twitch_vod_id,
+            "thumb": thumbnail_url,
+            "vod_end": vod_ended_at,
+            "min_gap": _END_REPAIR_MIN_SECONDS,
+            "session_id": twitch_stream_session_id,
+        },
     )
     row = cursor.fetchone()
     connection.commit()

--- a/backend/tests/unit/collector/test_live_chat_collector.py
+++ b/backend/tests/unit/collector/test_live_chat_collector.py
@@ -104,6 +104,83 @@ async def test_start_surfaces_loop_failure_and_cancels_sibling(monkeypatch) -> N
 
 
 @pytest.mark.asyncio
+async def test_start_sweeps_stale_sessions_before_loops(monkeypatch) -> None:
+    # Zombie rows leaked by the previous downtime must be cleared on startup, before the
+    # flush/status loops begin.
+    collector = LiveChatCollector(channels=["alice"])
+    collector.chat = MagicMock()
+    collector._sync_channels = AsyncMock()
+    sweep = AsyncMock()
+    monkeypatch.setattr(collector, "_sweep_stale_sessions", sweep)
+
+    async def fail_fast() -> None:
+        raise RuntimeError("stop start()")
+
+    monkeypatch.setattr(collector, "_flush_loop", fail_fast)
+    monkeypatch.setattr(collector, "_status_loop", AsyncMock())
+
+    with pytest.raises(RuntimeError, match="stop start"):
+        await collector.start()
+
+    sweep.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_sweep_enqueues_rollups_for_swept_streams(monkeypatch) -> None:
+    collector = LiveChatCollector(channels=["alice"])
+    sweep_gateway = MagicMock(return_value=[31, 32])
+    monkeypatch.setattr(collector_module, "sweep_stale_live_sessions_db", sweep_gateway)
+    outcome = MagicMock()
+    monkeypatch.setattr(collector_module, "compute_stream_rollup", MagicMock(return_value=outcome))
+
+    await collector._sweep_stale_sessions()
+
+    sweep_gateway.assert_called_once_with(collector_module._STALE_SESSION_HOURS)
+    assert outcome.require_success.call_count == 2
+    assert collector._pending_rollups == {}
+    assert collector.rollup_failures == {}
+
+
+@pytest.mark.asyncio
+async def test_sweep_with_no_zombies_computes_no_rollups(monkeypatch) -> None:
+    collector = LiveChatCollector(channels=["alice"])
+    monkeypatch.setattr(collector_module, "sweep_stale_live_sessions_db", MagicMock(return_value=[]))
+    rollup = MagicMock()
+    monkeypatch.setattr(collector_module, "compute_stream_rollup", rollup)
+
+    await collector._sweep_stale_sessions()
+
+    rollup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sweep_failure_is_swallowed(monkeypatch) -> None:
+    # A broken sweep must never take down live capture.
+    collector = LiveChatCollector(channels=["alice"])
+    monkeypatch.setattr(collector_module, "sweep_stale_live_sessions_db", MagicMock(side_effect=RuntimeError("db down")))
+    rollup = MagicMock()
+    monkeypatch.setattr(collector_module, "compute_stream_rollup", rollup)
+
+    await collector._sweep_stale_sessions()
+
+    rollup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sweep_rollup_failure_lands_in_retry_queue(monkeypatch) -> None:
+    # A swept stream whose rollup fails must enter the same retrying path finalized
+    # streams use (retried by _retry_failed_rollups on later status cycles).
+    collector = LiveChatCollector(channels=["alice"])
+    monkeypatch.setattr(collector_module, "sweep_stale_live_sessions_db", MagicMock(return_value=[31]))
+    monkeypatch.setattr(collector_module, "compute_stream_rollup", MagicMock(side_effect=RuntimeError("rollup failed")))
+
+    await collector._sweep_stale_sessions()
+
+    assert collector._pending_rollups == {31: 1}
+    assert collector.rollup_failures == {31: "rollup failed"}
+
+
+@pytest.mark.asyncio
 async def test_sync_channels_reconciles_added_and_removed_rooms(monkeypatch) -> None:
     collector = LiveChatCollector(channels=["new"])
     collector.tracking_driven = False

--- a/backend/tests/unit/collector/test_live_chat_collector.py
+++ b/backend/tests/unit/collector/test_live_chat_collector.py
@@ -125,26 +125,114 @@ async def test_start_sweeps_stale_sessions_before_loops(monkeypatch) -> None:
     sweep.assert_awaited_once_with()
 
 
+def _stale(stream_id: int, session_id: int, nick: str):
+    return SimpleNamespace(
+        stream_id=stream_id,
+        twitch_stream_session_id=session_id,
+        creator_nick=nick,
+    )
+
+
 @pytest.mark.asyncio
-async def test_sweep_enqueues_rollups_for_swept_streams(monkeypatch) -> None:
+async def test_sweep_finalizes_dead_candidates_and_enqueues_rollups(monkeypatch) -> None:
     collector = LiveChatCollector(channels=["alice"])
-    sweep_gateway = MagicMock(return_value=[31, 32])
-    monkeypatch.setattr(collector_module, "sweep_stale_live_sessions_db", sweep_gateway)
+    monkeypatch.setattr(
+        collector_module,
+        "select_stale_live_sessions_db",
+        MagicMock(return_value=[_stale(31, 901, "Alice"), _stale(32, 902, "bob")]),
+    )
+    finalize = MagicMock(return_value=True)
+    monkeypatch.setattr(collector_module, "finalize_stale_live_session_db", finalize)
+    monkeypatch.setattr(collector, "_stream_for", AsyncMock(return_value=None))  # not live on Twitch
     outcome = MagicMock()
     monkeypatch.setattr(collector_module, "compute_stream_rollup", MagicMock(return_value=outcome))
 
     await collector._sweep_stale_sessions()
 
-    sweep_gateway.assert_called_once_with(collector_module._STALE_SESSION_HOURS)
+    assert finalize.call_args_list == [((31,),), ((32,),)]
+    # Channel lookups are lowercased before hitting Twitch/sink state.
+    collector._stream_for.assert_any_await("alice")
     assert outcome.require_success.call_count == 2
     assert collector._pending_rollups == {}
     assert collector.rollup_failures == {}
 
 
 @pytest.mark.asyncio
-async def test_sweep_with_no_zombies_computes_no_rollups(monkeypatch) -> None:
+async def test_sweep_skips_session_active_in_sink(monkeypatch) -> None:
+    # A session this collector is still capturing must never be swept, whatever the DB says.
     collector = LiveChatCollector(channels=["alice"])
-    monkeypatch.setattr(collector_module, "sweep_stale_live_sessions_db", MagicMock(return_value=[]))
+    monkeypatch.setattr(
+        collector_module, "select_stale_live_sessions_db", MagicMock(return_value=[_stale(31, 901, "alice")])
+    )
+    collector.sink.active_twitch_session_id = MagicMock(return_value=901)
+    finalize = MagicMock()
+    monkeypatch.setattr(collector_module, "finalize_stale_live_session_db", finalize)
+    monkeypatch.setattr(collector, "_stream_for", AsyncMock())
+
+    await collector._sweep_stale_sessions()
+
+    finalize.assert_not_called()
+    collector._stream_for.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_session_twitch_still_reports_live(monkeypatch) -> None:
+    collector = LiveChatCollector(channels=["alice"])
+    monkeypatch.setattr(
+        collector_module, "select_stale_live_sessions_db", MagicMock(return_value=[_stale(31, 901, "alice")])
+    )
+    finalize = MagicMock()
+    monkeypatch.setattr(collector_module, "finalize_stale_live_session_db", finalize)
+    monkeypatch.setattr(collector, "_stream_for", AsyncMock(return_value=SimpleNamespace(id="901")))
+
+    await collector._sweep_stale_sessions()
+
+    finalize.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sweep_finalizes_when_channel_live_with_new_session(monkeypatch) -> None:
+    # The streamer restarted: the channel is live again under a NEW session id, so the old
+    # session is definitively dead and its row must be finalized.
+    collector = LiveChatCollector(channels=["alice"])
+    monkeypatch.setattr(
+        collector_module, "select_stale_live_sessions_db", MagicMock(return_value=[_stale(31, 901, "alice")])
+    )
+    finalize = MagicMock(return_value=True)
+    monkeypatch.setattr(collector_module, "finalize_stale_live_session_db", finalize)
+    monkeypatch.setattr(collector, "_stream_for", AsyncMock(return_value=SimpleNamespace(id="777")))
+    monkeypatch.setattr(collector_module, "compute_stream_rollup", MagicMock(return_value=MagicMock()))
+
+    await collector._sweep_stale_sessions()
+
+    finalize.assert_called_once_with(31)
+
+
+@pytest.mark.asyncio
+async def test_sweep_fails_closed_on_twitch_error(monkeypatch) -> None:
+    # No definitive liveness answer -> keep the row open; a later sweep retries.
+    collector = LiveChatCollector(channels=["alice"])
+    monkeypatch.setattr(
+        collector_module, "select_stale_live_sessions_db", MagicMock(return_value=[_stale(31, 901, "alice")])
+    )
+    finalize = MagicMock()
+    monkeypatch.setattr(collector_module, "finalize_stale_live_session_db", finalize)
+    monkeypatch.setattr(collector, "_stream_for", AsyncMock(side_effect=RuntimeError("twitch down")))
+
+    await collector._sweep_stale_sessions()
+
+    finalize.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sweep_lost_finalize_race_skips_rollup(monkeypatch) -> None:
+    # finalize returns False when a concurrent real finalize already closed the row.
+    collector = LiveChatCollector(channels=["alice"])
+    monkeypatch.setattr(
+        collector_module, "select_stale_live_sessions_db", MagicMock(return_value=[_stale(31, 901, "alice")])
+    )
+    monkeypatch.setattr(collector_module, "finalize_stale_live_session_db", MagicMock(return_value=False))
+    monkeypatch.setattr(collector, "_stream_for", AsyncMock(return_value=None))
     rollup = MagicMock()
     monkeypatch.setattr(collector_module, "compute_stream_rollup", rollup)
 
@@ -154,10 +242,12 @@ async def test_sweep_with_no_zombies_computes_no_rollups(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_sweep_failure_is_swallowed(monkeypatch) -> None:
+async def test_sweep_candidate_query_failure_is_swallowed(monkeypatch) -> None:
     # A broken sweep must never take down live capture.
     collector = LiveChatCollector(channels=["alice"])
-    monkeypatch.setattr(collector_module, "sweep_stale_live_sessions_db", MagicMock(side_effect=RuntimeError("db down")))
+    monkeypatch.setattr(
+        collector_module, "select_stale_live_sessions_db", MagicMock(side_effect=RuntimeError("db down"))
+    )
     rollup = MagicMock()
     monkeypatch.setattr(collector_module, "compute_stream_rollup", rollup)
 
@@ -171,7 +261,11 @@ async def test_sweep_rollup_failure_lands_in_retry_queue(monkeypatch) -> None:
     # A swept stream whose rollup fails must enter the same retrying path finalized
     # streams use (retried by _retry_failed_rollups on later status cycles).
     collector = LiveChatCollector(channels=["alice"])
-    monkeypatch.setattr(collector_module, "sweep_stale_live_sessions_db", MagicMock(return_value=[31]))
+    monkeypatch.setattr(
+        collector_module, "select_stale_live_sessions_db", MagicMock(return_value=[_stale(31, 901, "alice")])
+    )
+    monkeypatch.setattr(collector_module, "finalize_stale_live_session_db", MagicMock(return_value=True))
+    monkeypatch.setattr(collector, "_stream_for", AsyncMock(return_value=None))
     monkeypatch.setattr(collector_module, "compute_stream_rollup", MagicMock(side_effect=RuntimeError("rollup failed")))
 
     await collector._sweep_stale_sessions()

--- a/backend/tests/unit/collector/test_live_vod_reconciliation.py
+++ b/backend/tests/unit/collector/test_live_vod_reconciliation.py
@@ -38,10 +38,9 @@ def test_completed_live_capture_reconciles_and_skips_vod(monkeypatch):
 
     def record_reconcile(*args):
         reconciled.append(args)
-        return (77, False)  # end already accurate -> no rollup recompute
+        return (77, False)  # rollup consistent with the recorded end -> no recompute
 
     monkeypatch.setattr(downloader_module, "reconcile_live_stream_vod_db", record_reconcile)
-    rollup = SimpleNamespace(called=False)
     monkeypatch.setattr(
         downloader_module,
         "compute_stream_rollup",
@@ -53,12 +52,11 @@ def test_completed_live_capture_reconciles_and_skips_vod(monkeypatch):
     assert result is None
     # The VOD's authoritative end (created_at + duration) rides along for end repair.
     assert reconciled == [(123, 987, "thumb", datetime(2024, 1, 15, 21))]
-    assert rollup.called is False
 
 
-def test_repaired_end_triggers_rollup_recompute(monkeypatch):
-    # A swept zombie's provisional end got extended by the VOD metadata -> duration-derived
-    # rollups are stale and must be recomputed.
+def test_stale_rollup_triggers_recompute(monkeypatch):
+    # A swept zombie's provisional end got repaired from VOD metadata -> stream_metrics
+    # disagrees with the stream row and must be recomputed.
     video = ArchivedVideo(
         twitch_vod_id=987,
         twitch_stream_session_id=123,
@@ -80,6 +78,39 @@ def test_repaired_end_triggers_rollup_recompute(monkeypatch):
 
     assert result is None
     assert recomputed == [77]
+
+
+def test_failed_recompute_is_retried_on_rediscovery(monkeypatch):
+    # The staleness flag is durable (stream_metrics vs the stream row), so when the first
+    # recompute fails transiently, the next discovery of the same VOD sees stale again and
+    # retries — the failure is never lost to a one-shot signal.
+    def make_video():
+        return ArchivedVideo(
+            twitch_vod_id=987,
+            twitch_stream_session_id=123,
+            thumbnail_url="thumb",
+            title="title",
+            created_at=datetime(2024, 1, 15, 20),
+            duration="3h",
+        )
+
+    monkeypatch.setattr(downloader_module, "select_live_stream_by_session_db", lambda session: (77, True))
+    monkeypatch.setattr(downloader_module, "reconcile_live_stream_vod_db", lambda *args: (77, True))
+    attempts = []
+
+    def rollup(stream_id):
+        attempts.append(stream_id)
+        if len(attempts) == 1:
+            raise RuntimeError("transient db failure")
+        return SimpleNamespace(require_success=lambda: None)
+
+    monkeypatch.setattr(downloader_module, "compute_stream_rollup", rollup)
+
+    # First discovery: recompute fails, VOD is still skipped (never downloaded).
+    assert _skipping_downloader(make_video()).open_chat_stream() is None
+    # Second discovery: reconcile reports stale again -> retried and succeeds.
+    assert _skipping_downloader(make_video()).open_chat_stream() is None
+    assert attempts == [77, 77]
 
 
 def test_unparseable_vod_duration_reconciles_without_end(monkeypatch):

--- a/backend/tests/unit/collector/test_live_vod_reconciliation.py
+++ b/backend/tests/unit/collector/test_live_vod_reconciliation.py
@@ -11,6 +11,18 @@ from stream_sniper.collector.archived.twitch_vod_chat_downloader import (
 from stream_sniper.collector.twitch_api import ArchivedVideo
 
 
+def _skipping_downloader(video):
+    downloader = TwitchVodChatDownloader.__new__(TwitchVodChatDownloader)
+    downloader.available_videos = [video]
+    downloader.logger = SimpleNamespace(
+        info=lambda *args: None, debug=lambda *args: None, exception=lambda *args: None
+    )
+    downloader.chat_client = SimpleNamespace(
+        open_messages=lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not download"))
+    )
+    return downloader
+
+
 def test_completed_live_capture_reconciles_and_skips_vod(monkeypatch):
     reconciled = []
     video = ArchivedVideo(
@@ -21,23 +33,78 @@ def test_completed_live_capture_reconciles_and_skips_vod(monkeypatch):
         created_at=datetime(2024, 1, 15, 20),
         duration="1h",
     )
-    downloader = TwitchVodChatDownloader.__new__(TwitchVodChatDownloader)
-    downloader.available_videos = [video]
-    downloader.logger = SimpleNamespace(info=lambda *args: None, debug=lambda *args: None)
-    downloader.chat_client = SimpleNamespace(
-        open_messages=lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not download"))
-    )
+    downloader = _skipping_downloader(video)
     monkeypatch.setattr(downloader_module, "select_live_stream_by_session_db", lambda session: (77, True))
+
+    def record_reconcile(*args):
+        reconciled.append(args)
+        return (77, False)  # end already accurate -> no rollup recompute
+
+    monkeypatch.setattr(downloader_module, "reconcile_live_stream_vod_db", record_reconcile)
+    rollup = SimpleNamespace(called=False)
     monkeypatch.setattr(
         downloader_module,
-        "reconcile_live_stream_vod_db",
-        lambda *args: reconciled.append(args),
+        "compute_stream_rollup",
+        lambda *_: (_ for _ in ()).throw(AssertionError("must not recompute")),
     )
 
     result = downloader.open_chat_stream()
 
     assert result is None
-    assert reconciled == [(123, 987, "thumb")]
+    # The VOD's authoritative end (created_at + duration) rides along for end repair.
+    assert reconciled == [(123, 987, "thumb", datetime(2024, 1, 15, 21))]
+    assert rollup.called is False
+
+
+def test_repaired_end_triggers_rollup_recompute(monkeypatch):
+    # A swept zombie's provisional end got extended by the VOD metadata -> duration-derived
+    # rollups are stale and must be recomputed.
+    video = ArchivedVideo(
+        twitch_vod_id=987,
+        twitch_stream_session_id=123,
+        thumbnail_url="thumb",
+        title="title",
+        created_at=datetime(2024, 1, 15, 20),
+        duration="3h",
+    )
+    downloader = _skipping_downloader(video)
+    monkeypatch.setattr(downloader_module, "select_live_stream_by_session_db", lambda session: (77, True))
+    monkeypatch.setattr(downloader_module, "reconcile_live_stream_vod_db", lambda *args: (77, True))
+    recomputed = []
+    outcome = SimpleNamespace(require_success=lambda: None)
+    monkeypatch.setattr(
+        downloader_module, "compute_stream_rollup", lambda stream_id: recomputed.append(stream_id) or outcome
+    )
+
+    result = downloader.open_chat_stream()
+
+    assert result is None
+    assert recomputed == [77]
+
+
+def test_unparseable_vod_duration_reconciles_without_end(monkeypatch):
+    reconciled = []
+    video = ArchivedVideo(
+        twitch_vod_id=987,
+        twitch_stream_session_id=123,
+        thumbnail_url="thumb",
+        title="title",
+        created_at=datetime(2024, 1, 15, 20),
+        duration="",  # Twitch occasionally returns junk; end repair must degrade to a no-op
+    )
+    downloader = _skipping_downloader(video)
+    monkeypatch.setattr(downloader_module, "select_live_stream_by_session_db", lambda session: (77, True))
+
+    def record_reconcile(*args):
+        reconciled.append(args)
+        return (77, False)
+
+    monkeypatch.setattr(downloader_module, "reconcile_live_stream_vod_db", record_reconcile)
+
+    result = downloader.open_chat_stream()
+
+    assert result is None
+    assert reconciled == [(123, 987, "thumb", None)]
 
 
 def test_exposed_vod_chat_start_failure_is_not_reported_as_success(monkeypatch):


### PR DESCRIPTION
## What

Closes the last item in the improvements backlog: live-capture stream rows leak as permanent zombies (`end IS NULL`, `live_capture_complete=false`) when the live service restarts mid-capture and the stream ends while it is down — the reconcile loop only finalizes channels in the sink's in-memory map, and VOD reconciliation requires `live_capture_complete=true`. **Prod has 9 such rows aged 2–4 days**; deploying this clears them on the live container's startup sweep.

### The sweep (self-healing)
- `select_stale_live_sessions_db` — read-only candidates: open live-captured rows with **no chat message AND no viewer sample** for the same Twitch session in 12h.
- `LiveChatCollector._sweep_stale_sessions` (startup + hourly) confirms each candidate is dead before finalizing: skips sessions the sink is actively capturing, skips channels Twitch still reports live with the same session id, and **fails closed** on Twitch errors (skip; retried next sweep). Sweep failures never take down capture.
- `finalize_stale_live_session_db` — closes one confirmed-dead row (`end` = last message time as a *provisional* estimate, `live_capture_complete=true` so the VOD path can reconcile), guarded on `"end" IS NULL` for race safety. Swept streams get rollups through the collector's existing retrying path.

### VOD-metadata end repair (durable)
A restart leak means capture stopped before the stream necessarily ended, so the provisional end underreports duration. `reconcile_live_stream_vod_db` now takes the VOD's authoritative end (`created_at + duration`, reusing the archived-stream parser) and repairs `end` forward when the gap exceeds 5 minutes. The recompute trigger is a **durable staleness flag** computed in the UPDATE's RETURNING — `stream_metrics.duration_seconds` disagreeing with the stream row (the rollup's own formula) or missing entirely — so a transiently-failed rollup recompute is retried on every later VOD rediscovery until one succeeds, never lost to a one-shot signal.

### Hygiene
- `actions/checkout` v4 → v5 across all workflows (Node 20 runner deprecation warning).
- Removed a stale `error-message-audit.csv` work artifact.

## Review

Three Codex `adversarial-review` rounds; every finding root-fixed:
1. **[high]** one-shot sweep could finalize an actively-captured quiet session → candidates + sink/Twitch confirm-dead guards, fail closed.
2. **[high]** last-message end is not a defensible stream end and was permanent → VOD-metadata repair + rollup recompute.
3. **[high]** end repair committed before an unretryable rollup attempt → durable metrics-vs-stream staleness flag; regression test forces the first recompute to fail and proves rediscovery retries.

## Verification

- 664 backend unit tests, ruff, mypy clean (14 new tests across sweep guards, retry queue, races, reconcile semantics).
- Scratch Postgres at alembic head: candidate selection (zombies only — actively-chatting, freshly-sampled, and VOD rows excluded), finalize end values + idempotence, sub-threshold/backward VOD ends never move `end`, missing/mismatched metrics report stale on repeated passes, matching metrics do not.

https://claude.ai/code/session_0199uX11DFnKqLPVbB2gaAhE