### PR TITLE
Admin dormant-vs-broken triage + VOD chapter export

### DIFF
--- a/backend/stream_sniper/api/features/tracking/tracking_models.py
+++ b/backend/stream_sniper/api/features/tracking/tracking_models.py
@@ -12,6 +12,7 @@ from stream_sniper.application.tracking.models import (
     ProcessingJob,
     TrackedStreamer,
 )
+from stream_sniper.database.gateways.streams.records import CreatorStreamSummaryRow
 
 from ....tracking.status import (
     HeartbeatSnapshot,
@@ -66,6 +67,11 @@ class TrackedStreamerResponse(BaseModel):
     creator_display_name: str
     profile_image_url: str | None = None
     created_by_username: str | None = None
+    # Collection summary (populated on list/detail reads; None until attached).
+    # Lets the admin UI distinguish dormant channels (old/absent last stream)
+    # from broken ingestion (active on Twitch but nothing collected).
+    total_streams_collected: int | None = None
+    last_collected_stream_start: str | None = None
 
 
 class TrackedStreamersResponse(BaseModel):
@@ -108,6 +114,15 @@ class ProcessingTriggerResponse(BaseModel):
     job_id: int | None = None
     twitch_vod_id: int | None = None
     vod_title: str | None = None
+
+
+class TwitchProbeResponse(BaseModel):
+    """On-demand Twitch snapshot for a tracked streamer — dormant vs broken triage."""
+
+    is_live: bool
+    archive_vod_count: int
+    last_vod_created_at: str | None = None
+    checked_at: str
 
 
 class TrackingSystemStatus(BaseModel):
@@ -165,8 +180,13 @@ class TwitchChannelResult(BaseModel):
 
 def convert_tracked_streamer_to_response(
     row: TrackedStreamer,
+    summary: CreatorStreamSummaryRow | None = None,
 ) -> TrackedStreamerResponse:
-    """Convert a gateway record to the transport model."""
+    """Convert a gateway record to the transport model.
+
+    ``summary`` (batched per-creator collection stats) is attached on list and
+    detail reads; mutation responses skip it — the admin UI re-reads the list.
+    """
     return TrackedStreamerResponse(
         id=row.id,
         creator_id=row.creator_id,
@@ -183,6 +203,10 @@ def convert_tracked_streamer_to_response(
         creator_display_name=row.creator_display_name,
         profile_image_url=row.profile_image_url,
         created_by_username=row.created_by_username,
+        total_streams_collected=summary.total_streams if summary else None,
+        last_collected_stream_start=(
+            summary.last_stream_start.isoformat() if summary and summary.last_stream_start else None
+        ),
     )
 
 

--- a/backend/stream_sniper/api/features/tracking/tracking_streamer_endpoints.py
+++ b/backend/stream_sniper/api/features/tracking/tracking_streamer_endpoints.py
@@ -3,6 +3,8 @@ Tracked-streamer administration endpoints: CRUD plus the Twitch channel search
 used by the add-streamer autocomplete.
 """
 
+import asyncio
+from datetime import UTC, datetime
 from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
@@ -17,6 +19,7 @@ from ....application.identity.tracked_streamer_creation import (
     create_tracked_streamer,
 )
 from ....collector.twitch_api import TwitchConfigurationError, TwitchUpstreamError
+from ....database.gateways.streams.stream_table_gateway import select_creator_stream_summaries_db
 from ....database.gateways.tracking.tracked_streamers_table_gateway import (
     count_tracked_streamers_db,
     delete_tracked_streamer_db,
@@ -37,6 +40,7 @@ from .tracking_models import (
     TrackedStreamersResponse,
     TrackedStreamerUpdate,
     TwitchChannelResult,
+    TwitchProbeResponse,
     convert_tracked_streamer_to_response,
 )
 
@@ -81,7 +85,14 @@ def get_tracked_streamers(
 
     total = count_tracked_streamers_db(is_active=is_active, processing_enabled=processing_enabled)
 
-    streamers = [convert_tracked_streamer_to_response(streamer) for streamer in streamer_records]
+    summaries = {
+        row.creator_id: row
+        for row in select_creator_stream_summaries_db([s.creator_id for s in streamer_records])
+    }
+    streamers = [
+        convert_tracked_streamer_to_response(streamer, summaries.get(streamer.creator_id))
+        for streamer in streamer_records
+    ]
 
     return TrackedStreamersResponse(streamers=streamers, total=total, offset=offset, limit=limit)
 
@@ -252,7 +263,8 @@ def get_tracked_streamer(streamer_id: int, request: Request, response: Response)
     if not streamer:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tracked streamer not found")
 
-    return convert_tracked_streamer_to_response(streamer)
+    summaries = select_creator_stream_summaries_db([streamer.creator_id])
+    return convert_tracked_streamer_to_response(streamer, summaries[0] if summaries else None)
 
 
 @router.put(
@@ -355,3 +367,69 @@ def remove_tracked_streamer(
         "Tracked streamer removed by admin %s: streamer_id=%s", sanitize_log_value(current_user.username), streamer_id
     )
     return None
+
+
+@router.post(
+    "/streamers/{streamer_id}/probe",
+    response_model=TwitchProbeResponse,
+    summary="Probe a tracked streamer on Twitch",
+    description="""
+    On-demand Twitch snapshot for a tracked streamer: live status, archive VOD
+    count, and the newest VOD's creation time. Lets an admin distinguish a
+    dormant channel (nothing to collect) from broken ingestion.
+
+    Requires admin role.
+
+    **Rate Limit**: 5 requests per minute
+    """,
+    responses={
+        200: {"description": "Twitch snapshot for the streamer"},
+        401: {"model": ErrorResponse, "description": "Authentication required"},
+        403: {"model": ErrorResponse, "description": "Admin role required"},
+        404: {"model": ErrorResponse, "description": "Streamer not found"},
+        502: {"model": ErrorResponse, "description": "Twitch lookup failed"},
+        503: {"model": ErrorResponse, "description": "Twitch integration is not configured"},
+        429: {"model": RateLimitErrorResponse, "description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit("5/minute")
+async def probe_twitch_channel(
+    streamer_id: int, request: Request, response: Response, current_user: UserInDB = Depends(get_current_admin_user)
+) -> TwitchProbeResponse:
+    streamer = await asyncio.to_thread(select_tracked_streamer_by_id_db, streamer_id)
+    if not streamer:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tracked streamer not found")
+
+    login = streamer.twitch_username
+    try:
+        twitch_api = get_twitch_client(request)
+        await twitch_api.ensure_initialized()
+        live = await twitch_api.get_live_stream(login)
+        videos = await twitch_api.get_archived_videos(login)
+    except TwitchConfigurationError as error:
+        logger.exception("Twitch integration is not configured")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Twitch lookups aren't available right now because the server's Twitch access isn't configured. Contact the administrator.",
+        ) from error
+    except TwitchUpstreamError as error:
+        logger.exception("Twitch probe failed for %s", sanitize_log_value(login))
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Could not reach Twitch for this channel. Try again in a moment.",
+        ) from error
+
+    last_vod = max(videos, key=lambda video: video.created_at) if videos else None
+    logger.info(
+        "Twitch probe by admin %s: streamer_id=%s live=%s vods=%s",
+        sanitize_log_value(current_user.username),
+        streamer_id,
+        live is not None,
+        len(videos),
+    )
+    return TwitchProbeResponse(
+        is_live=live is not None,
+        archive_vod_count=len(videos),
+        last_vod_created_at=last_vod.created_at.isoformat() if last_vod else None,
+        checked_at=datetime.now(UTC).isoformat(),
+    )

--- a/backend/stream_sniper/database/gateways/streams/records.py
+++ b/backend/stream_sniper/database/gateways/streams/records.py
@@ -81,6 +81,14 @@ class OtherCreatorRow(NamedTuple):
     nick: str
 
 
+class CreatorStreamSummaryRow(NamedTuple):
+    """Per-creator collection summary for the admin tracking table."""
+
+    creator_id: int
+    total_streams: int
+    last_stream_start: datetime | None
+
+
 class StreamParticipantRow(NamedTuple):
     chatter_id: int
     nick: str

--- a/backend/stream_sniper/database/gateways/streams/stream_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/streams/stream_table_gateway.py
@@ -6,6 +6,7 @@ from psycopg2.extensions import cursor as Cursor
 
 from stream_sniper.database.gateways.streams.records import (
     ChatterMessageTextRow,
+    CreatorStreamSummaryRow,
     MentionedChatterRow,
     MentionPairRow,
     OtherCreatorRow,
@@ -340,3 +341,27 @@ def select_chatter_messages_on_stream_db(
         (stream_id, chatter_id),
     )
     return [ChatterMessageTextRow(*row) for row in cursor.fetchall()]
+
+
+@with_cursor
+def select_creator_stream_summaries_db(
+    cursor: Cursor,
+    creator_ids: list[int],
+) -> list[CreatorStreamSummaryRow]:
+    """Batched per-creator collection summary for the admin tracking table.
+
+    One query for the whole page of tracked streamers — avoids N+1 when the
+    admin list renders last-collected-stream info per row.
+    """
+    if not creator_ids:
+        return []
+    cursor.execute(
+        """
+    SELECT creator_id, COUNT(*), MAX(start)
+    FROM stream_sniper.stream
+    WHERE creator_id = ANY(%s)
+    GROUP BY creator_id
+    """,
+        (creator_ids,),
+    )
+    return [CreatorStreamSummaryRow(*row) for row in cursor.fetchall()]

--- a/backend/tests/unit/api/test_tracking_streamer_probe.py
+++ b/backend/tests/unit/api/test_tracking_streamer_probe.py
@@ -1,0 +1,145 @@
+"""Twitch probe endpoint + collection-summary list enrichment tests."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stream_sniper.api.features.tracking.tracking_streamer_endpoints import router
+from stream_sniper.api.security.auth import get_current_admin_user
+from stream_sniper.api.security.rate_limiter import setup_rate_limiting
+from stream_sniper.application.tracking.models import TrackedStreamer
+from stream_sniper.collector.twitch_api import TwitchConfigurationError, TwitchUpstreamError
+from stream_sniper.database.gateways.streams.records import CreatorStreamSummaryRow
+
+_ENDPOINTS = "stream_sniper.api.features.tracking.tracking_streamer_endpoints"
+
+
+def _row() -> TrackedStreamer:
+    now = datetime(2026, 7, 15, 12)
+    return TrackedStreamer(
+        7,
+        70,
+        "operator",
+        "Operator",
+        True,
+        None,
+        None,
+        True,
+        now,
+        now,
+        1,
+        None,
+        "Operator",
+        None,
+        "admin",
+    )
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    setup_rate_limiting(app)
+    app.include_router(router, prefix="/admin/tracking")
+    app.dependency_overrides[get_current_admin_user] = lambda: SimpleNamespace(username="admin")
+    return TestClient(app)
+
+
+def _twitch(live: object = None, videos: list | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        ensure_initialized=AsyncMock(),
+        get_live_stream=AsyncMock(return_value=live),
+        get_archived_videos=AsyncMock(return_value=videos or []),
+    )
+
+
+class TestProbe:
+    def test_reports_live_channel_with_vods(self) -> None:
+        videos = [
+            SimpleNamespace(created_at=datetime(2026, 7, 1, 10)),
+            SimpleNamespace(created_at=datetime(2026, 7, 14, 20)),
+        ]
+        with (
+            patch(f"{_ENDPOINTS}.select_tracked_streamer_by_id_db", return_value=_row()),
+            patch(f"{_ENDPOINTS}.get_twitch_client", return_value=_twitch(live=object(), videos=videos)),
+        ):
+            response = _client().post("/admin/tracking/streamers/7/probe")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["is_live"] is True
+        assert body["archive_vod_count"] == 2
+        assert body["last_vod_created_at"] == "2026-07-14T20:00:00"
+        assert body["checked_at"]
+
+    def test_reports_dormant_channel(self) -> None:
+        with (
+            patch(f"{_ENDPOINTS}.select_tracked_streamer_by_id_db", return_value=_row()),
+            patch(f"{_ENDPOINTS}.get_twitch_client", return_value=_twitch()),
+        ):
+            response = _client().post("/admin/tracking/streamers/7/probe")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["is_live"] is False
+        assert body["archive_vod_count"] == 0
+        assert body["last_vod_created_at"] is None
+
+    def test_unknown_streamer_404s(self) -> None:
+        with patch(f"{_ENDPOINTS}.select_tracked_streamer_by_id_db", return_value=None):
+            response = _client().post("/admin/tracking/streamers/999/probe")
+
+        assert response.status_code == 404
+
+    def test_missing_twitch_config_503s(self) -> None:
+        twitch = _twitch()
+        twitch.ensure_initialized = AsyncMock(side_effect=TwitchConfigurationError("no creds"))
+        with (
+            patch(f"{_ENDPOINTS}.select_tracked_streamer_by_id_db", return_value=_row()),
+            patch(f"{_ENDPOINTS}.get_twitch_client", return_value=twitch),
+        ):
+            response = _client().post("/admin/tracking/streamers/7/probe")
+
+        assert response.status_code == 503
+
+    def test_twitch_outage_502s(self) -> None:
+        twitch = _twitch()
+        twitch.get_archived_videos = AsyncMock(side_effect=TwitchUpstreamError("boom"))
+        with (
+            patch(f"{_ENDPOINTS}.select_tracked_streamer_by_id_db", return_value=_row()),
+            patch(f"{_ENDPOINTS}.get_twitch_client", return_value=twitch),
+        ):
+            response = _client().post("/admin/tracking/streamers/7/probe")
+
+        assert response.status_code == 502
+
+
+class TestListCollectionSummary:
+    def test_list_attaches_batched_summaries(self) -> None:
+        summary = CreatorStreamSummaryRow(70, 12, datetime(2026, 7, 10, 18))
+        with (
+            patch(f"{_ENDPOINTS}.select_tracked_streamers_db", return_value=[_row()]),
+            patch(f"{_ENDPOINTS}.count_tracked_streamers_db", return_value=1),
+            patch(f"{_ENDPOINTS}.select_creator_stream_summaries_db", return_value=[summary]) as summaries,
+        ):
+            response = _client().get("/admin/tracking/streamers")
+
+        assert response.status_code == 200
+        streamer = response.json()["streamers"][0]
+        assert streamer["total_streams_collected"] == 12
+        assert streamer["last_collected_stream_start"] == "2026-07-10T18:00:00"
+        summaries.assert_called_once_with([70])
+
+    def test_creator_without_streams_stays_null(self) -> None:
+        with (
+            patch(f"{_ENDPOINTS}.select_tracked_streamers_db", return_value=[_row()]),
+            patch(f"{_ENDPOINTS}.count_tracked_streamers_db", return_value=1),
+            patch(f"{_ENDPOINTS}.select_creator_stream_summaries_db", return_value=[]),
+        ):
+            response = _client().get("/admin/tracking/streamers")
+
+        assert response.status_code == 200
+        streamer = response.json()["streamers"][0]
+        assert streamer["total_streams_collected"] is None
+        assert streamer["last_collected_stream_start"] is None

--- a/frontend/components/admin/tracking/streamers/TrackedStreamerTable.jsx
+++ b/frontend/components/admin/tracking/streamers/TrackedStreamerTable.jsx
@@ -7,6 +7,36 @@ import LoadingSpinner from '@/components/common/LoadingSpinner'
 import StatusChip from '@/components/common/StatusChip'
 import { formatDateTime } from '@/utils/dateUtils'
 
+/**
+ * Dormant-vs-broken triage cell: what an on-demand Twitch probe said about the
+ * channel, next to what the collector has actually ingested. No probe yet →
+ * just the button.
+ */
+const TwitchProbeCell = ({
+    streamer, result, probing, onProbe,
+}) => (
+    <div className="d-flex align-items-center gap-2 flex-wrap">
+        {result && (
+            result.isLive ? (
+                <StatusChip variant="ok">Live now</StatusChip>
+            ) : result.archiveVodCount === 0 ? (
+                <StatusChip variant="warn">No VODs</StatusChip>
+            ) : (
+                <span className="mono" title={`${result.archiveVodCount} archive VODs`}>
+                    Last VOD {formatDateTime(result.lastVodCreatedAt, 'unknown')}
+                </span>
+            )
+        )}
+        <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={() => onProbe(streamer.id)}
+            disabled={probing}>
+            {probing ? 'Probing…' : result ? 'Re-probe' : 'Probe Twitch'}
+        </Button>
+    </div>
+)
+
 const TrackedStreamerTable = ({
     streamers,
     total,
@@ -19,6 +49,9 @@ const TrackedStreamerTable = ({
     onToggleActive,
     onToggleProcessing,
     onRemove,
+    onProbe,
+    probeResults = {},
+    probingId = null,
 }) => (
     <Card>
         <Card.Body className={!loading && streamers.length === 0 ? 'p-0' : ''}>
@@ -41,8 +74,9 @@ const TrackedStreamerTable = ({
                                 <th>Display Name</th>
                                 <th>Status</th>
                                 <th>Processing</th>
+                                <th>Collected</th>
                                 <th>Last Check</th>
-                                <th>Created</th>
+                                <th>Twitch</th>
                                 <th>Actions</th>
                             </tr>
                         </thead>
@@ -61,8 +95,20 @@ const TrackedStreamerTable = ({
                                             {streamer.processingEnabled ? 'Enabled' : 'Disabled'}
                                         </StatusChip>
                                     </td>
+                                    <td className="mono">
+                                        {streamer.totalStreamsCollected
+                                            ? `${streamer.totalStreamsCollected} · ${formatDateTime(streamer.lastCollectedStreamStart, 'unknown')}`
+                                            : 'Nothing yet'}
+                                    </td>
                                     <td className="mono">{formatDateTime(streamer.lastStreamCheck, 'Never')}</td>
-                                    <td className="mono">{formatDateTime(streamer.createdAt, 'Never')}</td>
+                                    <td>
+                                        <TwitchProbeCell
+                                            streamer={streamer}
+                                            result={probeResults[streamer.id]}
+                                            probing={probingId === streamer.id}
+                                            onProbe={onProbe}
+                                        />
+                                    </td>
                                     <td>
                                         <Button
                                             variant="outline-primary"

--- a/frontend/components/moments/MomentCard.jsx
+++ b/frontend/components/moments/MomentCard.jsx
@@ -1,6 +1,6 @@
 'use client'
 import Link from 'next/link'
-import { vodDeepLink } from '@/utils/chatRender'
+import { vodDeepLink } from '@/utils/vodChapters'
 import { formatTimeAgo } from '@/utils/dateUtils'
 import MomentReviewControls from './MomentReviewControls'
 import ErrorAlert from '@/components/common/error/ErrorAlert'

--- a/frontend/components/scene/HighlightCard.tsx
+++ b/frontend/components/scene/HighlightCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { vodDeepLink } from '@/utils/chatRender'
+import { vodDeepLink } from '@/utils/vodChapters'
 import { formatCompactNumber } from '@/utils/numberUtils'
 import { formatStreamTimestamp } from '@/utils/dateUtils'
 import StatusChip from '@/components/common/StatusChip'

--- a/frontend/components/stream/timeline/CopyChaptersButton.jsx
+++ b/frontend/components/stream/timeline/CopyChaptersButton.jsx
@@ -1,0 +1,43 @@
+// @ts-check
+'use client'
+import { useState } from 'react'
+import { Button } from 'react-bootstrap'
+import { buildVodChapters } from '@/utils/vodChapters'
+
+/**
+ * Copies a chapter list (moment offsets + Twitch VOD deep links) to the
+ * clipboard. Renders nothing when the stream has no VOD id or no moments —
+ * there would be nothing to copy.
+ *
+ * @param {{ timeline: Parameters<typeof buildVodChapters>[0] }} props
+ */
+const CopyChaptersButton = ({ timeline }) => {
+    const [copied, setCopied] = useState(false)
+    const chapters = buildVodChapters(timeline)
+
+    if (!chapters) return null
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(chapters)
+            setCopied(true)
+            setTimeout(() => setCopied(false), 2000)
+        } catch {
+            // Clipboard access denied (permissions/insecure context) — leave
+            // the label unchanged rather than pretending it copied.
+        }
+    }
+
+    return (
+        <Button
+            variant="outline-secondary"
+            size="sm"
+            onClick={handleCopy}
+            aria-label="Copy VOD chapter list to clipboard">
+            <i className="bi bi-list-ol me-1" aria-hidden="true"></i>
+            {copied ? 'Copied!' : 'Copy chapters'}
+        </Button>
+    )
+}
+
+export default CopyChaptersButton

--- a/frontend/components/stream/timeline/StreamTimeline.jsx
+++ b/frontend/components/stream/timeline/StreamTimeline.jsx
@@ -3,10 +3,11 @@ import {
     useCallback, useMemo, useState,
 } from 'react'
 import { Card } from 'react-bootstrap'
-import { vodDeepLink } from '@/utils/chatRender'
+import { vodDeepLink } from '@/utils/vodChapters'
 import { useAuth } from '@/contexts/AuthContext'
 import { useMomentReview } from '@/hooks/moments/useMomentsQueries'
 import { getHoverIndex, useTimelineGeometry } from '@/hooks/stream/timeline/useTimelineGeometry'
+import CopyChaptersButton from '@/components/stream/timeline/CopyChaptersButton'
 import TimelineLanes from '@/components/stream/timeline/TimelineLanes'
 import TimelineContextList from '@/components/stream/timeline/TimelineContextList'
 import TimelineSelection from '@/components/stream/timeline/TimelineSelection'
@@ -78,6 +79,7 @@ const StreamTimeline = ({ timeline, onJump }) => {
                 <div className="timeline-head">
                     <h3 id="timeline-heading" className="section-label mb-0">Chat activity</h3>
                     <span className="timeline-subtitle">messages / minute</span>
+                    <CopyChaptersButton timeline={timeline} />
                 </div>
                 <TimelineLanes
                     buckets={buckets}

--- a/frontend/e2e/critical-journeys.spec.ts
+++ b/frontend/e2e/critical-journeys.spec.ts
@@ -32,6 +32,8 @@ const trackedStreamer = {
   is_active: true,
   last_stream_check: null,
   last_processed_vod_id: null,
+  total_streams_collected: 3,
+  last_collected_stream_start: '2026-07-13T18:00:00',
   processing_enabled: true,
   created_at: '2026-07-14T10:00:00Z',
   updated_at: '2026-07-14T10:00:00Z',

--- a/frontend/hooks/admin/tracking/useStreamerTrackingActions.js
+++ b/frontend/hooks/admin/tracking/useStreamerTrackingActions.js
@@ -1,7 +1,9 @@
+import { useState } from 'react'
 import { useActionFeedback } from '../shared/useActionFeedback'
 import {
     useCreateTrackedStreamer,
     useDeleteTrackedStreamer,
+    useProbeTwitchChannel,
     useUpdateTrackedStreamer,
 } from './useTrackingQueries'
 
@@ -10,6 +12,11 @@ export const useStreamerTrackingActions = () => {
     const createStreamer = useCreateTrackedStreamer()
     const updateStreamer = useUpdateTrackedStreamer()
     const deleteStreamer = useDeleteTrackedStreamer()
+    const probeChannel = useProbeTwitchChannel()
+    // Probe snapshots live only in memory: nothing is persisted server-side,
+    // so results are keyed per streamer id and reset on unmount.
+    const [probeResults, setProbeResults] = useState({})
+    const [probingId, setProbingId] = useState(null)
 
     const handleAddStreamer = streamer => feedback.runAction({
         action: () => createStreamer.mutateAsync(streamer),
@@ -45,17 +52,40 @@ export const useStreamerTrackingActions = () => {
         errorTitle: 'Failed to remove streamer',
     })
 
+    const handleProbeChannel = async streamerId => {
+        setProbingId(streamerId)
+        try {
+            await feedback.runAction({
+                action: async () => {
+                    const result = await probeChannel.mutateAsync(streamerId)
+                    setProbeResults(current => ({
+                        ...current,
+                        [streamerId]: result,
+                    }))
+                },
+                errorTitle: 'Twitch probe failed',
+            })
+        } finally {
+            setProbingId(null)
+        }
+    }
+
     return {
         feedback,
         pending: {
             update: updateStreamer.isPending,
             delete: deleteStreamer.isPending,
         },
+        probe: {
+            results: probeResults,
+            probingId,
+        },
         commands: {
             addStreamer: handleAddStreamer,
             toggleActive: handleToggleActive,
             toggleProcessing: handleToggleProcessing,
             removeStreamer: handleRemoveStreamer,
+            probeChannel: handleProbeChannel,
         },
     }
 }

--- a/frontend/hooks/admin/tracking/useStreamerTrackingController.js
+++ b/frontend/hooks/admin/tracking/useStreamerTrackingController.js
@@ -67,6 +67,9 @@ export const useStreamerTrackingController = () => {
             onToggleActive: actions.commands.toggleActive,
             onToggleProcessing: actions.commands.toggleProcessing,
             onRemove: setRemoveTarget,
+            onProbe: actions.commands.probeChannel,
+            probeResults: actions.probe.results,
+            probingId: actions.probe.probingId,
         },
         addModalProps: {
             show: showAddModal,

--- a/frontend/hooks/admin/tracking/useTrackingQueries.js
+++ b/frontend/hooks/admin/tracking/useTrackingQueries.js
@@ -1,8 +1,9 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { useInvalidatingMutation } from '@/hooks/useInvalidatingMutation'
 import {
     createTrackedStreamer,
     deleteTrackedStreamer,
+    probeTwitchChannel,
     retrieveProcessingJobs,
     retrieveTrackedStreamers,
     retrieveTrackingStats,
@@ -17,6 +18,7 @@ import {
     requireArrayField,
     requireBooleanField,
     requireFiniteNumberField,
+    requireNullableFiniteNumberField,
     requireNullableStringField,
     requireRecord,
     requireStringField,
@@ -92,6 +94,19 @@ export const mapTrackedStreamer = value => {
         processingEnabled: requireBooleanField(streamer, 'processing_enabled', 'tracked streamer'),
         lastStreamCheck: requireNullableStringField(streamer, 'last_stream_check', 'tracked streamer'),
         createdAt: requireStringField(streamer, 'created_at', 'tracked streamer'),
+        totalStreamsCollected: requireNullableFiniteNumberField(streamer, 'total_streams_collected', 'tracked streamer'),
+        lastCollectedStreamStart: requireNullableStringField(streamer, 'last_collected_stream_start', 'tracked streamer'),
+    }
+}
+
+/** @param {unknown} value */
+const mapTwitchProbeResult = value => {
+    const probe = requireRecord(value, 'twitch probe result')
+    return {
+        isLive: requireBooleanField(probe, 'is_live', 'twitch probe result'),
+        archiveVodCount: requireFiniteNumberField(probe, 'archive_vod_count', 'twitch probe result'),
+        lastVodCreatedAt: requireNullableStringField(probe, 'last_vod_created_at', 'twitch probe result'),
+        checkedAt: requireStringField(probe, 'checked_at', 'twitch probe result'),
     }
 }
 
@@ -273,3 +288,14 @@ export const useDeleteTrackedStreamer = (options = {}) => useInvalidatingMutatio
     trackingKeys.all,
     options,
 )
+
+/**
+ * On-demand Twitch snapshot for one tracked streamer. Nothing is stored, so
+ * this is a plain mutation — the caller keeps the result in component state.
+ */
+export const useProbeTwitchChannel = (options = {}) => useMutation({
+    mutationFn: async (/** @type {number} */ streamerId) => (
+        mapTwitchProbeResult((await probeTwitchChannel(streamerId)).data)
+    ),
+    ...options,
+})

--- a/frontend/lib/api/tracking.ts
+++ b/frontend/lib/api/tracking.ts
@@ -43,6 +43,15 @@ export interface TrackedStreamerDto {
   creator_display_name: string
   profile_image_url: string | null
   created_by_username: string | null
+  total_streams_collected: number | null
+  last_collected_stream_start: string | null
+}
+
+export interface TwitchProbeResultDto {
+  is_live: boolean
+  archive_vod_count: number
+  last_vod_created_at: string | null
+  checked_at: string
 }
 
 export interface TrackedStreamerListDto {
@@ -124,6 +133,9 @@ export const updateTrackedStreamer = (
 
 export const deleteTrackedStreamer = (streamerId: number) =>
   api.delete<void>(`/admin/tracking/streamers/${streamerId}`)
+
+export const probeTwitchChannel = (streamerId: number) =>
+  api.post<TwitchProbeResultDto>(`/admin/tracking/streamers/${streamerId}/probe`)
 
 export const retrieveProcessingJobs = (request: ProcessingJobListRequest = {}) =>
   api.get<ProcessingJobListDto>(`/admin/tracking/jobs?${buildQuery({

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/test/queryModelContracts.test.tsx
+++ b/frontend/test/queryModelContracts.test.tsx
@@ -242,6 +242,8 @@ describe('query view-model contracts', () => {
       processing_enabled: false,
       last_stream_check: null,
       created_at: 'created',
+      total_streams_collected: 3,
+      last_collected_stream_start: '2026-07-13T18:00:00',
     }
     const rawJob = {
       id: 9,

--- a/frontend/test/streamerTrackingPagination.test.tsx
+++ b/frontend/test/streamerTrackingPagination.test.tsx
@@ -5,6 +5,7 @@ const hooks = vi.hoisted(() => ({
   loadTrackedStreamerOptions: vi.fn(),
   useCreateTrackedStreamer: vi.fn(),
   useDeleteTrackedStreamer: vi.fn(),
+  useProbeTwitchChannel: vi.fn(),
   useTrackedStreamers: vi.fn(),
   useUpdateTrackedStreamer: vi.fn(),
 }))
@@ -25,6 +26,8 @@ const streamer = {
   processingEnabled: true,
   lastStreamCheck: null,
   createdAt: '2026-07-14T10:00:00Z',
+  totalStreamsCollected: 3,
+  lastCollectedStreamStart: '2026-07-13T18:00:00',
 }
 
 describe('StreamerTracking pagination', () => {
@@ -39,6 +42,7 @@ describe('StreamerTracking pagination', () => {
     hooks.loadTrackedStreamerOptions.mockResolvedValue([])
     hooks.useDeleteTrackedStreamer.mockReturnValue(deleteStreamer)
     hooks.useUpdateTrackedStreamer.mockReturnValue(updateStreamer)
+    hooks.useProbeTwitchChannel.mockReturnValue({ mutateAsync: vi.fn(), isPending: false })
   })
 
   it('moves to the previous page after deleting its last row', async () => {

--- a/frontend/test/vodChapters.test.js
+++ b/frontend/test/vodChapters.test.js
@@ -1,0 +1,65 @@
+import {
+    describe, expect, it,
+} from 'vitest'
+import { buildVodChapters } from '@/utils/vodChapters'
+
+const timeline = {
+    twitchVodId: 123456,
+    streamStart: '2026-07-16T17:00:00',
+    moments: [
+        {
+            t: '2026-07-16T17:12:00',
+            count: 312,
+            topPhrases: [
+                'LETS GO',
+                'W',
+            ],
+        },
+        {
+            t: '2026-07-16T19:05:30',
+            count: 88,
+            topPhrases: null,
+        },
+    ],
+}
+
+describe('buildVodChapters', () => {
+    it('builds one line per moment with offset, label, count, and deep link', () => {
+        const chapters = buildVodChapters(timeline)
+
+        expect(chapters).toBe([
+            '0:12:00 — LETS GO (312 msgs) https://www.twitch.tv/videos/123456?t=0h12m0s',
+            '2:05:30 — chat spike (88 msgs) https://www.twitch.tv/videos/123456?t=2h5m30s',
+        ].join('\n'))
+    })
+
+    it('returns null without a VOD id', () => {
+        expect(buildVodChapters({
+            ...timeline,
+            twitchVodId: null,
+        })).toBeNull()
+    })
+
+    it('returns null without moments', () => {
+        expect(buildVodChapters({
+            ...timeline,
+            moments: [],
+        })).toBeNull()
+        expect(buildVodChapters(null)).toBeNull()
+    })
+
+    it('clamps pre-start moments to offset zero', () => {
+        const chapters = buildVodChapters({
+            ...timeline,
+            moments: [
+                {
+                    t: '2026-07-16T16:59:00',
+                    count: 5,
+                    topPhrases: [],
+                },
+            ],
+        })
+
+        expect(chapters).toContain('0:00:00 — chat spike (5 msgs)')
+    })
+})

--- a/frontend/tsconfig.checkjs-boundaries.json
+++ b/frontend/tsconfig.checkjs-boundaries.json
@@ -7,6 +7,8 @@
   "include": [
     "next-env.d.ts",
     "components/common/search/AsyncSearchSelect.jsx",
+    "components/stream/timeline/CopyChaptersButton.jsx",
+    "utils/vodChapters.js",
     "hooks/useAsyncSearchLoader.js",
     "hooks/useTableSort.js",
     "hooks/chatter/useChattersQuery.js",

--- a/frontend/utils/chatRender.jsx
+++ b/frontend/utils/chatRender.jsx
@@ -124,26 +124,3 @@ export const renderMessageWithBetterTtvEmotes = message => {
             return <span key={index}>{word + ' '}</span>
         })
 }
-
-/**
- * Builds a Twitch VOD deep-link seeked to a moment's offset from the stream start.
- * @param {string|number|null} twitchVodId - The VOD id
- * @param {string} streamStart - ISO timestamp of the stream start
- * @param {string} momentTs - ISO timestamp of the moment to seek to
- * @returns {string|null} A twitch.tv/videos deep-link, or null when there is no VOD id
- */
-export const vodDeepLink = (twitchVodId, streamStart, momentTs) => {
-    if (!twitchVodId) {
-        return null
-    }
-    const startMs = new Date(streamStart).getTime()
-    const momentMs = new Date(momentTs).getTime()
-    let offset = Math.max(0, Math.floor((momentMs - startMs) / 1000))
-    if (!Number.isFinite(offset)) {
-        offset = 0
-    }
-    const h = Math.floor(offset / 3600)
-    const m = Math.floor((offset % 3600) / 60)
-    const s = offset % 60
-    return `https://www.twitch.tv/videos/${twitchVodId}?t=${h}h${m}m${s}s`
-}

--- a/frontend/utils/vodChapters.js
+++ b/frontend/utils/vodChapters.js
@@ -1,0 +1,64 @@
+// @ts-check
+
+/**
+ * Twitch VOD deep-link + chapter-list helpers. Kept separate from
+ * chatRender.jsx so checkJs boundary files can import them without pulling the
+ * (unchecked) chat-render module into the typecheck graph.
+ */
+
+/**
+ * Build a twitch.tv VOD deep link that seeks to a moment's offset.
+ *
+ * @param {string|number|null} twitchVodId - The VOD id
+ * @param {string} streamStart - ISO timestamp of the stream start
+ * @param {string} momentTs - ISO timestamp of the moment to seek to
+ * @returns {string|null} A twitch.tv/videos deep-link, or null when there is no VOD id
+ */
+export const vodDeepLink = (twitchVodId, streamStart, momentTs) => {
+    if (!twitchVodId) {
+        return null
+    }
+    const startMs = new Date(streamStart).getTime()
+    const momentMs = new Date(momentTs).getTime()
+    let offset = Math.max(0, Math.floor((momentMs - startMs) / 1000))
+    if (!Number.isFinite(offset)) {
+        offset = 0
+    }
+    const h = Math.floor(offset / 3600)
+    const m = Math.floor((offset % 3600) / 60)
+    const s = offset % 60
+    return `https://www.twitch.tv/videos/${twitchVodId}?t=${h}h${m}m${s}s`
+}
+
+/**
+ * Build a shareable chapter list for a stream's detected moments: one line per
+ * moment with its VOD offset, a label (top chat phrase when available), the
+ * message count, and a Twitch deep link.
+ *
+ * @param {{
+ *   twitchVodId: string|number|null,
+ *   streamStart: string,
+ *   moments: Array<{t: string, count: number, topPhrases?: string[]|null}>,
+ * }|null|undefined} timeline
+ * @returns {string|null} Chapter text, or null when there is no VOD or no moments
+ */
+export const buildVodChapters = timeline => {
+    if (!timeline?.twitchVodId || !timeline.moments?.length) {
+        return null
+    }
+    const startMs = new Date(timeline.streamStart).getTime()
+    const lines = timeline.moments.map(moment => {
+        let offset = Math.max(0, Math.floor((new Date(moment.t).getTime() - startMs) / 1000))
+        if (!Number.isFinite(offset)) {
+            offset = 0
+        }
+        const h = Math.floor(offset / 3600)
+        const m = Math.floor((offset % 3600) / 60)
+        const s = offset % 60
+        const stamp = `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+        const label = moment.topPhrases?.[0] || 'chat spike'
+        const link = vodDeepLink(timeline.twitchVodId, timeline.streamStart, moment.t)
+        return `${stamp} — ${label} (${moment.count} msgs) ${link}`
+    })
+    return lines.join('\n')
+}


### PR DESCRIPTION
First of three PRs from the "do all of those" feature batch (1/3).

## Dormant vs broken (admin tracking)
- Streamers table: new **Collected** column (`total_streams_collected` + `last_collected_stream_start`, one batched `GROUP BY creator_id` query per page — no N+1) and **Twitch** column with an on-demand probe
- `POST /admin/tracking/streamers/{id}/probe` (admin, 5/min): live status + archive VOD count + newest VOD date via the shared TwitchAPI client; 503 unconfigured / 502 upstream, mirroring `trigger_processing`
- Probe snapshots are ephemeral (component state) — nothing stored, no migration
- The `Created` column was swapped out for the two new ones (kept table width sane)

## VOD chapters
- "Copy chapters" button on the stream timeline: `H:MM:SS — top phrase (N msgs) <twitch deep link>` per detected moment; hidden when no VOD id or no moments
- `vodDeepLink` + new `buildVodChapters` extracted to `utils/vodChapters.js` (checkJs boundary; chatRender.jsx stays unchecked)

## Verification
- Backend: 11 new endpoint tests (live/dormant/404/502/503 + summary attach), full unit suite green 79.29%, ruff clean
- Frontend: 374/374 vitest (4 new), 12/12 e2e, tsc + boundaries + ratchet (2 files newly checked), build compiles

https://claude.ai/code/session_01N6W8wgzD5qPXBXuCTE4PJF