### PR TITLE
Creator Wrapped, chat companions, and archetype badges on Rankings

### DIFF
--- a/backend/stream_sniper/analytics/rollups/rollup_engine.py
+++ b/backend/stream_sniper/analytics/rollups/rollup_engine.py
@@ -91,6 +91,11 @@ def compute_stream_rollup(stream_id: int, *, refresh_overlap: bool = True) -> Ro
       4. Copypasta rollup replacement.
       5. Scene-event derivation and replacement.
       6. Community overlap refresh (non-blocking) when ``refresh_overlap`` is set.
+      7. Rollup-version touch — bumps ``stream_metrics.computed_at`` LAST. TX1 already
+         wrote ``computed_at``, so a cache entry keyed on the new version but stored
+         while phases 3–5 were still writing would pin pre-rollup moments/copypastas
+         for its full TTL; the final touch rolls the key again once every source is
+         current, so any mixed-generation entry is superseded immediately.
 
     NOTE: new_chatters / returning_chatters are only correct when streams are rolled up in
     chronological order (oldest first). The bulk/CLI ingest path processes VODs newest-first, so it
@@ -159,6 +164,15 @@ def compute_stream_rollup(stream_id: int, *, refresh_overlap: bool = True) -> Ro
             completed,
             failures,
         )
+    # Always last (even after phase failures): rolling the version key makes any
+    # cache entry stored mid-rollup age out instead of serving a mixed generation.
+    _run_phase(
+        stream_id,
+        "rollup_version_touch",
+        lambda: touch_stream_rollup_version_db(stream_id),
+        completed,
+        failures,
+    )
 
     return RollupOutcome(
         stream_id=stream_id,

--- a/backend/stream_sniper/api/api.py
+++ b/backend/stream_sniper/api/api.py
@@ -30,6 +30,7 @@ from .features.content.scene_trending_endpoints import router as scene_trending_
 from .features.content.scene_wrapped_endpoints import router as scene_wrapped_router
 from .features.creators.analytics_endpoints import router as analytics_router
 from .features.creators.creator_endpoints import router as creator_router
+from .features.creators.creator_wrapped_endpoints import router as creator_wrapped_router
 from .features.operations.operations_endpoints import router as operations_router
 from .features.search.search_endpoints import router as search_router
 from .features.streams.compare_endpoints import router as compare_router
@@ -90,6 +91,7 @@ def _include_routers(app: FastAPI) -> None:
         compare_router,
         stream_router,
         creator_router,
+        creator_wrapped_router,
         tracking_router,
         operations_router,
         message_router,

--- a/backend/stream_sniper/api/features/content/scene_chatter_endpoints.py
+++ b/backend/stream_sniper/api/features/content/scene_chatter_endpoints.py
@@ -5,6 +5,8 @@ handler (psycopg2 blocks), `request: Request` + `response: Response` for slowapi
 in-process TTL cache keyed on the query params plus the scene rollup version.
 """
 
+from datetime import UTC, datetime
+
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 
 from ....database.gateways.creators.scene_chatter_rankings_gateway import (
@@ -63,7 +65,8 @@ def get_scene_chatter_rankings(
             return cached
 
         rows, has_more = select_scene_chatter_rankings_db(_WINDOWS[window], limit, offset)
-        items = [RankItem.from_row(row, rank=offset + index + 1) for index, row in enumerate(rows)]
+        now = datetime.now(UTC)
+        items = [RankItem.from_row(row, rank=offset + index + 1, now=now) for index, row in enumerate(rows)]
         result = SceneChatterRankings(window=window, items=items, has_more=has_more)
         _RANKINGS_CACHE.store(cache, response, cache_key, result)
         return result

--- a/backend/stream_sniper/api/features/content/scene_chatter_models.py
+++ b/backend/stream_sniper/api/features/content/scene_chatter_models.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
+
+from ....application.chatters.archetypes import compute_archetypes
+from ....application.chatters.passport_models import PassportArchetype
 
 if TYPE_CHECKING:
     from ....database.gateways.creators.scene_chatter_rankings_gateway import SceneChatterRankRow
@@ -33,9 +37,16 @@ class RankItem(BaseModel):
     home_channel: RankHomeChannel | None = Field(
         None, description="The creator the chatter chats in most within the window"
     )
+    archetypes: list[PassportArchetype] = Field(
+        default_factory=list,
+        description=(
+            "Rule-based identity badges derived from ACCOUNT-WIDE aggregates "
+            "(never the window slice — badges must not flip with the ranking window)"
+        ),
+    )
 
     @classmethod
-    def from_row(cls, row: SceneChatterRankRow, *, rank: int) -> RankItem:
+    def from_row(cls, row: SceneChatterRankRow, *, rank: int, now: datetime | None = None) -> RankItem:
         home = None
         if row.home_creator_id is not None:
             home = RankHomeChannel(
@@ -45,6 +56,22 @@ class RankItem(BaseModel):
                 messages=row.home_messages or 0,
                 share=_share(row.home_messages or 0, row.total_messages),
             )
+        # Identity badges read the lifetime aggregates, NOT the window slice above:
+        # a lifetime loyalist who spread out for one week must not badge as Wanderer
+        # on the 7-day tab (the gateway carries lifetime_* account-wide in both paths).
+        lifetime_home_share = (
+            _share(row.lifetime_home_messages, row.lifetime_messages)
+            if row.lifetime_home_messages is not None
+            else None
+        )
+        archetypes = compute_archetypes(
+            total_messages=row.lifetime_messages,
+            streams_attended=row.lifetime_streams,
+            creators_visited=row.lifetime_creators,
+            home_share=lifetime_home_share,
+            first_seen=row.first_seen,
+            now=now if now is not None else datetime.now(UTC),
+        )
         return cls(
             rank=rank,
             chatter_id=row.chatter_id,
@@ -53,6 +80,7 @@ class RankItem(BaseModel):
             streams_attended=row.streams_attended,
             creators_visited=row.creators_visited,
             home_channel=home,
+            archetypes=archetypes,
         )
 
 

--- a/backend/stream_sniper/api/features/creators/creator_wrapped_endpoints.py
+++ b/backend/stream_sniper/api/features/creators/creator_wrapped_endpoints.py
@@ -1,0 +1,59 @@
+"""Public read endpoint for the Creator Wrapped period recap.
+
+One creator's version of the Scene Wrapped recap. Public (no auth), following the sibling creator/scene
+endpoint conventions: sync ``def`` handler (psycopg2 blocks), ``request: Request`` +
+``response: Response`` for slowapi, in-process TTL cache keyed on creator id + window +
+the creator's rollup version, nullable = unknown, 404 on an unknown creator id (see
+``analytics_endpoints.get_creator_summary``). The multi-gateway assembly lives in
+``application/creators/wrapped_query``; this handler owns only HTTP + caching.
+"""
+
+from fastapi import APIRouter, HTTPException, Path, Query, Request, Response
+
+from ....application.creators.analytics_query import CreatorNotFoundError
+from ....application.creators.wrapped_models import CreatorWrapped
+from ....application.creators.wrapped_query import get_creator_wrapped
+from ...caching.cache import CacheTTL
+from ...caching.model_cache import ModelCachePolicy
+from ...caching.rollup_version import creator_rollup_version
+from ...dependencies import get_cache
+from ...security.rate_limiter import limiter, rate_limits
+from ...transport.models import ErrorOrValidationResponse, ErrorResponse, RateLimitErrorResponse
+
+router = APIRouter(tags=["Creators"])
+
+_WRAPPED_CACHE = ModelCachePolicy("creator_wrapped", CacheTTL.STREAM_ANALYTICS, CreatorWrapped)
+
+
+@router.get(
+    "/creators/{creator_id}/wrapped",
+    response_model=CreatorWrapped,
+    summary="Get the Creator Wrapped period recap",
+    description="A single creator's recap over a trailing window: totals plus top chatters, moments, "
+    "copypastas, and emotes.",
+    responses={
+        404: {"model": ErrorResponse, "description": "Creator not found"},
+        422: {"model": ErrorOrValidationResponse, "description": "Invalid window parameter"},
+        429: {"model": RateLimitErrorResponse, "description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit(rate_limits.ANALYTICS)
+def get_creator_wrapped_endpoint(
+    request: Request,
+    response: Response,
+    creator_id: int = Path(..., description="Creator ID", json_schema_extra={"example": 5}),
+    days: int = Query(30, ge=7, le=90, description="Recap window length in days (7-90)"),
+) -> CreatorWrapped:
+    """Get the Creator Wrapped recap for one creator over the trailing ``days`` window."""
+    with _WRAPPED_CACHE.record_failures():
+        cache = get_cache(request)
+        cache_key, cached = _WRAPPED_CACHE.lookup(cache, response, creator_id, days, creator_rollup_version(creator_id))
+        if cached is not None:
+            return cached
+
+        try:
+            result = get_creator_wrapped(creator_id, days)
+        except CreatorNotFoundError as error:
+            raise HTTPException(status_code=404, detail="Creator not found") from error
+        _WRAPPED_CACHE.store(cache, response, cache_key, result)
+        return result

--- a/backend/stream_sniper/application/chatters/passport_models.py
+++ b/backend/stream_sniper/application/chatters/passport_models.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
         ChatterDebutRow,
     )
     from stream_sniper.database.gateways.chat.records import ChatterProfileRow
+    from stream_sniper.database.gateways.community.records import ChatCompanionRow
     from stream_sniper.database.gateways.creators.records import ChatterLoyaltyRow
 
 
@@ -120,6 +121,16 @@ class PassportMilestones(BaseModel):
     )
 
 
+class PassportCompanion(BaseModel):
+    chatter_id: int = Field(..., description="Co-chatter's chatter ID")
+    nick: str = Field(..., description="Co-chatter's nickname")
+    shared_streams: int = Field(..., description="Streams both chatters attended")
+
+    @classmethod
+    def from_row(cls, row: ChatCompanionRow) -> PassportCompanion:
+        return cls(chatter_id=row.chatter_id, nick=row.nick, shared_streams=row.shared_streams)
+
+
 class PassportArchetype(BaseModel):
     key: str = Field(..., description="Stable archetype identifier (e.g. 'loyalist')")
     label: str = Field(..., description="Human-readable badge label")
@@ -135,4 +146,7 @@ class ChatterPassport(BaseModel):
     milestones: PassportMilestones
     archetypes: list[PassportArchetype] = Field(
         default_factory=list, description="Rule-based identity badges derived from the passport's own data"
+    )
+    companions: list[PassportCompanion] = Field(
+        default_factory=list, description="Top co-chatters ranked by shared-stream count, bots excluded"
     )

--- a/backend/stream_sniper/application/chatters/passport_query.py
+++ b/backend/stream_sniper/application/chatters/passport_query.py
@@ -14,12 +14,14 @@ from stream_sniper.database.gateways.analytics.stream_chatter_stats_table_gatewa
     select_chatter_most_active_stream_db,
 )
 from stream_sniper.database.gateways.chat.chatter_table_gateway import select_chatter_profile_db
+from stream_sniper.database.gateways.community.chat_companions_gateway import select_chat_companions_db
 from stream_sniper.database.gateways.creators.creator_chatter_stats_table_gateway import select_chatter_loyalty_db
 
 from .archetypes import compute_archetypes
 from .passport_models import (
     ChatterPassport,
     PassportChatter,
+    PassportCompanion,
     PassportDebut,
     PassportHomeChannel,
     PassportLoyalty,
@@ -57,6 +59,7 @@ def get_chatter_passport(chatter_id: int) -> ChatterPassport | None:
 
     debut_row = select_chatter_debut_db(chatter_id)
     active_row = select_chatter_most_active_stream_db(chatter_id)
+    companion_rows = select_chat_companions_db(chatter_id)
 
     # Archetypes are derived purely from the aggregates already assembled above
     # (no extra query). now=UTC keeps the age-based badges deterministic per request.
@@ -81,4 +84,5 @@ def get_chatter_passport(chatter_id: int) -> ChatterPassport | None:
             )
         ),
         archetypes=archetypes,
+        companions=[PassportCompanion.from_row(row) for row in companion_rows],
     )

--- a/backend/stream_sniper/application/creators/wrapped_models.py
+++ b/backend/stream_sniper/application/creators/wrapped_models.py
@@ -1,0 +1,73 @@
+"""Canonical Creator Wrapped read models (a single creator's period recap).
+
+Application-owned Pydantic (FastAPI-free), mirroring ``scenes/wrapped_models.py``
+scoped to one creator: totals, top chatters, top moments, top copypastas, and top
+emotes over a trailing window. There is no ``creators_active``/``top_creators``
+section (single-creator scope makes both trivial) and no ``notable_events`` section
+(scene events are cross-creator by design). Fields that would be constant for a
+single creator are dropped from the nested rows too: chatters carry no
+``creators_visited``/``home_creator_display_name`` (always 1 / this creator), moments
+carry no ``creator_display_name``, and copypastas carry no ``creator_count`` (always
+1, since the source rows are already filtered to this creator).
+
+Nullable fields mean "unknown" and are never coalesced to 0 — a creator with no
+streams in the window has ``hours_streamed=None``, not ``0``.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CreatorWrappedTotals(BaseModel):
+    streams: int = Field(..., description="Streams that started within the window")
+    hours_streamed: float | None = Field(
+        None, description="Total streamed hours in the window (null when nothing was streamed)"
+    )
+    messages: int = Field(..., description="Total chat messages across those streams")
+    active_chatters: int = Field(..., description="Distinct human chatters active in the window")
+
+
+class CreatorWrappedChatter(BaseModel):
+    rank: int = Field(..., description="1-based rank by total messages")
+    chatter_id: int
+    nick: str
+    total_messages: int = Field(..., description="Messages the chatter sent to this creator in the window")
+    streams_attended: int = Field(..., description="This creator's distinct streams the chatter attended")
+
+
+class CreatorWrappedMoment(BaseModel):
+    stream_id: int
+    stream_title: str
+    twitch_id: str | None = Field(None, description="Twitch VOD id, if known")
+    bucket_minute: str = Field(..., description="Minute the moment peaked (ISO 8601)")
+    offset_seconds: int = Field(..., description="Seconds into the VOD")
+    ratio: float | None = Field(None, description="Spike ratio vs baseline (null = no baseline)")
+    message_count: int = Field(..., description="Messages in the peak minute")
+
+
+class CreatorWrappedCopypasta(BaseModel):
+    message_text_id: int
+    text: str
+    usage_count: int = Field(..., description="Total sends across the window, this creator's streams only")
+    stream_count: int = Field(..., description="This creator's distinct streams the copypasta appeared in")
+
+
+class CreatorWrappedEmote(BaseModel):
+    emote_id: int
+    name: str
+    source: str = Field(..., description="Emote provider: bttv or twitch")
+    usage: int = Field(..., description="Total emote uses across the window")
+    chatter_reach: int = Field(..., description="Sum of per-stream chatter_count over the window")
+
+
+class CreatorWrapped(BaseModel):
+    creator_id: int
+    days: int = Field(..., description="Length of the recap window in days")
+    totals: CreatorWrappedTotals
+    top_chatters: list[CreatorWrappedChatter] = Field(
+        ..., description="Top chatters by messages, bots excluded (up to 5)"
+    )
+    top_moments: list[CreatorWrappedMoment] = Field(..., description="Highest-hype moments (up to 3)")
+    top_copypastas: list[CreatorWrappedCopypasta] = Field(..., description="Most-used copypastas (up to 3)")
+    top_emotes: list[CreatorWrappedEmote] = Field(..., description="Most-used emotes (up to 5)")

--- a/backend/stream_sniper/application/creators/wrapped_query.py
+++ b/backend/stream_sniper/application/creators/wrapped_query.py
@@ -1,0 +1,112 @@
+"""Application-owned assembly for the Creator Wrapped period recap.
+
+Mirrors ``scenes/wrapped_query.get_scene_wrapped`` scoped to a single creator: fans out
+to the creator-scoped ``creator_wrapped_gateway`` aggregates (totals, active chatters,
+chatters, emotes) plus the existing scene highlights/copypasta gateways, both of which
+already accept an optional ``creator_id`` filter — no bespoke gateway was needed for
+moments or copypastas. Unlike the scene recap, an unknown creator IS a 404: the caller
+must check ``get_creator_wrapped`` for a :class:`CreatorNotFoundError` before trusting an
+empty-looking recap.
+"""
+
+from ...database.gateways.content.scene_highlights_gateway import select_scene_highlights_db
+from ...database.gateways.content.stream_copypasta_stats_table_gateway import select_scene_copypastas_db
+from ...database.gateways.creators.creator_wrapped_gateway import (
+    select_creator_active_chatters_db,
+    select_creator_wrapped_chatters_db,
+    select_creator_wrapped_emotes_db,
+    select_creator_wrapped_totals_db,
+)
+from ...database.gateways.identity.creator_table_gateway import select_creator_exists_db
+from .analytics_query import CreatorNotFoundError
+from .wrapped_models import (
+    CreatorWrapped,
+    CreatorWrappedChatter,
+    CreatorWrappedCopypasta,
+    CreatorWrappedEmote,
+    CreatorWrappedMoment,
+    CreatorWrappedTotals,
+)
+
+_TOP_CHATTERS = 5
+_TOP_MOMENTS = 3
+_TOP_COPYPASTAS = 3
+_TOP_EMOTES = 5
+
+
+def get_creator_wrapped(creator_id: int, days: int) -> CreatorWrapped:
+    """Assemble the Creator Wrapped recap for one creator over the trailing ``days`` window.
+
+    Raises :class:`CreatorNotFoundError` when ``creator_id`` does not exist (matching
+    ``get_creator_summary``'s contract); an existing creator with no activity in the
+    window still returns 200 with zeroed totals and empty lists, same as the scene recap.
+    """
+    if not select_creator_exists_db(creator_id):
+        raise CreatorNotFoundError
+
+    totals_row = select_creator_wrapped_totals_db(creator_id, days)
+    active_chatters = select_creator_active_chatters_db(creator_id, days)
+    totals = CreatorWrappedTotals(
+        streams=totals_row.streams,
+        hours_streamed=totals_row.hours_streamed,
+        messages=totals_row.messages,
+        active_chatters=active_chatters,
+    )
+
+    chatter_rows, _ = select_creator_wrapped_chatters_db(creator_id, days, _TOP_CHATTERS, 0)
+    top_chatters = [
+        CreatorWrappedChatter(
+            rank=rank,
+            chatter_id=row.chatter_id,
+            nick=row.nick,
+            total_messages=row.total_messages,
+            streams_attended=row.streams_attended,
+        )
+        for rank, row in enumerate(chatter_rows, start=1)
+    ]
+
+    moment_rows, _ = select_scene_highlights_db(days, creator_id, "hype", _TOP_MOMENTS, 0)
+    top_moments = [
+        CreatorWrappedMoment(
+            stream_id=row.stream_id,
+            stream_title=row.stream_title,
+            twitch_id=str(row.twitch_id) if row.twitch_id is not None else None,
+            bucket_minute=row.bucket_minute,
+            offset_seconds=row.offset_seconds,
+            ratio=row.ratio,
+            message_count=row.message_count,
+        )
+        for row in moment_rows
+    ]
+
+    copypasta_rows, _ = select_scene_copypastas_db(days, creator_id, "usage", _TOP_COPYPASTAS, 0)
+    top_copypastas = [
+        CreatorWrappedCopypasta(
+            message_text_id=row.message_text_id,
+            text=row.text,
+            usage_count=row.usage_count,
+            stream_count=row.stream_count,
+        )
+        for row in copypasta_rows
+    ]
+
+    top_emotes = [
+        CreatorWrappedEmote(
+            emote_id=row.emote_id,
+            name=row.name,
+            source=row.source,
+            usage=row.usage,
+            chatter_reach=row.chatter_reach,
+        )
+        for row in select_creator_wrapped_emotes_db(creator_id, days, _TOP_EMOTES)
+    ]
+
+    return CreatorWrapped(
+        creator_id=creator_id,
+        days=days,
+        totals=totals,
+        top_chatters=top_chatters,
+        top_moments=top_moments,
+        top_copypastas=top_copypastas,
+        top_emotes=top_emotes,
+    )

--- a/backend/stream_sniper/database/gateways/analytics/stream_metrics_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/analytics/stream_metrics_table_gateway.py
@@ -16,10 +16,14 @@ from ...core.wire_format import to_char_wire
 def touch_stream_rollup_version_db(cursor: Cursor, connection: Connection, stream_id: int) -> None:
     """Bump one stream's rollup version (``computed_at``) without recomputing its metrics.
 
-    Targeted refreshes (e.g. the post-bot-classification copypasta/scene-event refresh)
-    rewrite rollup-derived data that the API's rollup-versioned cache keys guard. Touching
-    ``computed_at`` rolls every scene/stream cache key derived from it, so superseded
-    entries age out instead of being served for their full TTL. ``now()`` matches the
+    Two callers, one contract — "the version rolls only after every rollup source is
+    current": targeted refreshes (e.g. the post-bot-classification copypasta/scene-event
+    refresh) rewrite rollup-derived data that the API's rollup-versioned cache keys
+    guard, and ``compute_stream_rollup`` runs this as its FINAL phase because TX1
+    already wrote ``computed_at`` before the moment/copypasta phases finished (a cache
+    entry stored in that gap would otherwise pin a mixed generation for its full TTL).
+    Touching ``computed_at`` rolls every scene/stream cache key derived from it, so
+    superseded entries age out instead of being served. ``now()`` matches the
     expression the metrics upsert itself writes.
     """
     cursor.execute(

--- a/backend/stream_sniper/database/gateways/community/chat_companions_gateway.py
+++ b/backend/stream_sniper/database/gateways/community/chat_companions_gateway.py
@@ -1,0 +1,42 @@
+"""Database gateway for a chatter's top "chat companions" (co-attendance ranking).
+
+Self-joins stream_chatter_stats on stream_id to find other chatters who shared streams
+with the given chatter, keyed by the stream_chatter_stats_chatter_idx index. Bots are
+excluded on the companion side (c.is_bot IS NOT TRUE, per creator_overlap's
+convention); the anchor is a single caller-supplied id and is not re-checked here.
+"""
+
+from psycopg2.extensions import cursor as Cursor
+
+from ...core.decorators import with_cursor
+from .records import ChatCompanionRow
+
+
+@with_cursor
+def select_chat_companions_db(
+    cursor: Cursor,
+    chatter_id: int,
+    limit: int = 8,
+) -> list[ChatCompanionRow]:
+    """Top co-chatters ranked by shared-stream count, bot companions excluded.
+
+    :param chatter_id: The chatter whose companions are being looked up.
+    :param limit: Maximum number of companions to return (default 8).
+    :return: ChatCompanionRow records ordered by shared_streams DESC, then nick ASC.
+    """
+    cursor.execute(
+        """
+        SELECT co.chatter_id, c.nick, count(*) AS shared_streams
+        FROM stream_chatter_stats a
+        JOIN stream_chatter_stats co
+            ON co.stream_id = a.stream_id AND co.chatter_id != a.chatter_id
+        JOIN chatter c ON c.id = co.chatter_id
+        WHERE a.chatter_id = %s
+          AND c.is_bot IS NOT TRUE
+        GROUP BY co.chatter_id, c.nick
+        ORDER BY shared_streams DESC, c.nick ASC
+        LIMIT %s
+        """,
+        (chatter_id, limit),
+    )
+    return [ChatCompanionRow(*row) for row in cursor.fetchall()]

--- a/backend/stream_sniper/database/gateways/community/records.py
+++ b/backend/stream_sniper/database/gateways/community/records.py
@@ -46,3 +46,9 @@ class CreatorNeighborRow(NamedTuple):
     display_name: str
     shared_chatters: int
     shared_regulars: int
+
+
+class ChatCompanionRow(NamedTuple):
+    chatter_id: int
+    nick: str
+    shared_streams: int

--- a/backend/stream_sniper/database/gateways/creators/creator_wrapped_gateway.py
+++ b/backend/stream_sniper/database/gateways/creators/creator_wrapped_gateway.py
@@ -1,0 +1,173 @@
+"""Database gateway for the Creator Wrapped period recap's creator-scoped aggregates.
+
+Mirrors the shape of ``content/scene_wrapped_gateway.py`` and
+``creators/scene_chatter_rankings_gateway.py`` but restricted to one creator's streams
+instead of the whole scene. Top moments and top copypastas are NOT duplicated here —
+``select_scene_highlights_db`` and ``select_scene_copypastas_db`` already accept an
+optional ``creator_id`` filter, so the application query reuses them directly.
+
+* ``select_creator_wrapped_totals_db`` — one creator's streams/hours/messages over the
+  window (a single aggregate row; an empty window naturally yields
+  ``streams=0``/``messages=0`` and ``hours_streamed=None``, since ``SUM`` over zero rows
+  is NULL — nullable = unknown, never coalesced to 0).
+* ``select_creator_active_chatters_db`` — distinct human chatters across that creator's
+  streams over the window.
+* ``select_creator_wrapped_chatters_db`` — that creator's top chatters by messages over
+  the window (a page, with a ``has_more`` sentinel like the scene ranking gateway).
+* ``select_creator_wrapped_emotes_db`` — that creator's top emotes by usage over the
+  window.
+"""
+
+from typing import NamedTuple
+
+from psycopg2.extensions import cursor as Cursor
+
+from stream_sniper.database.gateways.content.scene_wrapped_gateway import SceneWrappedEmoteRow
+
+from ...core.decorators import with_cursor
+
+
+class CreatorWrappedTotalsRow(NamedTuple):
+    """One creator's stream/hour/message aggregate over the recap window."""
+
+    streams: int
+    hours_streamed: float | None
+    messages: int
+
+
+class CreatorWrappedChatterRow(NamedTuple):
+    """One ranked chatter within a single creator's window, from ``stream_chatter_stats``."""
+
+    chatter_id: int
+    nick: str
+    total_messages: int
+    streams_attended: int
+
+
+@with_cursor
+def select_creator_wrapped_totals_db(
+    cursor: Cursor,
+    creator_id: int,
+    days: int,
+) -> CreatorWrappedTotalsRow:
+    """Streams/hours/messages for one creator over the trailing ``days`` window.
+
+    Aggregates ``stream`` directly (no GROUP BY — always exactly one row). An unclosed
+    stream contributes 0h via a per-row CASE, matching the scene leaderboard's
+    convention; a creator with zero streams in the window yields ``streams=0``,
+    ``messages=0``, and ``hours_streamed=None`` (SUM over zero rows is NULL).
+    """
+    cursor.execute(
+        """
+        SELECT
+            COUNT(*)::int AS streams,
+            SUM(CASE WHEN s."end" IS NOT NULL
+                     THEN EXTRACT(EPOCH FROM (s."end" - s.start)) ELSE 0 END) / 3600.0 AS hours_streamed,
+            COALESCE(SUM(s.message_count), 0)::bigint AS messages
+        FROM stream s
+        WHERE s.creator_id = %s
+          AND s.start >= (now() AT TIME ZONE 'UTC') - (%s * interval '1 day')
+        """,
+        (creator_id, days),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        raise RuntimeError("creator wrapped totals returned no row")
+    return CreatorWrappedTotalsRow(*row)
+
+
+@with_cursor
+def select_creator_active_chatters_db(
+    cursor: Cursor,
+    creator_id: int,
+    days: int,
+) -> int:
+    """Count of distinct human chatters active across one creator's streams over the window.
+
+    Excludes bots (``chatter.is_bot IS NOT TRUE`` — an unclassified NULL is kept),
+    matching ``select_scene_active_chatters_db``'s convention.
+    """
+    cursor.execute(
+        """
+        SELECT COUNT(DISTINCT scs.chatter_id)
+        FROM stream_chatter_stats scs
+        JOIN stream s ON s.id = scs.stream_id
+        JOIN chatter c ON c.id = scs.chatter_id
+        WHERE s.creator_id = %s
+          AND c.is_bot IS NOT TRUE
+          AND s.start >= (now() AT TIME ZONE 'UTC') - (%s * interval '1 day')
+        """,
+        (creator_id, days),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        raise RuntimeError("creator wrapped active-chatter count returned no row")
+    return int(row[0])
+
+
+@with_cursor
+def select_creator_wrapped_chatters_db(
+    cursor: Cursor,
+    creator_id: int,
+    days: int,
+    limit: int,
+    offset: int,
+) -> tuple[list[CreatorWrappedChatterRow], bool]:
+    """A page of one creator's top chatters by messages over the trailing window.
+
+    Bots are excluded. Fetches ``limit + 1`` rows; the caller receives the first
+    ``limit`` and a boolean overflow flag, matching ``select_scene_chatter_rankings_db``.
+    """
+    cursor.execute(
+        """
+        SELECT
+            scs.chatter_id,
+            c.nick,
+            SUM(scs.message_count)::bigint AS total_messages,
+            COUNT(DISTINCT scs.stream_id)::int AS streams_attended
+        FROM stream_chatter_stats scs
+        JOIN stream s ON s.id = scs.stream_id
+        JOIN chatter c ON c.id = scs.chatter_id
+        WHERE s.creator_id = %s
+          AND c.is_bot IS NOT TRUE
+          AND s.start >= (now() AT TIME ZONE 'UTC') - (%s * interval '1 day')
+        GROUP BY scs.chatter_id, c.nick
+        ORDER BY total_messages DESC, scs.chatter_id ASC
+        LIMIT %s OFFSET %s
+        """,
+        (creator_id, days, limit + 1, offset),
+    )
+    rows = [CreatorWrappedChatterRow(*row) for row in cursor.fetchall()]
+    has_more = len(rows) > limit
+    return rows[:limit], has_more
+
+
+@with_cursor
+def select_creator_wrapped_emotes_db(
+    cursor: Cursor,
+    creator_id: int,
+    days: int,
+    limit: int,
+) -> list[SceneWrappedEmoteRow]:
+    """Top emotes by usage across one creator's streams over the trailing window.
+
+    Same aggregate as ``select_scene_emotes_db`` with a creator filter added; reuses its
+    row shape (emote_id, name, source, usage, chatter_reach).
+    """
+    cursor.execute(
+        """
+        SELECT d.id, d.name, d.source,
+               SUM(ses.usage_count)::bigint   AS usage,
+               SUM(ses.chatter_count)::bigint AS chatter_reach
+        FROM stream_emote_stats ses
+        JOIN stream s ON s.id = ses.stream_id
+        JOIN emote_dictionary d ON d.id = ses.emote_id
+        WHERE s.creator_id = %s
+          AND s.start >= (now() AT TIME ZONE 'UTC') - (%s * interval '1 day')
+        GROUP BY d.id, d.name, d.source
+        ORDER BY usage DESC, d.id ASC
+        LIMIT %s
+        """,
+        (creator_id, days, limit),
+    )
+    return [SceneWrappedEmoteRow(*row) for row in cursor.fetchall()]

--- a/backend/stream_sniper/database/gateways/creators/scene_chatter_rankings_gateway.py
+++ b/backend/stream_sniper/database/gateways/creators/scene_chatter_rankings_gateway.py
@@ -12,6 +12,15 @@ Both paths exclude bots (``chatter.is_bot IS NOT TRUE``), rank by total messages
 creator the chatter sent the most messages to within the same scope — via a
 ``LEFT JOIN LATERAL``. Each query fetches ``limit + 1`` rows so the caller can read
 a ``has_more`` sentinel off the overflow row.
+
+Archetype badges are identity claims, so every input feeding them is account-wide
+regardless of the ranking window: ``first_seen`` (earliest
+``creator_chatter_stats.first_seen_at``) and the ``lifetime_*`` fields (messages,
+streams, creators, and the top channel's messages, all aggregated over
+``creator_chatter_stats``). Only the displayed rank metrics
+(``total_messages``/``streams_attended``/``creators_visited``/``home_*``) are
+window-scoped. Without this split a lifetime loyalist who spread out for one week
+would badge as Wanderer on the 7-day tab — window slices are rankings, not identity.
 """
 
 from typing import NamedTuple
@@ -19,6 +28,7 @@ from typing import NamedTuple
 from psycopg2.extensions import cursor as Cursor
 
 from ...core.decorators import with_cursor
+from ...core.wire_format import to_char_wire
 
 
 class SceneChatterRankRow(NamedTuple):
@@ -27,7 +37,14 @@ class SceneChatterRankRow(NamedTuple):
     ``home_*`` fields are populated from the top creator by messages within the
     same window; they are only ``None`` for the degenerate no-creator case that a
     ``LEFT JOIN LATERAL`` guards against (never happens for a chatter that appears
-    in the aggregate at all).
+    in the aggregate at all). ``first_seen`` is the account-wide earliest
+    first-seen wire timestamp (``None`` = unknown era).
+
+    The ``lifetime_*`` fields are ALWAYS account-wide (identical to the display
+    aggregates on the all-time path; independently aggregated on windowed paths)
+    and exist solely to feed archetype computation — identity badges must not
+    flip with the ranking window. ``lifetime_home_messages`` is the top channel's
+    lifetime message count (``None`` when the chatter has no per-creator rollup).
     """
 
     chatter_id: int
@@ -35,20 +52,26 @@ class SceneChatterRankRow(NamedTuple):
     total_messages: int
     streams_attended: int
     creators_visited: int
+    first_seen: str | None
     home_creator_id: int | None
     home_creator_nick: str | None
     home_creator_display_name: str | None
     home_messages: int | None
+    lifetime_messages: int
+    lifetime_streams: int
+    lifetime_creators: int
+    lifetime_home_messages: int | None
 
 
 # All-time: aggregate the per-creator rollup, then attach each chatter's top creator.
-_ALL_TIME_SQL = """
+_ALL_TIME_SQL = f"""
     WITH agg AS (
         SELECT
             ccs.chatter_id,
             SUM(ccs.total_messages)::bigint AS total_messages,
             SUM(ccs.streams_attended)::int  AS streams_attended,
-            COUNT(DISTINCT ccs.creator_id)::int AS creators_visited
+            COUNT(DISTINCT ccs.creator_id)::int AS creators_visited,
+            MIN(ccs.first_seen_at) AS first_seen_at
         FROM stream_sniper.creator_chatter_stats ccs
         JOIN stream_sniper.chatter c ON c.id = ccs.chatter_id
         WHERE c.is_bot IS NOT TRUE
@@ -62,10 +85,15 @@ _ALL_TIME_SQL = """
         a.total_messages,
         a.streams_attended,
         a.creators_visited,
+        {to_char_wire("a.first_seen_at")},
         home.creator_id,
         home.creator_nick,
         home.creator_display_name,
-        home.messages
+        home.messages,
+        a.total_messages    AS lifetime_messages,
+        a.streams_attended  AS lifetime_streams,
+        a.creators_visited  AS lifetime_creators,
+        home.messages       AS lifetime_home_messages
     FROM agg a
     JOIN stream_sniper.chatter ch ON ch.id = a.chatter_id
     LEFT JOIN LATERAL (
@@ -84,8 +112,11 @@ _ALL_TIME_SQL = """
 """
 
 # Windowed: aggregate the per-stream rollup within the trailing window, then attach
-# the top creator computed over that same window.
-_WINDOWED_SQL = """
+# the top creator computed over that same window plus the account-wide identity
+# aggregates (first-seen and lifetime totals from creator_chatter_stats, never
+# limited to the window — see module docstring). The identity lateral runs only on
+# the <= limit+1 page rows, so it adds one indexed aggregate per returned row.
+_WINDOWED_SQL = f"""
     WITH agg AS (
         SELECT
             scs.chatter_id,
@@ -107,12 +138,27 @@ _WINDOWED_SQL = """
         a.total_messages,
         a.streams_attended,
         a.creators_visited,
+        {to_char_wire("fs.first_seen_at")},
         home.creator_id,
         home.creator_nick,
         home.creator_display_name,
-        home.messages
+        home.messages,
+        COALESCE(fs.lifetime_messages, 0) AS lifetime_messages,
+        COALESCE(fs.lifetime_streams, 0)  AS lifetime_streams,
+        COALESCE(fs.lifetime_creators, 0) AS lifetime_creators,
+        fs.lifetime_home_messages
     FROM agg a
     JOIN stream_sniper.chatter ch ON ch.id = a.chatter_id
+    LEFT JOIN LATERAL (
+        SELECT
+            MIN(ccs.first_seen_at)          AS first_seen_at,
+            SUM(ccs.total_messages)::bigint AS lifetime_messages,
+            SUM(ccs.streams_attended)::int  AS lifetime_streams,
+            COUNT(ccs.creator_id)::int      AS lifetime_creators,
+            MAX(ccs.total_messages)::bigint AS lifetime_home_messages
+        FROM stream_sniper.creator_chatter_stats ccs
+        WHERE ccs.chatter_id = a.chatter_id
+    ) fs ON TRUE
     LEFT JOIN LATERAL (
         SELECT
             s2.creator_id,

--- a/backend/stream_sniper/database/gateways/identity/creator_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/identity/creator_table_gateway.py
@@ -68,6 +68,16 @@ def find_or_insert_creator_id_db(
 
 
 @with_cursor
+def select_creator_exists_db(
+    cursor: Cursor,
+    creator_id: int,
+) -> bool:
+    """Cheap existence check for a creator id, used by 404-on-unknown-creator endpoints."""
+    cursor.execute("SELECT 1 FROM creator WHERE id = %s", (creator_id,))
+    return cursor.fetchone() is not None
+
+
+@with_cursor
 def select_creators_db(
     cursor: Cursor,
 ) -> list[CreatorListRow]:

--- a/backend/tests/unit/analytics/test_rollup_outcomes.py
+++ b/backend/tests/unit/analytics/test_rollup_outcomes.py
@@ -42,6 +42,11 @@ def _install_successful_phases(monkeypatch, calls: list[str]) -> None:
         "recompute_creator_overlap",
         lambda *, blocking: calls.append(f"community_overlap:{blocking}") or True,
     )
+    monkeypatch.setattr(
+        rollup_engine,
+        "touch_stream_rollup_version_db",
+        lambda _stream_id: calls.append("rollup_version_touch"),
+    )
 
 
 def test_complete_rollup_returns_a_checked_success(monkeypatch):
@@ -60,7 +65,12 @@ def test_complete_rollup_returns_a_checked_success(monkeypatch):
         "copypasta_rollup",
         "scene_events",
         "community_overlap",
+        "rollup_version_touch",
     )
+    # The version touch must be the LAST real act: TX1 already bumped computed_at,
+    # so only a final roll of the key evicts cache entries stored while the
+    # moment/copypasta phases were still writing.
+    assert calls[-1] == "rollup_version_touch"
     outcome.require_success()
 
 
@@ -82,6 +92,26 @@ def test_partial_rollup_records_failure_and_cannot_report_success(monkeypatch):
     assert "community_overlap" not in outcome.completed_phases
     with pytest.raises(RollupIncompleteError, match="sql_rollup: database unavailable"):
         outcome.require_success()
+
+
+def test_version_touch_runs_last_even_after_phase_failure(monkeypatch):
+    """A failed phase must not skip the final version touch: TX1 already bumped
+    computed_at, so without the touch a cache entry stored mid-rollup would pin
+    the mixed generation for its full TTL."""
+    calls: list[str] = []
+    monkeypatch.setattr(rollup_engine, "select_stream_creator_id_db", lambda _stream_id: (7,))
+    _install_successful_phases(monkeypatch, calls)
+
+    def fail_copypasta(_stream_id: int) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(rollup_engine, "_compute_and_store_copypasta_rollup", fail_copypasta)
+
+    outcome = rollup_engine.compute_stream_rollup(42, refresh_overlap=False)
+
+    assert outcome.succeeded is False
+    assert "rollup_version_touch" in outcome.completed_phases
+    assert calls[-1] == "rollup_version_touch"
 
 
 def test_lock_skipped_overlap_is_not_reported_as_completed(monkeypatch):

--- a/backend/tests/unit/api/test_chatter_passport.py
+++ b/backend/tests/unit/api/test_chatter_passport.py
@@ -17,6 +17,7 @@ from stream_sniper.application.chatters.passport_models import (
     ChatterPassport,
     PassportArchetype,
     PassportChatter,
+    PassportCompanion,
     PassportDebut,
     PassportHomeChannel,
     PassportLoyalty,
@@ -87,6 +88,10 @@ def _sample_passport() -> ChatterPassport:
         archetypes=[
             PassportArchetype(key="loyalist", label="Loyalist", description="Devoted to one channel."),
         ],
+        companions=[
+            PassportCompanion(chatter_id=3, nick="buddy", shared_streams=9),
+            PassportCompanion(chatter_id=8, nick="pal", shared_streams=4),
+        ],
     )
 
 
@@ -127,6 +132,10 @@ class TestChatterPassportEndpoint:
         assert data["milestones"]["most_active_stream"]["messages"] == 350
         assert data["archetypes"] == [
             {"key": "loyalist", "label": "Loyalist", "description": "Devoted to one channel."}
+        ]
+        assert data["companions"] == [
+            {"chatter_id": 3, "nick": "buddy", "shared_streams": 9},
+            {"chatter_id": 8, "nick": "pal", "shared_streams": 4},
         ]
         mock_query.assert_called_once_with(42)
 
@@ -169,8 +178,9 @@ class TestChatterPassportEndpoint:
         assert data["loyalty"] == []
         assert data["milestones"]["most_active_stream"] is None
         assert data["chatter"]["is_bot"] is None
-        # archetypes defaults to an empty list when none are supplied
+        # archetypes/companions default to an empty list when none are supplied
         assert data["archetypes"] == []
+        assert data["companions"] == []
 
     @patch("stream_sniper.api.features.chatters.chatter_endpoints.scene_rollup_version", return_value="v1")
     @patch("stream_sniper.api.features.chatters.chatter_endpoints.get_cache")

--- a/backend/tests/unit/api/test_creator_wrapped.py
+++ b/backend/tests/unit/api/test_creator_wrapped.py
@@ -1,0 +1,234 @@
+"""Unit tests for the Creator Wrapped recap endpoint (GET /creators/{creator_id}/wrapped).
+
+The recap's data-source gateways are monkeypatched at the application-assembly import
+path (``wrapped_query``); the endpoint's cache and rollup-version probe are patched at the
+endpoint path. Mirrors ``test_scene_wrapped.py``'s style, plus the 404-on-unknown-creator
+case shared with ``test_creator_analytics.py``'s summary suite.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import Mock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stream_sniper.api.error_boundary import UnexpectedExceptionMiddleware
+from stream_sniper.api.features.creators.creator_wrapped_endpoints import router
+from stream_sniper.api.security.rate_limiter import setup_rate_limiting
+from stream_sniper.database.gateways.content.records import SceneCopypastaRow
+from stream_sniper.database.gateways.content.scene_highlights_gateway import SceneHighlightRow
+from stream_sniper.database.gateways.content.scene_wrapped_gateway import SceneWrappedEmoteRow
+from stream_sniper.database.gateways.creators.creator_wrapped_gateway import (
+    CreatorWrappedChatterRow,
+    CreatorWrappedTotalsRow,
+)
+
+_QUERY = "stream_sniper.application.creators.wrapped_query"
+_ENDPOINT = "stream_sniper.api.features.creators.creator_wrapped_endpoints"
+
+
+def _build_app():
+    app = FastAPI()
+    setup_rate_limiting(app)
+    app.add_middleware(UnexpectedExceptionMiddleware)
+    app.include_router(router)
+    return app
+
+
+app = _build_app()
+
+
+def _miss_cache():
+    cache = Mock()
+    cache.generate_key = Mock(side_effect=lambda *a, **k: "key:" + ":".join(str(x) for x in a))
+    cache.get = Mock(return_value=None)
+    cache.set = Mock(return_value=True)
+    cache.delete = Mock(return_value=True)
+    return cache
+
+
+def _chatter_row(chatter_id=1, messages=500):
+    return CreatorWrappedChatterRow(
+        chatter_id=chatter_id,
+        nick=f"chatter{chatter_id}",
+        total_messages=messages,
+        streams_attended=4,
+    )
+
+
+def _highlight_row(stream_id=1, twitch_id=99887766, ratio=4.2):
+    return SceneHighlightRow(
+        stream_id=stream_id,
+        stream_title=f"Stream {stream_id}",
+        twitch_id=twitch_id,
+        creator_id=5,
+        creator_nick="creator5",
+        creator_display_name="Creator 5",
+        bucket_minute="2026-07-17T20:15:00",
+        offset_seconds=915,
+        ratio=ratio,
+        message_count=240,
+        unique_chatters=120,
+        sub_share=0.3,
+        emote_share=0.6,
+        top_phrases=None,
+        sample_messages=None,
+        clip_url=None,
+        review_status=None,
+    )
+
+
+def _copypasta_row(mtid=1, usage=80):
+    return SceneCopypastaRow(
+        message_text_id=mtid,
+        text=f"copypasta {mtid}",
+        usage_count=usage,
+        chatter_appearances=40,
+        stream_count=5,
+        creator_count=1,
+        first_seen="2026-07-10T00:00:00",
+        last_stream_start="2026-07-17T00:00:00",
+    )
+
+
+def _emote_row(emote_id=1, usage=500):
+    return SceneWrappedEmoteRow(
+        emote_id=emote_id,
+        name=f"Emote{emote_id}",
+        source="bttv",
+        usage=usage,
+        chatter_reach=90,
+    )
+
+
+def _patch_query(
+    *,
+    exists=True,
+    totals=CreatorWrappedTotalsRow(0, None, 0),
+    active_chatters=0,
+    chatters=(),
+    moments=(),
+    copypastas=(),
+    emotes=(),
+):
+    """Patch every gateway wrapped_query calls, plus the endpoint cache/version probe."""
+    stack = ExitStack()
+    stack.enter_context(patch(f"{_ENDPOINT}.get_cache", return_value=_miss_cache()))
+    stack.enter_context(patch(f"{_ENDPOINT}.creator_rollup_version", return_value="v1"))
+    stack.enter_context(patch(f"{_QUERY}.select_creator_exists_db", return_value=exists))
+    stack.enter_context(patch(f"{_QUERY}.select_creator_wrapped_totals_db", return_value=totals))
+    stack.enter_context(patch(f"{_QUERY}.select_creator_active_chatters_db", return_value=active_chatters))
+    stack.enter_context(
+        patch(f"{_QUERY}.select_creator_wrapped_chatters_db", return_value=(list(chatters), False))
+    )
+    stack.enter_context(patch(f"{_QUERY}.select_scene_highlights_db", return_value=(list(moments), False)))
+    stack.enter_context(
+        patch(f"{_QUERY}.select_scene_copypastas_db", return_value=(list(copypastas), len(copypastas)))
+    )
+    stack.enter_context(patch(f"{_QUERY}.select_creator_wrapped_emotes_db", return_value=list(emotes)))
+    return stack
+
+
+class TestCreatorWrapped:
+    def test_full_recap_shape_and_defaults(self):
+        with _patch_query(
+            totals=CreatorWrappedTotalsRow(streams=3, hours_streamed=6.0, messages=1000),
+            active_chatters=42,
+            chatters=[_chatter_row(1, 500), _chatter_row(2, 400)],
+            moments=[_highlight_row(1)],
+            copypastas=[_copypasta_row(1)],
+            emotes=[_emote_row(1)],
+        ):
+            with TestClient(app) as client:
+                resp = client.get("/creators/5/wrapped")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["creator_id"] == 5
+        assert data["days"] == 30  # default window
+        assert data["totals"] == {
+            "streams": 3,
+            "hours_streamed": 6.0,
+            "messages": 1000,
+            "active_chatters": 42,
+        }
+        assert [c["rank"] for c in data["top_chatters"]] == [1, 2]
+        assert data["top_chatters"][0]["chatter_id"] == 1
+        assert data["top_moments"][0]["twitch_id"] == "99887766"
+        assert data["top_moments"][0]["ratio"] == 4.2
+        assert data["top_copypastas"][0]["stream_count"] == 5
+        assert data["top_emotes"][0]["usage"] == 500
+
+    def test_forwards_days_and_creator_id_to_the_gateways(self):
+        with _patch_query() as stack:
+            mock_totals = stack.enter_context(
+                patch(
+                    f"{_QUERY}.select_creator_wrapped_totals_db",
+                    return_value=CreatorWrappedTotalsRow(0, None, 0),
+                )
+            )
+            mock_chatters = stack.enter_context(
+                patch(f"{_QUERY}.select_creator_wrapped_chatters_db", return_value=([], False))
+            )
+            with TestClient(app) as client:
+                resp = client.get("/creators/5/wrapped?days=7")
+
+        assert resp.status_code == 200
+        mock_totals.assert_called_once_with(5, 7)
+        mock_chatters.assert_called_once_with(5, 7, 5, 0)
+
+    def test_empty_window_is_zeros_not_error(self):
+        with _patch_query(totals=CreatorWrappedTotalsRow(0, None, 0)):
+            with TestClient(app) as client:
+                resp = client.get("/creators/5/wrapped?days=14")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["totals"] == {
+            "streams": 0,
+            "hours_streamed": None,  # no streamed time -> unknown, not 0
+            "messages": 0,
+            "active_chatters": 0,
+        }
+        assert data["top_chatters"] == []
+        assert data["top_moments"] == []
+        assert data["top_copypastas"] == []
+        assert data["top_emotes"] == []
+
+    def test_unknown_creator_404(self):
+        with _patch_query(exists=False):
+            with TestClient(app) as client:
+                resp = client.get("/creators/404/wrapped")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Creator not found"
+
+    def test_null_moment_twitch_id_and_ratio_survive(self):
+        with _patch_query(moments=[_highlight_row(1, twitch_id=None, ratio=None)]):
+            with TestClient(app) as client:
+                resp = client.get("/creators/5/wrapped")
+
+        assert resp.status_code == 200
+        moment = resp.json()["top_moments"][0]
+        assert moment["twitch_id"] is None
+        assert moment["ratio"] is None
+
+    def test_days_below_min_is_422(self):
+        with TestClient(app) as client:
+            resp = client.get("/creators/5/wrapped?days=6")
+        assert resp.status_code == 422
+
+    def test_days_above_max_is_422(self):
+        with TestClient(app) as client:
+            resp = client.get("/creators/5/wrapped?days=91")
+        assert resp.status_code == 422
+
+    def test_gateway_error_returns_500(self):
+        with patch(f"{_ENDPOINT}.get_cache", return_value=_miss_cache()):
+            with patch(f"{_ENDPOINT}.creator_rollup_version", return_value="v1"):
+                with patch(f"{_QUERY}.select_creator_exists_db", side_effect=Exception("db down")):
+                    with TestClient(app) as client:
+                        resp = client.get("/creators/5/wrapped")
+
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Internal server error"

--- a/backend/tests/unit/api/test_scene_chatter_rankings.py
+++ b/backend/tests/unit/api/test_scene_chatter_rankings.py
@@ -45,17 +45,37 @@ def _hit_cache(payload):
     return cache
 
 
-def _row(chatter_id, nick, total, streams, creators, *, home_id=5, home_msgs=None):
+def _row(
+    chatter_id,
+    nick,
+    total,
+    streams,
+    creators,
+    *,
+    home_id=5,
+    home_msgs=None,
+    first_seen=None,
+    lifetime=None,
+):
+    """``lifetime`` overrides the account-wide archetype aggregates; by default they
+    mirror the window aggregates (the all-time path's real behavior)."""
+    home_messages = home_msgs if home_msgs is not None else total
+    lifetime = lifetime or {}
     return SceneChatterRankRow(
         chatter_id=chatter_id,
         nick=nick,
         total_messages=total,
         streams_attended=streams,
         creators_visited=creators,
+        first_seen=first_seen,
         home_creator_id=home_id,
         home_creator_nick="homie",
         home_creator_display_name="Homie",
-        home_messages=home_msgs if home_msgs is not None else total,
+        home_messages=home_messages,
+        lifetime_messages=lifetime.get("messages", total),
+        lifetime_streams=lifetime.get("streams", streams),
+        lifetime_creators=lifetime.get("creators", creators),
+        lifetime_home_messages=lifetime.get("home_messages", home_messages),
     )
 
 
@@ -155,10 +175,15 @@ class TestChatterRankingsEndpoint:
                     total_messages=0,
                     streams_attended=0,
                     creators_visited=0,
+                    first_seen=None,
                     home_creator_id=None,
                     home_creator_nick=None,
                     home_creator_display_name=None,
                     home_messages=None,
+                    lifetime_messages=0,
+                    lifetime_streams=0,
+                    lifetime_creators=0,
+                    lifetime_home_messages=None,
                 )
             ],
             False,
@@ -219,3 +244,106 @@ class TestChatterRankingsEndpoint:
 
         assert response.status_code == 500
         assert response.json()["detail"] == "Internal server error"
+
+    @patch(_VERSION, return_value="v1")
+    @patch(_CACHE)
+    @patch(_GATEWAY)
+    def test_archetypes_present_for_crafted_row(self, mock_gw, mock_get_cache, _v):
+        # home_share=5000/6000≈0.83 (>=0.70) with streams_attended=40 (>=3) -> loyalist.
+        # 6000/40=150 msgs/stream (>=100) with streams_attended>=3 -> marathoner.
+        # total_messages=6000 (>=5000) -> chatterbox.
+        # first_seen far in the past (>180 days ago, always true) -> veteran.
+        # creators_visited=2 (<5) -> not wanderer.
+        mock_get_cache.return_value = _miss_cache()
+        mock_gw.return_value = (
+            [
+                _row(
+                    1,
+                    "grinder",
+                    6000,
+                    40,
+                    2,
+                    home_msgs=5000,
+                    first_seen="2020-01-01T00:00:00",
+                )
+            ],
+            False,
+        )
+
+        response = TestClient(app).get("/scene/chatter-rankings")
+
+        assert response.status_code == 200
+        keys = [badge["key"] for badge in response.json()["items"][0]["archetypes"]]
+        assert keys == ["loyalist", "marathoner", "chatterbox", "veteran"]
+
+    @patch(_VERSION, return_value="v1")
+    @patch(_CACHE)
+    @patch(_GATEWAY)
+    def test_archetypes_empty_without_home_channel(self, mock_gw, mock_get_cache, _v):
+        mock_get_cache.return_value = _miss_cache()
+        mock_gw.return_value = (
+            [
+                SceneChatterRankRow(
+                    chatter_id=2,
+                    nick="quiet",
+                    total_messages=10,
+                    streams_attended=1,
+                    creators_visited=0,
+                    first_seen=None,
+                    home_creator_id=None,
+                    home_creator_nick=None,
+                    home_creator_display_name=None,
+                    home_messages=None,
+                    lifetime_messages=10,
+                    lifetime_streams=1,
+                    lifetime_creators=0,
+                    lifetime_home_messages=None,
+                )
+            ],
+            False,
+        )
+
+        response = TestClient(app).get("/scene/chatter-rankings")
+
+        assert response.status_code == 200
+        item = response.json()["items"][0]
+        assert item["home_channel"] is None
+        assert item["archetypes"] == []
+
+    @patch(_VERSION, return_value="v1")
+    @patch(_CACHE)
+    @patch(_GATEWAY)
+    def test_archetypes_use_lifetime_not_window_aggregates(self, mock_gw, mock_get_cache, _v):
+        # In-window this chatter binged one channel (900/1000 = 0.90 share, which
+        # would badge loyalist if the window slice fed the computation). Lifetime
+        # they are the opposite: 10k messages spread over 8 creators with a top
+        # channel at 3000/10000 = 0.30 -> wanderer (plus marathoner 10000/80=125,
+        # chatterbox >= 5000, veteran). Badges must follow the lifetime identity.
+        mock_get_cache.return_value = _miss_cache()
+        mock_gw.return_value = (
+            [
+                _row(
+                    7,
+                    "binger",
+                    1000,
+                    5,
+                    1,
+                    home_msgs=900,
+                    first_seen="2020-01-01T00:00:00",
+                    lifetime={"messages": 10000, "streams": 80, "creators": 8, "home_messages": 3000},
+                )
+            ],
+            False,
+        )
+
+        response = TestClient(app).get("/scene/chatter-rankings?window=7")
+
+        assert response.status_code == 200
+        item = response.json()["items"][0]
+        # The displayed metrics stay window-scoped...
+        assert item["total_messages"] == 1000
+        assert item["home_channel"]["share"] == 0.9
+        # ...but the badges are the account-wide identity.
+        keys = [badge["key"] for badge in item["archetypes"]]
+        assert keys == ["wanderer", "marathoner", "chatterbox", "veteran"]
+        assert "loyalist" not in keys

--- a/backend/tests/unit/api/test_scene_wrapped.py
+++ b/backend/tests/unit/api/test_scene_wrapped.py
@@ -71,10 +71,15 @@ def _chatter_row(chatter_id=1, messages=500):
         total_messages=messages,
         streams_attended=4,
         creators_visited=2,
+        first_seen=None,
         home_creator_id=1,
         home_creator_nick="creator1",
         home_creator_display_name="Creator 1",
         home_messages=300,
+        lifetime_messages=messages,
+        lifetime_streams=4,
+        lifetime_creators=2,
+        lifetime_home_messages=300,
     )
 
 

--- a/backend/tests/unit/application/test_chatter_passport_query.py
+++ b/backend/tests/unit/application/test_chatter_passport_query.py
@@ -8,16 +8,18 @@ from stream_sniper.database.gateways.analytics.records import (
     ChatterTimeBoundsRow,
 )
 from stream_sniper.database.gateways.chat.records import ChatterProfileRow
+from stream_sniper.database.gateways.community.records import ChatCompanionRow
 from stream_sniper.database.gateways.creators.records import ChatterLoyaltyRow
 
 
-def _patch(monkeypatch, *, profile, loyalty, debut, active, time_bounds=None) -> None:
+def _patch(monkeypatch, *, profile, loyalty, debut, active, time_bounds=None, companions=None) -> None:
     bounds = time_bounds if time_bounds is not None else ChatterTimeBoundsRow(None, None)
     monkeypatch.setattr(passport_query, "select_chatter_profile_db", lambda _cid: profile)
     monkeypatch.setattr(passport_query, "select_chatter_loyalty_db", lambda _cid: loyalty)
     monkeypatch.setattr(passport_query, "select_chatter_debut_db", lambda _cid: debut)
     monkeypatch.setattr(passport_query, "select_chatter_most_active_stream_db", lambda _cid: active)
     monkeypatch.setattr(passport_query, "select_chatter_message_time_bounds_db", lambda _cid: bounds)
+    monkeypatch.setattr(passport_query, "select_chat_companions_db", lambda _cid: companions or [])
 
 
 def test_unknown_chatter_returns_none(monkeypatch) -> None:
@@ -39,6 +41,10 @@ def test_assembles_totals_loyalty_and_shares(monkeypatch) -> None:
         # Message-time bounds intentionally differ from the loyalty rows' stream-start
         # first/last_seen: totals must reflect MESSAGE times (the debut, not stream start).
         time_bounds=ChatterTimeBoundsRow("2024-01-01T20:00:00", "2024-06-01T13:37:00"),
+        companions=[
+            ChatCompanionRow(chatter_id=3, nick="buddy", shared_streams=9),
+            ChatCompanionRow(chatter_id=8, nick="pal", shared_streams=4),
+        ],
     )
 
     result = get_chatter_passport(42)
@@ -82,6 +88,11 @@ def test_assembles_totals_loyalty_and_shares(monkeypatch) -> None:
     keys = [badge.key for badge in result.archetypes]
     assert keys == ["loyalist", "veteran"]
 
+    # companions preserve gateway order (shared_streams desc) and pass through unchanged
+    assert [c.chatter_id for c in result.companions] == [3, 8]
+    assert result.companions[0].nick == "buddy"
+    assert result.companions[0].shared_streams == 9
+
 
 def test_empty_corpus_yields_zero_share_and_null_milestones(monkeypatch) -> None:
     _patch(
@@ -105,6 +116,8 @@ def test_empty_corpus_yields_zero_share_and_null_milestones(monkeypatch) -> None
     assert result.chatter.is_bot is None
     # No corpus -> no archetypes (empty totals, no home share, no first_seen).
     assert result.archetypes == []
+    # No companions returned by the gateway -> passport surfaces an empty list, not None.
+    assert result.companions == []
 
 
 def test_totals_seen_come_from_message_time_bounds(monkeypatch) -> None:
@@ -127,3 +140,26 @@ def test_totals_seen_come_from_message_time_bounds(monkeypatch) -> None:
     assert result.totals.last_seen == "2024-03-02T02:10:00"
     assert result.chatter.is_bot is True
     assert result.chatter.bot_reason == "known-bot"
+
+
+def test_companions_bot_exclusion_boundary_is_the_gateway(monkeypatch) -> None:
+    """The gateway's SQL excludes bot chatters; the application layer just relays the list.
+
+    A companion list with a bot chatter mixed in would never actually reach this layer
+    (select_chat_companions_db filters ``c.is_bot IS NOT TRUE`` in SQL), so a correctly
+    filtered gateway result is exactly what get_chatter_passport should surface unchanged.
+    """
+    _patch(
+        monkeypatch,
+        profile=ChatterProfileRow(42, "chatty", False, None),
+        loyalty=[],
+        debut=None,
+        active=None,
+        # Simulates the gateway already having excluded a bot co-chatter (e.g. "spambot")
+        # from the raw shared-stream join — only non-bot companions are ever passed in.
+        companions=[ChatCompanionRow(chatter_id=3, nick="buddy", shared_streams=9)],
+    )
+
+    result = get_chatter_passport(42)
+    assert result is not None
+    assert [c.nick for c in result.companions] == ["buddy"]

--- a/backend/tests/unit/application/test_creator_wrapped_query.py
+++ b/backend/tests/unit/application/test_creator_wrapped_query.py
@@ -1,0 +1,156 @@
+"""Unit tests for the Creator Wrapped assembly (get_creator_wrapped).
+
+Gateways are monkeypatched at the ``wrapped_query`` import path; this suite asserts the
+FastAPI-free assembly directly (existence check -> CreatorNotFoundError, totals
+passthrough, top-N truncation and 1-based ranking, empty-window zeros).
+"""
+
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import pytest
+
+from stream_sniper.application.creators.analytics_query import CreatorNotFoundError
+from stream_sniper.application.creators.wrapped_query import get_creator_wrapped
+from stream_sniper.database.gateways.content.records import SceneCopypastaRow
+from stream_sniper.database.gateways.content.scene_highlights_gateway import SceneHighlightRow
+from stream_sniper.database.gateways.content.scene_wrapped_gateway import SceneWrappedEmoteRow
+from stream_sniper.database.gateways.creators.creator_wrapped_gateway import (
+    CreatorWrappedChatterRow,
+    CreatorWrappedTotalsRow,
+)
+
+_QUERY = "stream_sniper.application.creators.wrapped_query"
+
+
+def _totals(streams=3, hours=6.0, messages=1000):
+    return CreatorWrappedTotalsRow(streams=streams, hours_streamed=hours, messages=messages)
+
+
+def _chatter(chatter_id, messages=100):
+    return CreatorWrappedChatterRow(
+        chatter_id=chatter_id,
+        nick=f"ch{chatter_id}",
+        total_messages=messages,
+        streams_attended=2,
+    )
+
+
+def _highlight():
+    return SceneHighlightRow(
+        stream_id=1,
+        stream_title="S1",
+        twitch_id=42,
+        creator_id=5,
+        creator_nick="c5",
+        creator_display_name="C5",
+        bucket_minute="2026-07-17T20:00:00",
+        offset_seconds=10,
+        ratio=3.0,
+        message_count=100,
+        unique_chatters=40,
+        sub_share=None,
+        emote_share=None,
+        top_phrases=None,
+        sample_messages=None,
+        clip_url=None,
+        review_status=None,
+    )
+
+
+def _copypasta():
+    return SceneCopypastaRow(1, "text", 50, 20, 3, 1, "2026-07-10T00:00:00", "2026-07-17T00:00:00")
+
+
+def _emote():
+    return SceneWrappedEmoteRow(1, "PogChamp", "twitch", 300, 60)
+
+
+def _patch(*, exists=True, **overrides):
+    defaults = {
+        "select_creator_wrapped_totals_db": _totals(),
+        "select_creator_active_chatters_db": 0,
+        "select_creator_wrapped_chatters_db": ([], False),
+        "select_scene_highlights_db": ([], False),
+        "select_scene_copypastas_db": ([], 0),
+        "select_creator_wrapped_emotes_db": [],
+    }
+    defaults.update(overrides)
+    stack = ExitStack()
+    stack.enter_context(patch(f"{_QUERY}.select_creator_exists_db", return_value=exists))
+    for name, value in defaults.items():
+        stack.enter_context(patch(f"{_QUERY}.{name}", return_value=value))
+    return stack
+
+
+def test_unknown_creator_raises_not_found():
+    with _patch(exists=False):
+        with pytest.raises(CreatorNotFoundError):
+            get_creator_wrapped(999, 30)
+
+
+def test_totals_and_active_chatters_passthrough():
+    with _patch(
+        select_creator_wrapped_totals_db=_totals(streams=5, hours=12.0, messages=2000),
+        select_creator_active_chatters_db=42,
+    ):
+        wrapped = get_creator_wrapped(5, 30)
+
+    assert wrapped.creator_id == 5
+    assert wrapped.days == 30
+    assert wrapped.totals.streams == 5
+    assert wrapped.totals.hours_streamed == 12.0
+    assert wrapped.totals.messages == 2000
+    assert wrapped.totals.active_chatters == 42
+
+
+def test_empty_window_hours_is_unknown_not_zero():
+    with _patch(select_creator_wrapped_totals_db=CreatorWrappedTotalsRow(0, None, 0)):
+        wrapped = get_creator_wrapped(5, 7)
+
+    assert wrapped.totals.streams == 0
+    assert wrapped.totals.hours_streamed is None
+    assert wrapped.totals.messages == 0
+    assert wrapped.top_chatters == []
+    assert wrapped.top_moments == []
+    assert wrapped.top_copypastas == []
+    assert wrapped.top_emotes == []
+
+
+def test_top_chatters_ranked_and_truncated_to_five():
+    with _patch(
+        select_creator_wrapped_chatters_db=([_chatter(i, messages=100 - i) for i in range(1, 6)], False)
+    ):
+        wrapped = get_creator_wrapped(5, 30)
+
+    assert [c.rank for c in wrapped.top_chatters] == [1, 2, 3, 4, 5]
+    assert wrapped.top_chatters[0].chatter_id == 1
+
+
+def test_moment_twitch_id_stringified_and_copypasta_emote_flow():
+    with _patch(
+        select_scene_highlights_db=([_highlight()], False),
+        select_scene_copypastas_db=([_copypasta()], 1),
+        select_creator_wrapped_emotes_db=[_emote()],
+    ):
+        wrapped = get_creator_wrapped(5, 30)
+
+    assert wrapped.top_moments[0].twitch_id == "42"
+    assert wrapped.top_moments[0].ratio == 3.0
+    assert wrapped.top_copypastas[0].message_text_id == 1
+    assert wrapped.top_copypastas[0].stream_count == 3
+    assert wrapped.top_emotes[0].name == "PogChamp"
+
+
+def test_moment_and_copypasta_gateways_scoped_to_creator():
+    with _patch() as stack:
+        mock_highlights = stack.enter_context(
+            patch(f"{_QUERY}.select_scene_highlights_db", return_value=([], False))
+        )
+        mock_copypastas = stack.enter_context(
+            patch(f"{_QUERY}.select_scene_copypastas_db", return_value=([], 0))
+        )
+        get_creator_wrapped(5, 14)
+
+    mock_highlights.assert_called_once_with(14, 5, "hype", 3, 0)
+    mock_copypastas.assert_called_once_with(14, 5, "usage", 3, 0)

--- a/backend/tests/unit/application/test_wrapped_query.py
+++ b/backend/tests/unit/application/test_wrapped_query.py
@@ -43,10 +43,15 @@ def _chatter(chatter_id):
         total_messages=100,
         streams_attended=2,
         creators_visited=1,
+        first_seen=None,
         home_creator_id=1,
         home_creator_nick="c1",
         home_creator_display_name="C1",
         home_messages=50,
+        lifetime_messages=100,
+        lifetime_streams=2,
+        lifetime_creators=1,
+        lifetime_home_messages=50,
     )
 
 

--- a/frontend/app/(app)/creator/[id]/wrapped/page.tsx
+++ b/frontend/app/(app)/creator/[id]/wrapped/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+import { use } from 'react'
+import CreatorWrapped from '@/views/creator/CreatorWrapped'
+
+export default function CreatorWrappedPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params)
+  return <CreatorWrapped creatorId={Number(id)} />
+}

--- a/frontend/app/(app)/creator/[id]/wrapped/page.tsx
+++ b/frontend/app/(app)/creator/[id]/wrapped/page.tsx
@@ -1,8 +1,24 @@
-'use client'
-import { use } from 'react'
+import { notFound } from 'next/navigation'
 import CreatorWrapped from '@/views/creator/CreatorWrapped'
 
-export default function CreatorWrappedPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = use(params)
-  return <CreatorWrapped creatorId={Number(id)} />
+// Server component on purpose (mirrors stream/[id]): the id is validated at the
+// route boundary so /creator/not-a-number/wrapped 404s instead of rendering a
+// plausible-looking "Nothing to wrap yet" empty recap. The view stays client.
+
+type PageProps = { params: Promise<{ id: string }> }
+
+const parseCreatorId = (raw: string): number | null => {
+  const id = Number(raw)
+  return Number.isSafeInteger(id) && id > 0 ? id : null
+}
+
+export default async function CreatorWrappedPage({ params }: PageProps) {
+  const { id } = await params
+  const creatorId = parseCreatorId(id)
+
+  if (creatorId == null) {
+    notFound()
+  }
+
+  return <CreatorWrapped creatorId={creatorId} />
 }

--- a/frontend/components/creator/CreatorDossierOverview.jsx
+++ b/frontend/components/creator/CreatorDossierOverview.jsx
@@ -30,6 +30,9 @@ const CreatorDossierOverview = ({ creator, creatorId }) => {
                     </div>
                 </div>
                 <div className="d-flex gap-2">
+                    <Link className="btn btn-outline-primary btn-sm" href={`/creator/${creatorId}/wrapped`}>
+                        Wrapped
+                    </Link>
                     <Link className="btn btn-outline-primary btn-sm" href={`/movement?creator=${creatorId}`}>
                         Audience movement
                     </Link>

--- a/frontend/components/creator/CreatorWrappedRecap.tsx
+++ b/frontend/components/creator/CreatorWrappedRecap.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import Link from 'next/link'
+import { formatCompactNumber, magnitudeBarWidth } from '@/utils/numberUtils'
+import StatusChip from '@/components/common/StatusChip'
+import WrappedSection from '@/components/scene/WrappedSection'
+import type { CreatorWrapped } from '@/hooks/creator/useCreatorWrappedQuery'
+
+/** Compact count, or an em-dash when the metric is unknown (null). */
+const compactOrDash = (value: number | null): string => (
+    value == null ? '—' : formatCompactNumber(value)
+)
+
+/**
+ * One creator's version of the Scene Wrapped recap layout. Reuses `WrappedSection`
+ * and the `.stat-grid` / `.rank-list` / `.wrapped-moments` / `.wrapped-pastas` styling
+ * from the scene recap rather than forking them; there is no top-creators table or
+ * notable-events timeline here (both are scene-wide, not single-creator concepts), and
+ * the chatter/moment/copypasta rows drop the fields that would be constant for one
+ * creator (home channel, creator label, channel count).
+ */
+const CreatorWrappedRecap = ({ wrapped }: { wrapped: CreatorWrapped }) => {
+    const {
+        totals, topChatters, topMoments, topCopypastas, topEmotes,
+    } = wrapped
+
+    const topChatterMessages = topChatters.reduce((max, row) => Math.max(max, row.totalMessages), 0)
+    const topEmoteUsage = topEmotes.reduce((max, row) => Math.max(max, row.usage), 0)
+
+    return (
+        <div className="wrapped-flow">
+            <WrappedSection label="The window, in numbers">
+                <div className="stat-grid">
+                    <div className="stat-tile">
+                        <div className="stat-label">Messages</div>
+                        <div className="stat-value text-phosphor">{formatCompactNumber(totals.messages)}</div>
+                    </div>
+                    <div className="stat-tile">
+                        <div className="stat-label">Streams</div>
+                        <div className="stat-value">{formatCompactNumber(totals.streams)}</div>
+                    </div>
+                    <div className="stat-tile">
+                        <div className="stat-label">Hours</div>
+                        <div className="stat-value">{compactOrDash(totals.hoursStreamed)}</div>
+                    </div>
+                    <div className="stat-tile">
+                        <div className="stat-label">Chatters</div>
+                        <div className="stat-value">{formatCompactNumber(totals.activeChatters)}</div>
+                    </div>
+                </div>
+            </WrappedSection>
+
+            {topChatters.length > 0 ? (
+                <WrappedSection label="Top chatters">
+                    <ol className="rank-list wrapped-rank-list">
+                        {topChatters.map(chatter => (
+                            <li key={chatter.chatterId}>
+                                <span className="rank">{String(chatter.rank).padStart(2, '0')}</span>
+                                <Link className="nick" href={`/chatter/${chatter.chatterId}`}>{chatter.nick}</Link>
+                                <span className="count">
+                                    {formatCompactNumber(chatter.totalMessages)}
+                                    <span className="data-bar" aria-hidden="true">
+                                        <span
+                                            className="data-bar-fill"
+                                            style={{ width: `${magnitudeBarWidth(chatter.totalMessages, topChatterMessages)}%` }}
+                                        />
+                                    </span>
+                                </span>
+                            </li>
+                        ))}
+                    </ol>
+                </WrappedSection>
+            ) : null}
+
+            {topMoments.length > 0 ? (
+                <WrappedSection label="Biggest moments">
+                    <div className="wrapped-moments">
+                        {/* (streamId, bucketMinute) is the moment's real primary key — one
+                            dominant stream can own several top moments, so streamId alone
+                            would collide as a list key. */}
+                        {topMoments.map(moment => (
+                            <article
+                                className="card card-hud wrapped-moment"
+                                key={`${moment.streamId}-${moment.bucketMinute}`}
+                            >
+                                <header className="wrapped-moment-head">
+                                    <Link
+                                        className="wrapped-moment-title"
+                                        href={`/stream/${moment.streamId}`}
+                                        title={moment.streamTitle}
+                                    >
+                                        {moment.streamTitle}
+                                    </Link>
+                                    {moment.ratio != null ? (
+                                        <span
+                                            className="wrapped-moment-hype text-phosphor mono"
+                                            title="Chat hype multiplier versus the stream baseline"
+                                        >
+                                            &times;{moment.ratio.toFixed(1)}
+                                        </span>
+                                    ) : null}
+                                </header>
+                                <span className="wrapped-moment-count mono">
+                                    {formatCompactNumber(moment.messageCount)}
+                                    <span className="wrapped-moment-unit"> msgs</span>
+                                </span>
+                            </article>
+                        ))}
+                    </div>
+                </WrappedSection>
+            ) : null}
+
+            {topCopypastas.length > 0 ? (
+                <WrappedSection label="Top copypastas">
+                    <ul className="wrapped-pastas">
+                        {topCopypastas.map(pasta => (
+                            <li className="wrapped-pasta" key={pasta.messageTextId}>
+                                <Link className="wrapped-pasta-text" href={`/copypasta/${pasta.messageTextId}`} title={pasta.text}>
+                                    {pasta.text}
+                                </Link>
+                                <span className="pasta-chips">
+                                    <span className="pasta-chip">
+                                        used
+                                        <span className="pasta-chip-unit">&times;{formatCompactNumber(pasta.usageCount)}</span>
+                                    </span>
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                </WrappedSection>
+            ) : null}
+
+            {topEmotes.length > 0 ? (
+                <WrappedSection label="Top emotes">
+                    <ol className="rank-list wrapped-emotes">
+                        {topEmotes.map((emote, index) => (
+                            <li key={emote.emoteId}>
+                                <span className="rank">{String(index + 1).padStart(2, '0')}</span>
+                                <span className="nick">{emote.name}</span>
+                                <StatusChip variant="neutral" className="wrapped-emote-source">{emote.source}</StatusChip>
+                                <span className="count">
+                                    {formatCompactNumber(emote.usage)}
+                                    <span className="data-bar" aria-hidden="true">
+                                        <span
+                                            className="data-bar-fill"
+                                            style={{ width: `${magnitudeBarWidth(emote.usage, topEmoteUsage)}%` }}
+                                        />
+                                    </span>
+                                </span>
+                            </li>
+                        ))}
+                    </ol>
+                </WrappedSection>
+            ) : null}
+        </div>
+    )
+}
+
+export default CreatorWrappedRecap

--- a/frontend/components/scene/RankingsTable.tsx
+++ b/frontend/components/scene/RankingsTable.tsx
@@ -4,12 +4,19 @@ import Link from 'next/link'
 import { Card, Table } from 'react-bootstrap'
 import { formatCompactNumber, magnitudeBarWidth } from '@/utils/numberUtils'
 import type { RankingsRow } from '@/hooks/scene/useSceneRankingsQueries'
+import ArchetypeBadges from '@/components/chatter/ArchetypeBadges'
 
 interface RankingsTableProps {
     rows: RankingsRow[]
     hasMore: boolean
     isFetchingMore: boolean
     onLoadMore: () => void
+    /**
+     * Shown as a single message row instead of the (empty) row list when
+     * client-side archetype filters have hidden every loaded row. Load more
+     * still renders below so more rows remain reachable.
+     */
+    filterEmptyMessage?: string
 }
 
 /**
@@ -18,7 +25,7 @@ interface RankingsTableProps {
  * leading row so relative volume reads at a glance.
  */
 const RankingsTable = ({
-    rows, hasMore, isFetchingMore, onLoadMore,
+    rows, hasMore, isFetchingMore, onLoadMore, filterEmptyMessage,
 }: RankingsTableProps) => {
     const topMessages = rows.reduce((max, row) => Math.max(max, row.totalMessages), 0)
 
@@ -39,13 +46,24 @@ const RankingsTable = ({
                                 </tr>
                             </thead>
                             <tbody>
-                                {rows.map(row => (
+                                {rows.length === 0 && filterEmptyMessage ? (
+                                    <tr>
+                                        <td colSpan={6} className="rankings-filter-empty text-center">
+                                            {filterEmptyMessage}
+                                        </td>
+                                    </tr>
+                                ) : rows.map(row => (
                                     <tr key={row.chatterId}>
                                         <td className="rank-num">{String(row.rank).padStart(2, '0')}</td>
                                         <td>
                                             <Link className="rankings-nick" href={`/chatter/${row.chatterId}`}>
                                                 {row.nick}
                                             </Link>
+                                            {row.archetypes.length > 0 ? (
+                                                <div className="rankings-archetypes">
+                                                    <ArchetypeBadges archetypes={row.archetypes} />
+                                                </div>
+                                            ) : null}
                                         </td>
                                         <td className="rankings-messages text-end">
                                             <span className="rankings-messages-value mono">

--- a/frontend/e2e/creator-wrapped.spec.ts
+++ b/frontend/e2e/creator-wrapped.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test, type Route } from '@playwright/test'
+
+const json = (route: Route, body: unknown, status = 200) => route.fulfill({
+  status,
+  contentType: 'application/json',
+  body: JSON.stringify(body),
+})
+
+const unexpected = (route: Route, pathname: string) => json(
+  route,
+  { detail: `Unexpected smoke request: ${route.request().method()} ${pathname}` },
+  500,
+)
+
+const wrappedBody = (days: number) => ({
+  creator_id: 71,
+  days,
+  totals: {
+    streams: 12,
+    hours_streamed: 48.5,
+    messages: 40000,
+    active_chatters: 320,
+  },
+  top_chatters: [{
+    rank: 1,
+    chatter_id: 301,
+    nick: 'chatterOne',
+    total_messages: 5000,
+    streams_attended: 12,
+  }],
+  top_moments: [{
+    stream_id: 501,
+    stream_title: 'PixelKobra plays ranked',
+    twitch_id: 'vod-501',
+    bucket_minute: '2026-07-14T20:15:00Z',
+    offset_seconds: 900,
+    ratio: 4.2,
+    message_count: 210,
+  }],
+  top_copypastas: [{
+    message_text_id: 9001,
+    text: 'OMEGALUL nice job chat',
+    usage_count: 340,
+    stream_count: 8,
+  }],
+  top_emotes: [{
+    emote_id: 42,
+    name: 'PogChamp',
+    source: 'twitch',
+    usage: 900,
+    chatter_reach: 210,
+  }],
+})
+
+test('creator wrapped: renders the recap, and the window pill re-queries', async ({ page }) => {
+  const requestedDays: string[] = []
+
+  await page.route('**/api/**', async (route) => {
+    const { pathname, searchParams } = new URL(route.request().url())
+    if (pathname !== '/api/creators/71/wrapped') return unexpected(route, pathname)
+    const days = searchParams.get('days') ?? ''
+    requestedDays.push(days)
+    if (days === '30' || days === '7') return json(route, wrappedBody(Number(days)))
+    return unexpected(route, pathname)
+  })
+
+  await page.goto('/creator/71/wrapped')
+  await expect(page.getByRole('heading', { name: 'Creator Wrapped' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'chatterOne' })).toBeVisible()
+  await expect(page.getByText('OMEGALUL nice job chat')).toBeVisible()
+  await expect(page.getByText('PogChamp')).toBeVisible()
+
+  const sevenDays = page.getByRole('button', { name: '7 days' })
+  await expect(sevenDays).toHaveAttribute('aria-pressed', 'false')
+  await sevenDays.click()
+  await expect(sevenDays).toHaveAttribute('aria-pressed', 'true')
+
+  await expect.poll(() => requestedDays).toEqual(['30', '7'])
+})
+
+test('creator wrapped: an unparseable creator id 404s instead of faking an empty recap', async ({ page }) => {
+  let apiRequests = 0
+  await page.route('**/api/**', async (route) => {
+    apiRequests += 1
+    return unexpected(route, new URL(route.request().url()).pathname)
+  })
+
+  await page.goto('/creator/not-a-number/wrapped')
+
+  await expect(page.getByText('404 — Target not found')).toBeVisible()
+  await expect(page.getByText('Nothing to wrap yet')).not.toBeVisible()
+  expect(apiRequests).toBe(0)
+})

--- a/frontend/e2e/scene-surfaces.spec.ts
+++ b/frontend/e2e/scene-surfaces.spec.ts
@@ -134,7 +134,12 @@ test('highlights: paginates, then window and sort pills re-query and reset the w
   ])
 })
 
-const rankingRow = (rank: number, chatterId: number, nick: string) => ({
+const rankingRow = (
+  rank: number,
+  chatterId: number,
+  nick: string,
+  archetypes: Array<{ key: string, label: string }> = [],
+) => ({
   rank,
   chatter_id: chatterId,
   nick,
@@ -148,6 +153,11 @@ const rankingRow = (rank: number, chatterId: number, nick: string) => ({
     messages: 3000,
     share: 0.6,
   },
+  archetypes: archetypes.map(({ key, label }) => ({
+    key,
+    label,
+    description: `${label} badge`,
+  })),
 })
 
 test('rankings: paginates, then the window pill re-queries and resets the table', async ({ page }) => {
@@ -170,7 +180,7 @@ test('rankings: paginates, then the window pill re-queries and resets the table'
       return json(route, {
         window: windowKey,
         has_more: true,
-        items: [rankingRow(1, 301, 'chatterOne')],
+        items: [rankingRow(1, 301, 'chatterOne', [{ key: 'loyalist', label: 'Loyalist' }])],
       })
     }
     if (windowKey === 'all') {
@@ -198,6 +208,23 @@ test('rankings: paginates, then the window pill re-queries and resets the table'
   await page.getByRole('button', { name: 'Load more' }).click()
   await expect(page.getByRole('link', { name: 'chatterTwo' })).toBeVisible()
   await expect(page.getByRole('button', { name: 'Load more' })).not.toBeVisible()
+
+  // Archetype filter chip: any-of, client-side only — toggling re-filters the
+  // already-loaded rows with no extra network request (chatterOne is a
+  // Loyalist, chatterTwo carries no badges).
+  const loyalistChip = page.getByRole('button', { name: 'Loyalist' })
+  await expect(loyalistChip).toHaveAttribute('aria-pressed', 'false')
+  await loyalistChip.click()
+  await expect(loyalistChip).toHaveAttribute('aria-pressed', 'true')
+  await expect(page.getByRole('link', { name: 'chatterOne' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'chatterTwo' })).not.toBeVisible()
+  expect(calls).toHaveLength(2)
+
+  // Clearing the chip restores both loaded rows, still with no new request.
+  await loyalistChip.click()
+  await expect(loyalistChip).toHaveAttribute('aria-pressed', 'false')
+  await expect(page.getByRole('link', { name: 'chatterTwo' })).toBeVisible()
+  expect(calls).toHaveLength(2)
 
   // Re-clicking the ACTIVE pill is a no-op: loaded pages survive, no request fires.
   await page.getByRole('button', { name: 'All time' }).click()

--- a/frontend/hooks/chatter/useChatterPassportQuery.ts
+++ b/frontend/hooks/chatter/useChatterPassportQuery.ts
@@ -42,6 +42,12 @@ export interface PassportMostActiveStream {
     messages: number
 }
 
+export interface PassportCompanion {
+    chatterId: number
+    nick: string
+    sharedStreams: number
+}
+
 export interface ChatterPassport {
     chatter: {
         id: number
@@ -63,6 +69,7 @@ export interface ChatterPassport {
         mostActiveStream: PassportMostActiveStream | null
     }
     archetypes: Array<{ key: string, label: string, description: string }>
+    companions: PassportCompanion[]
 }
 
 /**
@@ -116,6 +123,16 @@ const mapLoyaltyRow = (raw: unknown, index: number): PassportLoyaltyRow => {
     }
 }
 
+const mapCompanion = (raw: unknown, index: number): PassportCompanion => {
+    const label = `chatter passport.companions[${index}]`
+    const companion = requireRecord(raw, label)
+    return {
+        chatterId: requireFiniteNumberField(companion, 'chatter_id', label),
+        nick: requireStringField(companion, 'nick', label),
+        sharedStreams: requireFiniteNumberField(companion, 'shared_streams', label),
+    }
+}
+
 const mapMostActiveStream = (raw: unknown): PassportMostActiveStream | null => {
     if (raw === null) return null
     const label = 'chatter passport.milestones.most_active_stream'
@@ -163,6 +180,7 @@ export const mapChatterPassport = (value: unknown): ChatterPassport => {
                 description: requireStringField(badge, 'description', label),
             }
         }),
+        companions: requireArrayField(root, 'companions', 'chatter passport').map(mapCompanion),
     }
 }
 

--- a/frontend/hooks/creator/useCreatorWrappedQuery.ts
+++ b/frontend/hooks/creator/useCreatorWrappedQuery.ts
@@ -163,5 +163,8 @@ export const useCreatorWrapped = (
     ...options,
     queryKey: creatorWrappedKeys.detail(creatorId, days),
     queryFn: async () => mapCreatorWrapped((await retrieveCreatorWrapped(creatorId, days)).data),
-    enabled: Boolean(creatorId) && enabled,
+    // Positive safe integer, not just truthy: the route boundary already 404s
+    // invalid segments, but a fractional/NaN id reaching here must never fire
+    // a request that can only produce a misleading generic API error.
+    enabled: Number.isSafeInteger(creatorId) && creatorId > 0 && enabled,
 })

--- a/frontend/hooks/creator/useCreatorWrappedQuery.ts
+++ b/frontend/hooks/creator/useCreatorWrappedQuery.ts
@@ -1,0 +1,167 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import { retrieveCreatorWrapped } from '@/lib/api/creators'
+import {
+    requireArrayField,
+    requireFiniteNumberField,
+    requireNullableFiniteNumberField,
+    requireNullableStringField,
+    requireRecord,
+    requireStringField,
+} from '@/lib/api/contractGuards'
+
+/** One creator's totals for the recap window. */
+export interface CreatorWrappedTotals {
+    streams: number
+    /** Total streamed hours, or null when uptime is unknown for the window. */
+    hoursStreamed: number | null
+    messages: number
+    activeChatters: number
+}
+
+/** One ranked chatter in the recap. */
+export interface CreatorWrappedChatter {
+    rank: number
+    chatterId: number
+    nick: string
+    totalMessages: number
+    streamsAttended: number
+}
+
+/** One peak chat moment in the recap. */
+export interface CreatorWrappedMoment {
+    streamId: number
+    streamTitle: string
+    twitchId: string | null
+    bucketMinute: string
+    offsetSeconds: number
+    /** Chat-hype multiplier vs. the stream baseline, or null when unavailable. */
+    ratio: number | null
+    messageCount: number
+}
+
+/** One trending copypasta in the recap. */
+export interface CreatorWrappedCopypasta {
+    messageTextId: number
+    text: string
+    usageCount: number
+    streamCount: number
+}
+
+/** One trending emote in the recap. */
+export interface CreatorWrappedEmote {
+    emoteId: number
+    name: string
+    source: string
+    usage: number
+    chatterReach: number
+}
+
+/** Camel-cased view model for `GET /creators/{creatorId}/wrapped`. */
+export interface CreatorWrapped {
+    creatorId: number
+    days: number
+    totals: CreatorWrappedTotals
+    topChatters: CreatorWrappedChatter[]
+    topMoments: CreatorWrappedMoment[]
+    topCopypastas: CreatorWrappedCopypasta[]
+    topEmotes: CreatorWrappedEmote[]
+}
+
+const mapTotals = (raw: unknown): CreatorWrappedTotals => {
+    const label = 'creator wrapped.totals'
+    const totals = requireRecord(raw, label)
+    return {
+        streams: requireFiniteNumberField(totals, 'streams', label),
+        hoursStreamed: requireNullableFiniteNumberField(totals, 'hours_streamed', label),
+        messages: requireFiniteNumberField(totals, 'messages', label),
+        activeChatters: requireFiniteNumberField(totals, 'active_chatters', label),
+    }
+}
+
+/** Validate the wrapped envelope at the boundary, then project the view model. */
+export const mapCreatorWrapped = (value: unknown): CreatorWrapped => {
+    const root = requireRecord(value, 'creator wrapped')
+    return {
+        creatorId: requireFiniteNumberField(root, 'creator_id', 'creator wrapped'),
+        days: requireFiniteNumberField(root, 'days', 'creator wrapped'),
+        totals: mapTotals(root.totals),
+        topChatters: requireArrayField(root, 'top_chatters', 'creator wrapped').map((raw, index) => {
+            const label = `creator wrapped.top_chatters[${index}]`
+            const row = requireRecord(raw, label)
+            return {
+                rank: requireFiniteNumberField(row, 'rank', label),
+                chatterId: requireFiniteNumberField(row, 'chatter_id', label),
+                nick: requireStringField(row, 'nick', label),
+                totalMessages: requireFiniteNumberField(row, 'total_messages', label),
+                streamsAttended: requireFiniteNumberField(row, 'streams_attended', label),
+            }
+        }),
+        topMoments: requireArrayField(root, 'top_moments', 'creator wrapped').map((raw, index) => {
+            const label = `creator wrapped.top_moments[${index}]`
+            const row = requireRecord(raw, label)
+            return {
+                streamId: requireFiniteNumberField(row, 'stream_id', label),
+                streamTitle: requireStringField(row, 'stream_title', label),
+                twitchId: requireNullableStringField(row, 'twitch_id', label),
+                bucketMinute: requireStringField(row, 'bucket_minute', label),
+                offsetSeconds: requireFiniteNumberField(row, 'offset_seconds', label),
+                ratio: requireNullableFiniteNumberField(row, 'ratio', label),
+                messageCount: requireFiniteNumberField(row, 'message_count', label),
+            }
+        }),
+        topCopypastas: requireArrayField(root, 'top_copypastas', 'creator wrapped').map((raw, index) => {
+            const label = `creator wrapped.top_copypastas[${index}]`
+            const row = requireRecord(raw, label)
+            return {
+                messageTextId: requireFiniteNumberField(row, 'message_text_id', label),
+                text: requireStringField(row, 'text', label),
+                usageCount: requireFiniteNumberField(row, 'usage_count', label),
+                streamCount: requireFiniteNumberField(row, 'stream_count', label),
+            }
+        }),
+        topEmotes: requireArrayField(root, 'top_emotes', 'creator wrapped').map((raw, index) => {
+            const label = `creator wrapped.top_emotes[${index}]`
+            const row = requireRecord(raw, label)
+            return {
+                emoteId: requireFiniteNumberField(row, 'emote_id', label),
+                name: requireStringField(row, 'name', label),
+                source: requireStringField(row, 'source', label),
+                usage: requireFiniteNumberField(row, 'usage', label),
+                chatterReach: requireFiniteNumberField(row, 'chatter_reach', label),
+            }
+        }),
+    }
+}
+
+/**
+ * A recap is "empty" only when every ranked list is empty. Totals can still be
+ * zero-valued; the all-empty case is what the view collapses to one EmptyState.
+ */
+export const isCreatorWrappedEmpty = (wrapped: CreatorWrapped): boolean => (
+    wrapped.topChatters.length === 0
+    && wrapped.topMoments.length === 0
+    && wrapped.topCopypastas.length === 0
+    && wrapped.topEmotes.length === 0
+)
+
+export const creatorWrappedKeys = {
+    all: ['creator-wrapped'] as const,
+    detail: (creatorId: number, days: number) => [...creatorWrappedKeys.all, { creatorId, days }] as const,
+}
+
+type CreatorWrappedQueryOptions = Omit<
+    UseQueryOptions<CreatorWrapped, Error, CreatorWrapped, readonly unknown[]>,
+    'queryKey' | 'queryFn'
+> & { enabled?: boolean }
+
+/** Fetch one creator's recap for a rolling window (default 30 days). */
+export const useCreatorWrapped = (
+    creatorId: number,
+    days = 30,
+    { enabled = true, ...options }: CreatorWrappedQueryOptions = {},
+) => useQuery({
+    ...options,
+    queryKey: creatorWrappedKeys.detail(creatorId, days),
+    queryFn: async () => mapCreatorWrapped((await retrieveCreatorWrapped(creatorId, days)).data),
+    enabled: Boolean(creatorId) && enabled,
+})

--- a/frontend/hooks/scene/useSceneRankingsQueries.ts
+++ b/frontend/hooks/scene/useSceneRankingsQueries.ts
@@ -7,6 +7,7 @@ import {
     requireRecord,
     requireStringField,
 } from '@/lib/api/contractGuards'
+import type { ArchetypeBadge } from '@/components/chatter/ArchetypeBadges'
 import { sceneKeys } from './sceneKeys'
 
 /** A chatter's dominant channel, or `null` when no single channel dominates. */
@@ -27,6 +28,7 @@ export interface RankingsRow {
     streamsAttended: number
     creatorsVisited: number
     homeChannel: RankingsHomeChannel | null
+    archetypes: ArchetypeBadge[]
 }
 
 /** Camel-cased view model for `GET /scene/chatter-rankings`. */
@@ -70,6 +72,15 @@ export const mapSceneRankings = (value: unknown): SceneRankings => {
                 streamsAttended: requireFiniteNumberField(item, 'streams_attended', label),
                 creatorsVisited: requireFiniteNumberField(item, 'creators_visited', label),
                 homeChannel: mapHomeChannel(item.home_channel),
+                archetypes: requireArrayField(item, 'archetypes', label).map((raw, badgeIndex) => {
+                    const badgeLabel = `${label}.archetypes[${badgeIndex}]`
+                    const badge = requireRecord(raw, badgeLabel)
+                    return {
+                        key: requireStringField(badge, 'key', badgeLabel),
+                        label: requireStringField(badge, 'label', badgeLabel),
+                        description: requireStringField(badge, 'description', badgeLabel),
+                    }
+                }),
             }
         }),
     }

--- a/frontend/lib/api/creators.ts
+++ b/frontend/lib/api/creators.ts
@@ -82,6 +82,46 @@ export interface CreatorEmotesDto {
     stream_count: number
   }>
 }
+
+export interface CreatorWrappedDto {
+  creator_id: number
+  days: number
+  totals: {
+    streams: number
+    hours_streamed: number | null
+    messages: number
+    active_chatters: number
+  }
+  top_chatters: Array<{
+    rank: number
+    chatter_id: number
+    nick: string
+    total_messages: number
+    streams_attended: number
+  }>
+  top_moments: Array<{
+    stream_id: number
+    stream_title: string
+    twitch_id: string | null
+    bucket_minute: string
+    offset_seconds: number
+    ratio: number | null
+    message_count: number
+  }>
+  top_copypastas: Array<{
+    message_text_id: number
+    text: string
+    usage_count: number
+    stream_count: number
+  }>
+  top_emotes: Array<{
+    emote_id: number
+    name: string
+    source: string
+    usage: number
+    chatter_reach: number
+  }>
+}
 export interface CreatorRowDto {
   creator_id: number
   display_name: string
@@ -109,3 +149,6 @@ export const retrieveAudienceMovement = (creatorId: number, days = 30) =>
 
 export const retrieveCreatorEmotes = (creatorId: number, limit = 25) =>
   api.get<CreatorEmotesDto>(`/creators/${creatorId}/emotes?${buildQuery({ limit })}`)
+
+export const retrieveCreatorWrapped = (creatorId: number, days = 30) =>
+  api.get<CreatorWrappedDto>(`/creators/${creatorId}/wrapped?${buildQuery({ days })}`)

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/styles/_rankings.scss
+++ b/frontend/styles/_rankings.scss
@@ -35,6 +35,18 @@
     color: $gray-500;
 }
 
+.rankings-archetypes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin-top: 0.35rem;
+}
+
+.rankings-filter-empty {
+    color: $gray-500;
+    padding: 1.5rem 1rem;
+}
+
 .rankings-load-more {
     display: flex;
     justify-content: center;

--- a/frontend/test/chatterPassportContracts.test.tsx
+++ b/frontend/test/chatterPassportContracts.test.tsx
@@ -60,6 +60,10 @@ const fullPayload = {
   archetypes: [
     { key: 'loyalist', label: 'Loyalist', description: 'Most messages land in one home channel.' },
   ],
+  companions: [
+    { chatter_id: 11, nick: 'bestie', shared_streams: 9 },
+    { chatter_id: 12, nick: 'buddy', shared_streams: 4 },
+  ],
 }
 
 const createClient = () => new QueryClient({
@@ -132,6 +136,10 @@ describe('chatter passport pure logic', () => {
       archetypes: [
         { key: 'loyalist', label: 'Loyalist', description: 'Most messages land in one home channel.' },
       ],
+      companions: [
+        { chatterId: 11, nick: 'bestie', sharedStreams: 9 },
+        { chatterId: 12, nick: 'buddy', sharedStreams: 4 },
+      ],
     })
   })
 
@@ -150,6 +158,7 @@ describe('chatter passport pure logic', () => {
       loyalty: [],
       milestones: { most_active_stream: null },
       archetypes: [],
+      companions: [],
     })
     expect(mapped.debut).toBeNull()
     expect(mapped.homeChannel).toBeNull()
@@ -159,6 +168,7 @@ describe('chatter passport pure logic', () => {
     expect(mapped.chatter).toEqual({ id: 9, nick: 'bot9000', isBot: true, botReason: 'copypasta spam' })
     expect(mapped.loyalty).toEqual([])
     expect(mapped.archetypes).toEqual([])
+    expect(mapped.companions).toEqual([])
   })
 
   it.each([
@@ -168,8 +178,24 @@ describe('chatter passport pure logic', () => {
       { ...fullPayload, debut: { stream_id: 10, stream_title: 'x', creator_display_name: 'c' } },
       'chatter passport.debut.time must be a string',
     ],
+    [{ ...fullPayload, companions: {} }, 'chatter passport.companions must be an array'],
+    [
+      { ...fullPayload, companions: [{ chatter_id: 11, nick: 'bestie' }] },
+      'chatter passport.companions[0].shared_streams must be a finite number',
+    ],
   ])('rejects malformed passport payloads', (payload, message) => {
     expect(() => mapChatterPassport(payload)).toThrow(message)
+  })
+
+  it('maps companions verbatim, ordered by shared_streams desc (as returned by the API)', () => {
+    expect(mapChatterPassport(fullPayload).companions).toEqual([
+      { chatterId: 11, nick: 'bestie', sharedStreams: 9 },
+      { chatterId: 12, nick: 'buddy', sharedStreams: 4 },
+    ])
+  })
+
+  it('maps an empty companions list to an empty array (no shared-stream chatters)', () => {
+    expect(mapChatterPassport({ ...fullPayload, companions: [] }).companions).toEqual([])
   })
 })
 

--- a/frontend/test/creatorQueryContracts.test.tsx
+++ b/frontend/test/creatorQueryContracts.test.tsx
@@ -8,6 +8,7 @@ const api = vi.hoisted(() => ({
   retrieveCreatorRegulars: vi.fn(),
   retrieveCreatorSummary: vi.fn(),
   retrieveCreatorTrends: vi.fn(),
+  retrieveCreatorWrapped: vi.fn(),
 }))
 
 vi.mock('@/lib/api/creators', () => api)
@@ -25,6 +26,9 @@ import {
 import {
   creatorTrendsKeys, useCreatorTrends,
 } from '@/hooks/creator/useCreatorTrendsQuery'
+import {
+  creatorWrappedKeys, useCreatorWrapped,
+} from '@/hooks/creator/useCreatorWrappedQuery'
 import { createTestQueryClient, renderWithQueryClient } from './render'
 
 const createWrapper = () => {
@@ -44,12 +48,14 @@ describe('creator query contracts', () => {
       'creator-regulars', 'list', { creatorId: 7, minStreams: 3 },
     ])
     expect(creatorTrendsKeys.detail(7)).toEqual(['creator-trends', 'detail', 7])
+    expect(creatorWrappedKeys.detail(7, 30)).toEqual(['creator-wrapped', { creatorId: 7, days: 30 }])
 
     const hooks = renderHook(() => ({
       movement: useAudienceMovement(0),
       summary: useCreatorSummary(0),
       regulars: useCreatorRegulars(0),
       trends: useCreatorTrends(0),
+      wrapped: useCreatorWrapped(0, 30),
     }), { wrapper: createWrapper() })
 
     await waitFor(() => {
@@ -60,6 +66,7 @@ describe('creator query contracts', () => {
     expect(api.retrieveCreatorSummary).not.toHaveBeenCalled()
     expect(api.retrieveCreatorRegulars).not.toHaveBeenCalled()
     expect(api.retrieveCreatorTrends).not.toHaveBeenCalled()
+    expect(api.retrieveCreatorWrapped).not.toHaveBeenCalled()
   })
 
   it('maps audience movement associations and intentional nullable rates', async () => {
@@ -172,5 +179,69 @@ describe('creator query contracts', () => {
     expect(surface).toHaveTextContent('Messages / min0')
     expect(surface).toHaveTextContent('Duration1h 30m')
     expect(screen.getAllByRole('link', { name: /Launch/ })).toHaveLength(4)
+  })
+
+  it('maps creator wrapped totals and top lists without losing nulls', async () => {
+    api.retrieveCreatorWrapped.mockResolvedValue({ data: {
+      creator_id: 7,
+      days: 30,
+      totals: {
+        streams: 3,
+        hours_streamed: null,
+        messages: 900,
+        active_chatters: 42,
+      },
+      top_chatters: [{
+        rank: 1, chatter_id: 5, nick: 'viewer', total_messages: 300, streams_attended: 2,
+      }],
+      top_moments: [{
+        stream_id: 10,
+        stream_title: 'Launch',
+        twitch_id: null,
+        bucket_minute: '2026-07-14T10:00:00',
+        offset_seconds: 120,
+        ratio: null,
+        message_count: 80,
+      }],
+      top_copypastas: [{
+        message_text_id: 2, text: 'copypasta', usage_count: 40, stream_count: 3,
+      }],
+      top_emotes: [{
+        emote_id: 1, name: 'PogChamp', source: 'twitch', usage: 300, chatter_reach: 60,
+      }],
+    } })
+
+    const hook = renderHook(() => useCreatorWrapped(7, 30), { wrapper: createWrapper() })
+    await waitFor(() => expect(hook.result.current.isSuccess).toBe(true))
+
+    expect(api.retrieveCreatorWrapped).toHaveBeenCalledWith(7, 30)
+    expect(hook.result.current.data).toEqual({
+      creatorId: 7,
+      days: 30,
+      totals: {
+        streams: 3,
+        hoursStreamed: null,
+        messages: 900,
+        activeChatters: 42,
+      },
+      topChatters: [{
+        rank: 1, chatterId: 5, nick: 'viewer', totalMessages: 300, streamsAttended: 2,
+      }],
+      topMoments: [{
+        streamId: 10,
+        streamTitle: 'Launch',
+        twitchId: null,
+        bucketMinute: '2026-07-14T10:00:00',
+        offsetSeconds: 120,
+        ratio: null,
+        messageCount: 80,
+      }],
+      topCopypastas: [{
+        messageTextId: 2, text: 'copypasta', usageCount: 40, streamCount: 3,
+      }],
+      topEmotes: [{
+        emoteId: 1, name: 'PogChamp', source: 'twitch', usage: 300, chatterReach: 60,
+      }],
+    })
   })
 })

--- a/frontend/test/rankings.test.tsx
+++ b/frontend/test/rankings.test.tsx
@@ -37,6 +37,9 @@ const rankingsPayload = {
         messages: 4200,
         share: 0.84,
       },
+      archetypes: [
+        { key: 'loyalist', label: 'Loyalist', description: 'Sticks to one home channel.' },
+      ],
     },
     {
       rank: 2,
@@ -46,6 +49,7 @@ const rankingsPayload = {
       streams_attended: 12,
       creators_visited: 11,
       home_channel: null,
+      archetypes: [],
     },
   ],
 }
@@ -78,6 +82,9 @@ describe('scene rankings view-model contract', () => {
             messages: 4200,
             share: 0.84,
           },
+          archetypes: [
+            { key: 'loyalist', label: 'Loyalist', description: 'Sticks to one home channel.' },
+          ],
         },
         {
           rank: 2,
@@ -87,6 +94,7 @@ describe('scene rankings view-model contract', () => {
           streamsAttended: 12,
           creatorsVisited: 11,
           homeChannel: null,
+          archetypes: [],
         },
       ],
     })
@@ -111,6 +119,26 @@ describe('scene rankings view-model contract', () => {
       total_messages: 1,
       streams_attended: 1,
       creators_visited: 1,
+      archetypes: [],
+    }] }],
+    ['missing archetypes key', { window: 'all', has_more: false, items: [{
+      rank: 1,
+      chatter_id: 1,
+      nick: 'x',
+      total_messages: 1,
+      streams_attended: 1,
+      creators_visited: 1,
+      home_channel: null,
+    }] }],
+    ['badge missing description in archetypes', { window: 'all', has_more: false, items: [{
+      rank: 1,
+      chatter_id: 1,
+      nick: 'x',
+      total_messages: 1,
+      streams_attended: 1,
+      creators_visited: 1,
+      home_channel: null,
+      archetypes: [{ key: 'loyalist', label: 'Loyalist' }],
     }] }],
     ['null envelope', null],
   ])('rejects malformed rankings payloads (%s)', (_label, payload) => {
@@ -127,8 +155,13 @@ describe('scene rankings view-model contract', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(sceneApi.retrieveSceneRankings).toHaveBeenCalledWith({ window: '7', limit: 25, offset: 50 })
     expect(result.current.data?.hasMore).toBe(true)
-    expect(result.current.data?.items[0]).toMatchObject({ chatterId: 7, homeChannel: { creatorId: 3 } })
+    expect(result.current.data?.items[0]).toMatchObject({
+      chatterId: 7,
+      homeChannel: { creatorId: 3 },
+      archetypes: [{ key: 'loyalist', label: 'Loyalist', description: 'Sticks to one home channel.' }],
+    })
     expect(result.current.data?.items[1].homeChannel).toBeNull()
+    expect(result.current.data?.items[1].archetypes).toEqual([])
   })
 
   it('surfaces a malformed rankings response as a boundary TypeError', async () => {
@@ -158,6 +191,7 @@ const passportPayload = (archetypes: unknown) => ({
   loyalty: [],
   milestones: { most_active_stream: null },
   archetypes,
+  companions: [],
 })
 
 describe('chatter passport archetype badges contract', () => {

--- a/frontend/views/chatter/ChatterPassport.tsx
+++ b/frontend/views/chatter/ChatterPassport.tsx
@@ -47,7 +47,7 @@ const CopyLinkButton = () => {
 
 const PassportBody = ({ passport }: { passport: ChatterPassportModel }) => {
     const {
-        totals, debut, homeChannel, loyalty, milestones,
+        totals, debut, homeChannel, loyalty, milestones, companions,
     } = passport
     const mostActive = milestones.mostActiveStream
 
@@ -171,6 +171,38 @@ const PassportBody = ({ passport }: { passport: ChatterPassportModel }) => {
                     </EmptyState>
                 )}
             </section>
+
+            {companions.length ? (
+                <section className="mt-4">
+                    <div className="section-label">Chat companions</div>
+                    <Card className="card-hud">
+                        <Card.Body>
+                            <Table hover responsive className="mb-0">
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Chatter</th>
+                                        <th scope="col" className="text-end">Shared streams</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {companions.map(companion => (
+                                        <tr key={companion.chatterId}>
+                                            <td>
+                                                <Link href={`/chatter/${companion.chatterId}`}>
+                                                    {companion.nick}
+                                                </Link>
+                                            </td>
+                                            <td className="mono text-end">
+                                                {companion.sharedStreams.toLocaleString()}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+                        </Card.Body>
+                    </Card>
+                </section>
+            ) : null}
         </>
     )
 }

--- a/frontend/views/creator/CreatorWrapped.tsx
+++ b/frontend/views/creator/CreatorWrapped.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import QueryState from '@/components/common/QueryState'
+import EmptyState from '@/components/common/EmptyState'
+import FilterPills from '@/components/common/FilterPills'
+import CreatorWrappedRecap from '@/components/creator/CreatorWrappedRecap'
+import {
+    useCreatorWrapped,
+    isCreatorWrappedEmpty,
+    type CreatorWrapped as CreatorWrappedData,
+} from '@/hooks/creator/useCreatorWrappedQuery'
+
+const DAYS_TABS: Array<{ key: number, label: string }> = [
+    { key: 7, label: '7 days' },
+    { key: 30, label: '30 days' },
+    { key: 90, label: '90 days' },
+]
+
+const CreatorWrapped = ({ creatorId }: { creatorId: number }) => {
+    const [days, setDays] = useState(30)
+    const query = useCreatorWrapped(creatorId, days)
+
+    return (
+        <>
+            <div className="page-head">
+                <div>
+                    <p className="page-sub">this creator, condensed</p>
+                    <h1 className="page-title">Creator Wrapped</h1>
+                </div>
+                <Link className="btn btn-outline-primary btn-sm" href={`/creator/${creatorId}`}>
+                    Back to dossier
+                </Link>
+            </div>
+
+            <div
+                className="toolbar scene-toolbar wrapped-toolbar"
+                role="search"
+                aria-label="Recap window"
+            >
+                <FilterPills
+                    options={DAYS_TABS}
+                    activeKey={days}
+                    ariaLabel="Window"
+                    onChange={setDays}
+                />
+            </div>
+
+            <QueryState
+                query={query}
+                errorTitle="Failed to load the creator recap"
+                loadingText="Wrapping this creator's window..."
+                isEmpty={(value: CreatorWrappedData) => isCreatorWrappedEmpty(value)}
+                emptyState={(
+                    <EmptyState title="Nothing to wrap yet">
+                        No activity landed inside this window yet.
+                    </EmptyState>
+                )}
+            >
+                {(data: CreatorWrappedData) => <CreatorWrappedRecap wrapped={data} />}
+            </QueryState>
+        </>
+    )
+}
+
+export default CreatorWrapped

--- a/frontend/views/scene/Rankings.tsx
+++ b/frontend/views/scene/Rankings.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import QueryState from '@/components/common/QueryState'
 import EmptyState from '@/components/common/EmptyState'
 import FilterPills from '@/components/common/FilterPills'
@@ -20,6 +20,18 @@ const WINDOW_TABS: Array<{ key: RankingsWindow, label: string }> = [
     { key: '30', label: '30 days' },
 ]
 
+// Mirrors the stable archetype set backend/stream_sniper/application/chatters/archetypes.py
+// emits. Hardcoded (like WINDOW_TABS above) rather than derived from loaded rows so the
+// filter row stays stable as pages load instead of shifting chips in and out.
+const ARCHETYPE_FILTERS: Array<{ key: string, label: string }> = [
+    { key: 'loyalist', label: 'Loyalist' },
+    { key: 'wanderer', label: 'Wanderer' },
+    { key: 'marathoner', label: 'Marathoner' },
+    { key: 'chatterbox', label: 'Chatterbox' },
+    { key: 'veteran', label: 'Veteran' },
+    { key: 'newcomer', label: 'Newcomer' },
+]
+
 const Rankings = () => {
     const [activeWindow, setActiveWindow] = useState<RankingsWindow>('all')
 
@@ -29,6 +41,19 @@ const Rankings = () => {
     const appendedOffsetRef = useRef(-1)
 
     const query = useSceneRankings({ window: activeWindow, limit: PAGE_SIZE, offset })
+
+    // Any-of archetype filter, applied client-side only — it never touches the
+    // query key/offset, so toggling a chip re-filters already-loaded rows with
+    // no extra network request. Empty set = no filter (show every loaded row).
+    const [activeArchetypes, setActiveArchetypes] = useState<Set<string>>(new Set())
+    const toggleArchetype = (key: string) => {
+        setActiveArchetypes((prev) => {
+            const next = new Set(prev)
+            if (next.has(key)) next.delete(key)
+            else next.add(key)
+            return next
+        })
+    }
 
     // Reset accumulation synchronously WITH the window change (one batched render):
     // resetting in a useEffect instead fires a wasted query for the new window at
@@ -58,6 +83,18 @@ const Rankings = () => {
     const isFetchingMore = offset > 0 && query.isFetching
     const loadMore = () => setOffset(current => current + PAGE_SIZE)
 
+    const filteredAccumulated = useMemo(
+        () => (
+            activeArchetypes.size === 0
+                ? accumulated
+                : accumulated.filter(row => row.archetypes.some(badge => activeArchetypes.has(badge.key)))
+        ),
+        [accumulated, activeArchetypes],
+    )
+    const filterEmptyMessage = accumulated.length > 0 && filteredAccumulated.length === 0
+        ? 'No loaded chatters match the selected badges. Clear a filter or load more rows.'
+        : undefined
+
     return (
         <>
             <div className="page-head">
@@ -80,12 +117,27 @@ const Rankings = () => {
                 />
             </div>
 
+            <div className="chatter-tabs" role="group" aria-label="Filter by archetype">
+                {ARCHETYPE_FILTERS.map(option => (
+                    <button
+                        key={option.key}
+                        type="button"
+                        aria-pressed={activeArchetypes.has(option.key)}
+                        className={activeArchetypes.has(option.key) ? 'chatter-tab active' : 'chatter-tab'}
+                        onClick={() => toggleArchetype(option.key)}
+                    >
+                        {option.label}
+                    </button>
+                ))}
+            </div>
+
             {accumulated.length > 0 ? (
                 <RankingsTable
-                    rows={accumulated}
+                    rows={filteredAccumulated}
                     hasMore={hasMore}
                     isFetchingMore={isFetchingMore}
                     onLoadMore={loadMore}
+                    filterEmptyMessage={filterEmptyMessage}
                 />
             ) : (
                 <QueryState
@@ -108,14 +160,24 @@ const Rankings = () => {
                         </EmptyState>
                     )}
                 >
-                    {(data: SceneRankings) => (
-                        <RankingsTable
-                            rows={data.items}
-                            hasMore={data.hasMore}
-                            isFetchingMore={isFetchingMore}
-                            onLoadMore={loadMore}
-                        />
-                    )}
+                    {(data: SceneRankings) => {
+                        const rows = activeArchetypes.size === 0
+                            ? data.items
+                            : data.items.filter(row => row.archetypes.some(badge => activeArchetypes.has(badge.key)))
+                        return (
+                            <RankingsTable
+                                rows={rows}
+                                hasMore={data.hasMore}
+                                isFetchingMore={isFetchingMore}
+                                onLoadMore={loadMore}
+                                filterEmptyMessage={
+                                    data.items.length > 0 && rows.length === 0
+                                        ? 'No loaded chatters match the selected badges. Clear a filter or load more rows.'
+                                        : undefined
+                                }
+                            />
+                        )
+                    }}
                 </QueryState>
             )}
         </>


### PR DESCRIPTION
The product trio from the audit backlog, built as three parallel lanes and hardened by two adversarial passes (in-repo reviewer + two Codex rounds; final verdict: approve, no material findings).

## Creator-scoped Wrapped
`GET /creators/{id}/wrapped?days=7..90` mirrors the scene wrapped composition — totals, top chatters, moments, copypastas, emotes — scoped to one creator, cached per `creator_rollup_version`, 404 before any aggregate work. Frontend `/creator/[id]/wrapped` reuses the scene recap sections + FilterPills and is linked from the creator dossier. The route is a server component that validates a positive safe integer and `notFound()`s — `/creator/not-a-number/wrapped` is a 404, not a plausible-looking empty recap (Codex round 1).

## Chat companions
Index-bounded `stream_chatter_stats` self-join ranks a chatter's top 8 co-chatters (bot companions excluded), assembled in the passport application query and rendered as a passport card linking to each companion's own passport.

## Archetype badges + filters on Rankings
Rankings rows now carry archetype slugs computed server-side via the passport's `compute_archetypes`. The reviewer caught the subtle bug before commit: windowed rankings originally fed *window-scoped* aggregates into the computation, so a lifetime loyalist who spread out for one week would badge **Wanderer** on the 7-day tab. Identity inputs are now account-wide in both SQL paths (`lifetime_*` fields via page-bounded laterals, matching the existing account-wide `first_seen` decision) while displayed rank metrics stay window-scoped. Frontend renders `ArchetypeBadges` with client-side any-of filter chips that never touch server pagination.

## Rollup cache-generation fix (pre-existing, surfaced by review)
`compute_stream_rollup` bumps `stream_metrics.computed_at` in TX1, then writes moments/copypastas afterwards — a request in that gap cached pre-rollup content under the new version key for its full TTL, affecting every scene cache keyed on `computed_at`. The rollup now runs `touch_stream_rollup_version_db` as its final phase (even after mid-phase failures), so mixed-generation entries are superseded the moment the rollup finishes.

## Verification
Every new/changed SQL statement was executed against a scratch migrated Postgres with seeded lifetime-vs-window divergence — including the semantic core assertion (7-day row badges Wanderer from lifetime identity, not Loyalist from the window binge), bot exclusion, NULL `is_bot` inclusion, and companion anchor/bot exclusion.

Gates: backend 700 tests + ruff + mypy clean; frontend tsc, ratchet 182/182, 377 vitest, e2e 11/11 (new creator-wrapped spec: happy path, window re-query, malformed-URL 404 with zero API calls), build clean.

https://claude.ai/code/session_0199uX11DFnKqLPVbB2gaAhE