### PR TITLE
Unify report sub_share precision with compare; add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-2026 SlanyCukr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend/stream_sniper/application/streams/report_query.py
+++ b/backend/stream_sniper/application/streams/report_query.py
@@ -111,9 +111,10 @@ def _iso(value: str | datetime | None) -> str | None:
 
 
 def _sub_share(sub_messages: int | None, total_messages: int | None) -> float | None:
+    """Nullable share rounded to 4 places — same precision contract as compare's _share."""
     if sub_messages is None or total_messages is None or total_messages == 0:
         return None
-    return sub_messages / total_messages
+    return round(sub_messages / total_messages, 4)
 
 
 def _previous_rows(

--- a/backend/tests/unit/api/test_stream_report.py
+++ b/backend/tests/unit/api/test_stream_report.py
@@ -447,3 +447,19 @@ class TestStreamExport:
 
         assert response.status_code == 500
         assert response.json() == {"detail": "Internal server error"}
+
+
+class TestSubShareRounding:
+    """_sub_share carries the same 4-decimal precision contract as compare's _share."""
+
+    def test_rounds_to_four_places(self):
+        from stream_sniper.application.streams.report_query import _sub_share
+
+        assert _sub_share(1, 3) == 0.3333
+
+    def test_nullable_unknown_contract(self):
+        from stream_sniper.application.streams.report_query import _sub_share
+
+        assert _sub_share(None, 100) is None
+        assert _sub_share(10, None) is None
+        assert _sub_share(10, 0) is None


### PR DESCRIPTION
## Summary
- `_sub_share` (`application/streams/report_query.py`) now rounds to 4 decimal places, the same precision contract as `_share` in `compare_models.py`. Previously `/streams/{id}/report` returned raw ratios (e.g. `0.3333333333333333`) while compare returned `0.3333`. Response precision of the report endpoint changes accordingly (deliberate — was the one deferred item from the simplification sweep).
- Adds the MIT `LICENSE` file that the README badge and `pyproject.toml` already declare.

## Verification
- New `TestSubShareRounding` regression tests (4dp + nullable=unknown contract)
- `pytest tests/unit/api/test_stream_report.py tests/unit/api/test_compare.py` → 21 passed; ruff clean

https://claude.ai/code/session_01N6W8wgzD5qPXBXuCTE4PJF