### PR TITLE
Product truth: live message counts, real page metadata, regulars links

### DIFF
--- a/backend/stream_sniper/collector/live/live_chat_collector.py
+++ b/backend/stream_sniper/collector/live/live_chat_collector.py
@@ -13,6 +13,7 @@ from twitchAPI.type import AuthScope
 from ...analytics.rollups.rollup_engine import compute_stream_rollup
 from ...database.gateways.chat.live_chat_table_gateway import (
     finalize_stale_live_session_db,
+    refresh_live_stream_message_counts_db,
     select_stale_live_sessions_db,
 )
 from ...database.gateways.identity.creator_table_gateway import find_or_insert_creator_id_db, select_creator_id_db
@@ -206,7 +207,20 @@ class LiveChatCollector:
             ticks += 1
             if ticks % _SWEEP_EVERY_TICKS == 0:
                 await self._sweep_stale_sessions()
+            await self._refresh_message_counts()
             await self._reconcile_stream_sessions()
+
+    async def _refresh_message_counts(self) -> None:
+        """Keep stream.message_count truthful while streams are LIVE (minute cadence).
+
+        Only finalize paths wrote the counter, so live streams read as 0 messages for
+        their whole duration. Failures are swallowed: a cosmetic counter must never
+        take down capture.
+        """
+        try:
+            await asyncio.to_thread(refresh_live_stream_message_counts_db)
+        except Exception:
+            logger.exception("Live message-count refresh failed")
 
     async def _sweep_stale_sessions(self) -> None:
         """Finalize zombie live rows (no message + no viewer sample for the stale window).

--- a/backend/stream_sniper/database/gateways/chat/live_chat_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/chat/live_chat_table_gateway.py
@@ -104,6 +104,28 @@ def finalize_live_stream_db(
     connection.commit()
 
 
+@with_cursor_connection
+def refresh_live_stream_message_counts_db(cursor: Cursor, connection: Connection) -> int:
+    """Sync ``stream.message_count`` with reality for every open live-captured stream.
+
+    Only finalize paths ever wrote the counter, so live streams read as 0 messages for
+    their whole duration — every consumer (stream catalog, filters, report surfaces)
+    showed wrong data exactly while people were watching. Counting from the ``message``
+    table (rather than incrementing per flush) also self-corrects any drift from
+    deduplicated inserts. Returns the number of streams refreshed.
+    """
+    cursor.execute(
+        """
+        UPDATE stream_sniper.stream s
+        SET message_count = (SELECT count(*) FROM stream_sniper.message m WHERE m.stream_id = s.id)
+        WHERE s."end" IS NULL AND s.twitch_stream_session_id IS NOT NULL
+        """
+    )
+    refreshed = cursor.rowcount
+    connection.commit()
+    return refreshed
+
+
 class StaleLiveSessionRow(NamedTuple):
     """One open live-captured stream row with no recent sign of life (sweep candidate)."""
 

--- a/backend/tests/unit/collector/test_live_chat_collector.py
+++ b/backend/tests/unit/collector/test_live_chat_collector.py
@@ -242,6 +242,28 @@ async def test_sweep_lost_finalize_race_skips_rollup(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_refresh_message_counts_calls_gateway(monkeypatch) -> None:
+    collector = LiveChatCollector(channels=["alice"])
+    refresh = MagicMock(return_value=2)
+    monkeypatch.setattr(collector_module, "refresh_live_stream_message_counts_db", refresh)
+
+    await collector._refresh_message_counts()
+
+    refresh.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_refresh_message_counts_failure_is_swallowed(monkeypatch) -> None:
+    # A cosmetic counter must never take down live capture.
+    collector = LiveChatCollector(channels=["alice"])
+    monkeypatch.setattr(
+        collector_module, "refresh_live_stream_message_counts_db", MagicMock(side_effect=RuntimeError("db down"))
+    )
+
+    await collector._refresh_message_counts()  # must not raise
+
+
+@pytest.mark.asyncio
 async def test_sweep_candidate_query_failure_is_swallowed(monkeypatch) -> None:
     # A broken sweep must never take down live capture.
     collector = LiveChatCollector(channels=["alice"])

--- a/frontend/app/(app)/chatter/[id]/page.tsx
+++ b/frontend/app/(app)/chatter/[id]/page.tsx
@@ -1,13 +1,31 @@
-'use client'
-import { use } from 'react'
+import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import ChatterPassport from '@/views/chatter/ChatterPassport'
+import { buildEntityMetadata } from '@/lib/og/entityMetadata'
+import { fetchChatterOgData } from '@/lib/og/fetchOgData'
 
-export default function ChatterPassportPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = use(params)
-  const chatterId = Number(id)
+// Server component on purpose: generateMetadata cannot live in a 'use client' file,
+// and the bespoke OG images are pointless while every chatter link unfurls with the
+// generic app title/description. The view itself stays a client component.
 
-  if (!Number.isSafeInteger(chatterId) || chatterId <= 0) {
+type PageProps = { params: Promise<{ id: string }> }
+
+const parseChatterId = (raw: string): number | null => {
+  const id = Number(raw)
+  return Number.isSafeInteger(id) && id > 0 ? id : null
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params
+  if (parseChatterId(id) == null) return {}
+  return buildEntityMetadata(await fetchChatterOgData(id))
+}
+
+export default async function ChatterPassportPage({ params }: PageProps) {
+  const { id } = await params
+  const chatterId = parseChatterId(id)
+
+  if (chatterId == null) {
     notFound()
   }
 

--- a/frontend/app/(app)/creator/[id]/page.tsx
+++ b/frontend/app/(app)/creator/[id]/page.tsx
@@ -1,8 +1,21 @@
-'use client'
-import { use } from 'react'
+import type { Metadata } from 'next'
 import CreatorDossier from '@/views/creator/CreatorDossier'
+import { buildEntityMetadata } from '@/lib/og/entityMetadata'
+import { fetchCreatorOgData } from '@/lib/og/fetchOgData'
 
-export default function CreatorPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = use(params)
+// Server component on purpose: generateMetadata cannot live in a 'use client' file,
+// and the bespoke OG images are pointless while every creator link unfurls with the
+// generic app title/description. The view itself stays a client component.
+
+type PageProps = { params: Promise<{ id: string }> }
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params
+  if (!Number.isSafeInteger(Number(id)) || Number(id) <= 0) return {}
+  return buildEntityMetadata(await fetchCreatorOgData(id))
+}
+
+export default async function CreatorPage({ params }: PageProps) {
+  const { id } = await params
   return <CreatorDossier creatorId={Number(id)} />
 }

--- a/frontend/app/(app)/highlights/page.tsx
+++ b/frontend/app/(app)/highlights/page.tsx
@@ -1,5 +1,12 @@
-'use client'
+import type { Metadata } from 'next'
 import Highlights from '@/views/scene/Highlights'
+
+// Server wrapper so the public listing page carries a real title/description in
+// tabs and social unfurls; the view stays a client component.
+export const metadata: Metadata = {
+  title: 'Highlights',
+  description: 'The biggest chat moments across the Czech Twitch scene.',
+}
 
 export default function HighlightsPage() {
   return <Highlights />

--- a/frontend/app/(app)/radar/page.tsx
+++ b/frontend/app/(app)/radar/page.tsx
@@ -1,5 +1,12 @@
-'use client'
+import type { Metadata } from 'next'
 import Radar from '@/views/scene/Radar'
+
+// Server wrapper so the public listing page carries a real title/description in
+// tabs and social unfurls; the view stays a client component.
+export const metadata: Metadata = {
+  title: 'Moment Radar',
+  description: 'Live chat velocity across every currently-live Czech stream, spikes first.',
+}
 
 export default function RadarPage() {
   return <Radar />

--- a/frontend/app/(app)/rankings/page.tsx
+++ b/frontend/app/(app)/rankings/page.tsx
@@ -1,5 +1,12 @@
-'use client'
+import type { Metadata } from 'next'
 import Rankings from '@/views/scene/Rankings'
+
+// Server wrapper so the public listing page carries a real title/description in
+// tabs and social unfurls; the view stays a client component.
+export const metadata: Metadata = {
+  title: 'Chatter Rankings',
+  description: 'Scene-wide chatter power rankings across the Czech Twitch scene.',
+}
 
 export default function RankingsPage() {
   return <Rankings />

--- a/frontend/app/(app)/stream/[id]/page.tsx
+++ b/frontend/app/(app)/stream/[id]/page.tsx
@@ -1,13 +1,31 @@
-'use client'
-import { use } from 'react'
+import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import Stream from '@/views/stream/Stream'
+import { buildEntityMetadata } from '@/lib/og/entityMetadata'
+import { fetchStreamOgData } from '@/lib/og/fetchOgData'
 
-export default function StreamPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = use(params)
-  const streamId = Number(id)
+// Server component on purpose: generateMetadata cannot live in a 'use client' file,
+// and the bespoke OG images are pointless while every stream link unfurls with the
+// generic app title/description. The view itself stays a client component.
 
-  if (!Number.isSafeInteger(streamId) || streamId <= 0) {
+type PageProps = { params: Promise<{ id: string }> }
+
+const parseStreamId = (raw: string): number | null => {
+  const id = Number(raw)
+  return Number.isSafeInteger(id) && id > 0 ? id : null
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id } = await params
+  if (parseStreamId(id) == null) return {}
+  return buildEntityMetadata(await fetchStreamOgData(id))
+}
+
+export default async function StreamPage({ params }: PageProps) {
+  const { id } = await params
+  const streamId = parseStreamId(id)
+
+  if (streamId == null) {
     notFound()
   }
 

--- a/frontend/app/(app)/trending/page.tsx
+++ b/frontend/app/(app)/trending/page.tsx
@@ -1,5 +1,12 @@
-'use client'
+import type { Metadata } from 'next'
 import Trending from '@/views/scene/Trending'
+
+// Server wrapper so the public listing page carries a real title/description in
+// tabs and social unfurls; the view stays a client component.
+export const metadata: Metadata = {
+  title: 'Trending',
+  description: 'What is heating up across the Czech Twitch scene right now.',
+}
 
 export default function TrendingPage() {
   return <Trending />

--- a/frontend/app/(app)/wrapped/page.tsx
+++ b/frontend/app/(app)/wrapped/page.tsx
@@ -1,6 +1,13 @@
-'use client'
+import type { Metadata } from 'next'
 import Wrapped from '@/views/scene/Wrapped'
 
+// Server wrapper so the public listing page carries a real title/description in
+// tabs and social unfurls; the view stays a client component.
+export const metadata: Metadata = {
+  title: 'Scene Wrapped',
+  description: 'A recap of the Czech Twitch scene: top creators, chatters, moments, copypastas, and emotes.',
+}
+
 export default function WrappedPage() {
-    return <Wrapped />
+  return <Wrapped />
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -8,7 +8,10 @@ export const metadata: Metadata = {
   // resolves the generated opengraph-image routes against http://localhost:3000
   // in the standalone prod container, which breaks every social unfurl.
   metadataBase: new URL('https://stream-sniper.slanycukr.com'),
-  title: 'Stream Sniper',
+  // Template lets per-page metadata (entity pages' generateMetadata, listing pages'
+  // static titles) surface real names in tabs and social unfurls instead of the
+  // generic app title everywhere.
+  title: { default: 'Stream Sniper', template: '%s · Stream Sniper' },
   description: 'Twitch stream analytics dashboard',
 }
 

--- a/frontend/components/creator/RegularsPresentation.jsx
+++ b/frontend/components/creator/RegularsPresentation.jsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { Table } from 'react-bootstrap'
 import SortableTableHeader from '@/components/common/SortableTableHeader'
 import { formatTimeAgo } from '@/utils/dateUtils'
@@ -58,7 +59,11 @@ const RegularsTable = ({
                 {regulars.map((regular, index) => (
                     <tr key={regular.chatterId}>
                         <td className="rank-num">{String(index + 1).padStart(2, '0')}</td>
-                        <td>{regular.nick}</td>
+                        <td>
+                            {/* A creator's biggest fans are the top entry point into the
+                                chatter passport — every other chatter listing links there. */}
+                            <Link className="nick" href={`/chatter/${regular.chatterId}`}>{regular.nick}</Link>
+                        </td>
                         <td style={{ minWidth: '140px' }}>
                             <span className="mono">{regular.streamsAttended?.toLocaleString()}</span>
                             <span className="data-bar" aria-hidden="true">

--- a/frontend/lib/og/entityMetadata.ts
+++ b/frontend/lib/og/entityMetadata.ts
@@ -1,0 +1,26 @@
+/**
+ * Page <Metadata> derived from the same card data that renders the OG images.
+ *
+ * The bespoke per-entity OG images (opengraph-image.tsx) shipped without any
+ * generateMetadata, so every chatter/creator/stream link unfurled with the
+ * generic app title/description — defeating the point of the custom cards.
+ * This maps an OgCardData (already fetched, formatted, and truncated by
+ * fetchOgData, which never throws) into title + description; a null card
+ * (unknown id, dead backend) degrades to the layout defaults.
+ */
+import type { Metadata } from 'next'
+import type { OgCardData } from '@/lib/og/fetchOgData'
+
+export const buildEntityMetadata = (card: OgCardData | null): Metadata => {
+  if (!card) return {}
+  const description = [
+    card.subtitle,
+    card.stats.map(stat => `${stat.value} ${stat.label}`).join(' · '),
+  ]
+    .filter(Boolean)
+    .join(' — ')
+  return {
+    title: card.title,
+    ...(description ? { description } : {}),
+  }
+}


### PR DESCRIPTION
Three audit findings about the product showing wrong or generic data:

## Live streams showed 0 messages
`stream.message_count` was only written at finalize, so every consumer showed 0 for live streams — exactly while people are watching. The live collector now syncs it from the real `message` row count every status-loop minute; counting rather than incrementing also self-corrects dedup drift (the audit found a completed stream at 827 recorded vs 818 actual — repaired on prod after deploy).

## Social unfurls were generic everywhere
PR #51 shipped bespoke per-entity OG images, but no route defined `generateMetadata` — `og:title`/`og:description` (and tab titles) stayed "Stream Sniper / Twitch stream analytics dashboard" for every chatter, creator, and stream. Entity pages are now thin **server** components (the views stay client) deriving metadata from the same OG card fetchers (time-boxed, never throw, degrade to layout defaults); the five new listing pages get static titles; the root layout uses a `%s · Stream Sniper` template.

## Regulars were a dead end
The creator "Core regulars" table rendered nicks as plain text — the one chatter listing not linking to the chatter passport. Now linked like every other surface.

## Verification
Backend 666 tests / ruff / mypy clean (2 new tests for the counter refresh + failure swallowing). Frontend tsc / ratchet / 370 vitest / production build clean — all restructured routes present in the manifest.

https://claude.ai/code/session_0199uX11DFnKqLPVbB2gaAhE