### PR TITLE
Emote economy board + creator head-to-head

### DIFF
--- a/backend/stream_sniper/api/features/community/community_endpoints.py
+++ b/backend/stream_sniper/api/features/community/community_endpoints.py
@@ -1,6 +1,6 @@
 """Read-only endpoints for community overlap (shared-audience map + creator neighbors)."""
 
-from fastapi import APIRouter, Path, Query, Request, Response
+from fastapi import APIRouter, HTTPException, Path, Query, Request, Response, status
 
 from ....application.community.community_query import (
     get_community_overlap as query_community_overlap,
@@ -8,8 +8,15 @@ from ....application.community.community_query import (
 from ....application.community.community_query import (
     get_creator_neighbors as query_creator_neighbors,
 )
+from ....application.community.head_to_head_query import (
+    HeadToHeadNotFoundError,
+)
+from ....application.community.head_to_head_query import (
+    get_head_to_head as query_head_to_head,
+)
 from ....application.community.models import (
     CommunityOverlap,
+    CreatorHeadToHead,
     CreatorNeighbors,
 )
 from ....logging_config import get_logger
@@ -26,6 +33,53 @@ router = APIRouter(tags=["Community"])
 
 _OVERLAP_CACHE = ModelCachePolicy("community_overlap", CacheTTL.STREAM_ANALYTICS, CommunityOverlap)
 _NEIGHBORS_CACHE = ModelCachePolicy("creator_neighbors", CacheTTL.STREAM_ANALYTICS, CreatorNeighbors)
+_HEAD_TO_HEAD_CACHE = ModelCachePolicy("creator_head_to_head", CacheTTL.STREAM_ANALYTICS, CreatorHeadToHead)
+
+
+@router.get(
+    "/community/head-to-head",
+    response_model=CreatorHeadToHead,
+    summary="Compare two creators' audiences head-to-head",
+    description=(
+        "Shared audience, jaccard, and each side's share of overlap for two creators. "
+        "A pair that never co-attended is a legitimate zero, not a 404."
+    ),
+    responses={
+        404: {"description": "One or both creators have no audience rollup yet"},
+        429: {"model": RateLimitErrorResponse, "description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit(rate_limits.ANALYTICS)
+def get_creator_head_to_head(
+    request: Request,
+    response: Response,
+    creator_a: int = Query(..., description="First creator ID", ge=1),
+    creator_b: int = Query(..., description="Second creator ID", ge=1),
+) -> CreatorHeadToHead:
+    """Pairwise audience comparison built from the overlap rollups."""
+    if creator_a == creator_b:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Pick two different creators to compare.",
+        )
+    with _HEAD_TO_HEAD_CACHE.record_failures():
+        cache = get_cache(request)
+        lo, hi = sorted((creator_a, creator_b))
+        cache_key, cached_result = _HEAD_TO_HEAD_CACHE.lookup(cache, response, lo, hi, scene_rollup_version())
+        if cached_result is not None:
+            return cached_result
+
+        try:
+            # Normalized to (lo, hi) so the cached payload is order-independent:
+            # side `a` is always the lower creator id, whatever the param order.
+            result = query_head_to_head(lo, hi)
+        except HeadToHeadNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No audience data for one of these creators yet. It appears after their first rollup.",
+            ) from None
+        _HEAD_TO_HEAD_CACHE.store(cache, response, cache_key, result)
+        return result
 
 
 @router.get(

--- a/backend/stream_sniper/api/features/content/scene_trending_models.py
+++ b/backend/stream_sniper/api/features/content/scene_trending_models.py
@@ -78,6 +78,7 @@ class TrendingEmote(BaseModel):
     delta_pct: float | None = Field(None, description="Percent change vs the prior window; null when prior_usage is 0")
     trend: str = Field(..., description="One of: new, rising, falling, steady")
     chatter_reach: int = Field(..., description="Sum of per-stream chatter_count in the current window")
+    creator_count: int = Field(..., description="Distinct channels the emote appeared in during the current window")
     first_seen: str | None = Field(None, description="Dictionary first-seen time (ISO 8601), if known")
 
     @classmethod
@@ -92,6 +93,7 @@ class TrendingEmote(BaseModel):
             delta_pct=_delta_pct(row.current_usage, row.prior_usage),
             trend=_classify_trend(row.current_usage, row.prior_usage),
             chatter_reach=row.chatter_reach,
+            creator_count=row.creator_count,
             first_seen=row.first_seen,
         )
 

--- a/backend/stream_sniper/application/community/head_to_head_query.py
+++ b/backend/stream_sniper/application/community/head_to_head_query.py
@@ -1,0 +1,61 @@
+"""Application query assembling a creator head-to-head from overlap rollups."""
+
+from stream_sniper.database.gateways.community.creator_overlap_table_gateway import (
+    select_creator_audiences_db,
+    select_creator_pair_overlap_db,
+)
+from stream_sniper.database.gateways.community.records import CommunityCreatorRow
+
+from .community_query import jaccard
+from .models import CreatorHeadToHead, HeadToHeadCreator
+
+
+class HeadToHeadNotFoundError(LookupError):
+    """One or both creators have no audience rollup yet."""
+
+
+def _share(shared: int, audience: int) -> float | None:
+    """Fraction of this creator's audience that is shared; None for an empty audience."""
+    if audience <= 0:
+        return None
+    return round(shared / audience, 4)
+
+
+def _side(row: CommunityCreatorRow, shared_chatters: int, shared_regulars: int) -> HeadToHeadCreator:
+    return HeadToHeadCreator(
+        creator_id=row.creator_id,
+        nick=row.nick,
+        display_name=row.display_name,
+        chatters=row.chatters,
+        regulars=row.regulars,
+        shared_chatter_share=_share(shared_chatters, row.chatters),
+        shared_regular_share=_share(shared_regulars, row.regulars),
+    )
+
+
+def get_head_to_head(creator_a: int, creator_b: int) -> CreatorHeadToHead:
+    """Assemble the pairwise comparison for two creators.
+
+    A missing overlap row (pair never co-attended) is a legitimate zero, not an
+    error — only a missing audience rollup raises.
+    """
+    audiences = {row.creator_id: row for row in select_creator_audiences_db([creator_a, creator_b])}
+    missing = [cid for cid in (creator_a, creator_b) if cid not in audiences]
+    if missing:
+        raise HeadToHeadNotFoundError(f"No audience rollup for creators: {missing}")
+
+    pair = select_creator_pair_overlap_db(creator_a, creator_b)
+    shared_chatters = pair.shared_chatters if pair else 0
+    shared_regulars = pair.shared_regulars if pair else 0
+
+    row_a = audiences[creator_a]
+    row_b = audiences[creator_b]
+    return CreatorHeadToHead(
+        a=_side(row_a, shared_chatters, shared_regulars),
+        b=_side(row_b, shared_chatters, shared_regulars),
+        shared_chatters=shared_chatters,
+        shared_regulars=shared_regulars,
+        jaccard_chatters=jaccard(shared_chatters, row_a.chatters, row_b.chatters),
+        jaccard_regulars=jaccard(shared_regulars, row_a.regulars, row_b.regulars),
+        computed_at=row_a.computed_at,
+    )

--- a/backend/stream_sniper/application/community/models.py
+++ b/backend/stream_sniper/application/community/models.py
@@ -68,3 +68,27 @@ class CreatorNeighbors(BaseModel):
     creator_id: int
     metric: str
     neighbors: list[CreatorNeighbor]
+
+
+class HeadToHeadCreator(BaseModel):
+    """One side of a creator head-to-head: audience denominators + share of overlap."""
+
+    creator_id: int
+    nick: str
+    display_name: str
+    chatters: int
+    regulars: int
+    shared_chatter_share: float | None = None
+    shared_regular_share: float | None = None
+
+
+class CreatorHeadToHead(BaseModel):
+    """Pairwise audience comparison. nullable=unknown: shares are null for empty audiences."""
+
+    a: HeadToHeadCreator
+    b: HeadToHeadCreator
+    shared_chatters: int
+    shared_regulars: int
+    jaccard_chatters: float | None = None
+    jaccard_regulars: float | None = None
+    computed_at: str | None = None

--- a/backend/stream_sniper/database/gateways/analytics/scene_trends_gateway.py
+++ b/backend/stream_sniper/database/gateways/analytics/scene_trends_gateway.py
@@ -50,6 +50,7 @@ class TrendingEmoteRow(NamedTuple):
     current_usage: int
     prior_usage: int
     chatter_reach: int
+    creator_count: int
     first_seen: str | None
 
 
@@ -147,6 +148,8 @@ def select_trending_emotes_db(
                    FILTER (WHERE s.start >= b.prior_start AND s.start < b.cur_start), 0) AS prior_usage,
                COALESCE(SUM(ses.chatter_count)
                    FILTER (WHERE s.start >= b.cur_start AND s.start < b.cur_end), 0) AS chatter_reach,
+               COUNT(DISTINCT s.creator_id)
+                   FILTER (WHERE s.start >= b.cur_start AND s.start < b.cur_end) AS creator_count,
                {to_char_wire("d.first_seen AT TIME ZONE 'UTC'")} AS first_seen
         FROM stream_emote_stats ses
         JOIN stream s ON s.id = ses.stream_id

--- a/backend/stream_sniper/database/gateways/community/creator_overlap_table_gateway.py
+++ b/backend/stream_sniper/database/gateways/community/creator_overlap_table_gateway.py
@@ -152,3 +152,49 @@ def select_creator_neighbors_db(
         {"cid": creator_id, "limit": limit},
     )
     return [CreatorNeighborRow(*row) for row in cursor.fetchall()]
+
+
+@with_cursor
+def select_creator_audiences_db(
+    cursor: Cursor,
+    creator_ids: list[int],
+) -> list[CommunityCreatorRow]:
+    """Audience rollup rows for specific creators (head-to-head denominators)."""
+    if not creator_ids:
+        return []
+    cursor.execute(
+        f"""
+        SELECT ca.creator_id, c.nick, c.display_name, ca.chatters, ca.regulars,
+               {to_char_wire("ca.computed_at")}
+        FROM creator_audience ca
+        JOIN creator c ON c.id = ca.creator_id
+        WHERE ca.creator_id = ANY(%s)
+        ORDER BY ca.creator_id ASC
+        """,
+        (creator_ids,),
+    )
+    return [CommunityCreatorRow(*row) for row in cursor.fetchall()]
+
+
+@with_cursor
+def select_creator_pair_overlap_db(
+    cursor: Cursor,
+    creator_a: int,
+    creator_b: int,
+) -> CommunityPairRow | None:
+    """The stored overlap row for one creator pair, or None when never computed.
+
+    ``creator_overlap`` enforces creator_a < creator_b, so the pair is
+    normalized before querying.
+    """
+    lo, hi = sorted((creator_a, creator_b))
+    cursor.execute(
+        """
+        SELECT creator_a, creator_b, shared_chatters, shared_regulars
+        FROM creator_overlap
+        WHERE creator_a = %s AND creator_b = %s
+        """,
+        (lo, hi),
+    )
+    row = cursor.fetchone()
+    return CommunityPairRow(*row) if row else None

--- a/backend/tests/unit/api/test_community.py
+++ b/backend/tests/unit/api/test_community.py
@@ -160,3 +160,84 @@ class TestCreatorNeighborsEndpoint:
     def test_invalid_metric_rejected(self):
         response = _client().get("/community/creators/5/neighbors?metric=bogus")
         assert response.status_code == 422
+
+
+def _audience(cid, nick, chatters, regulars):
+    return CommunityCreatorRow(cid, nick, nick.title(), chatters, regulars, "2026-07-19T06:00:00")
+
+
+class TestHeadToHead:
+    _Q = "stream_sniper.application.community.head_to_head_query"
+    _E = "stream_sniper.api.features.community.community_endpoints"
+
+    def _get(self, a, b):
+        with (
+            patch(f"{self._E}.get_cache", return_value=_miss_cache()),
+            patch(f"{self._E}.scene_rollup_version", return_value="v1"),
+        ):
+            return _client().get(f"/community/head-to-head?creator_a={a}&creator_b={b}")
+
+    def test_shapes_pair_with_shares_and_jaccard(self):
+        with (
+            patch(
+                f"{self._Q}.select_creator_audiences_db",
+                return_value=[_audience(3, "alpha", 100, 20), _audience(4, "beta", 50, 10)],
+            ),
+            patch(
+                f"{self._Q}.select_creator_pair_overlap_db",
+                return_value=CommunityPairRow(3, 4, 30, 5),
+            ),
+        ):
+            response = self._get(3, 4)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["a"]["creator_id"] == 3
+        assert body["a"]["shared_chatter_share"] == 0.3
+        assert body["b"]["shared_chatter_share"] == 0.6
+        assert body["shared_chatters"] == 30
+        assert body["jaccard_chatters"] == _jaccard(30, 100, 50)
+        assert body["computed_at"] == "2026-07-19T06:00:00"
+
+    def test_param_order_never_changes_sides(self):
+        with (
+            patch(
+                f"{self._Q}.select_creator_audiences_db",
+                return_value=[_audience(3, "alpha", 100, 20), _audience(4, "beta", 50, 10)],
+            ),
+            patch(f"{self._Q}.select_creator_pair_overlap_db", return_value=None),
+        ):
+            response = self._get(4, 3)
+
+        assert response.status_code == 200
+        body = response.json()
+        # Side `a` is always the lower creator id, regardless of param order.
+        assert body["a"]["creator_id"] == 3
+        assert body["shared_chatters"] == 0
+        assert body["a"]["shared_chatter_share"] == 0.0
+
+    def test_missing_audience_rollup_404s(self):
+        with (
+            patch(f"{self._Q}.select_creator_audiences_db", return_value=[_audience(3, "alpha", 100, 20)]),
+            patch(f"{self._Q}.select_creator_pair_overlap_db", return_value=None),
+        ):
+            response = self._get(3, 99)
+
+        assert response.status_code == 404
+
+    def test_same_creator_rejected(self):
+        response = self._get(5, 5)
+        assert response.status_code == 400
+
+    def test_empty_audience_share_is_null(self):
+        with (
+            patch(
+                f"{self._Q}.select_creator_audiences_db",
+                return_value=[_audience(3, "alpha", 0, 0), _audience(4, "beta", 50, 10)],
+            ),
+            patch(f"{self._Q}.select_creator_pair_overlap_db", return_value=None),
+        ):
+            response = self._get(3, 4)
+
+        assert response.status_code == 200
+        assert response.json()["a"]["shared_chatter_share"] is None

--- a/backend/tests/unit/api/test_scene_trending.py
+++ b/backend/tests/unit/api/test_scene_trending.py
@@ -63,6 +63,7 @@ def _emote(eid=1, current=10, prior=5, first_seen="2026-01-01T00:00:00"):
         current_usage=current,
         prior_usage=prior,
         chatter_reach=7,
+        creator_count=4,
         first_seen=first_seen,
     )
 
@@ -211,6 +212,7 @@ class TestTrendingEmotes:
             "delta_pct": None,
             "trend": "new",
             "chatter_reach": 7,
+            "creator_count": 4,
             "first_seen": "2026-01-01T00:00:00",
         }
         mock_gw.assert_called_once_with(7, None, 20)

--- a/frontend/app/(app)/emotes/page.tsx
+++ b/frontend/app/(app)/emotes/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next'
+import EmoteEconomy from '@/views/scene/EmoteEconomy'
+
+// Server wrapper so the public listing page carries a real title/description in
+// tabs and social unfurls; the view stays a client component.
+export const metadata: Metadata = {
+  title: 'Emote economy',
+  description: 'Which emotes dominate the Czech Twitch scene, and how far they spread across channels.',
+}
+
+export default function EmotesPage() {
+  return <EmoteEconomy />
+}

--- a/frontend/app/(app)/versus/page.tsx
+++ b/frontend/app/(app)/versus/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+import { use } from 'react'
+import Versus from '@/views/community/Versus'
+
+const parseCreatorId = (raw: string | undefined): number | null => {
+  const id = Number(raw)
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+export default function VersusPage({ searchParams }: { searchParams: Promise<{ a?: string, b?: string }> }) {
+  const { a, b } = use(searchParams)
+  return <Versus initialA={parseCreatorId(a)} initialB={parseCreatorId(b)} />
+}

--- a/frontend/components/layout/Sidebar.jsx
+++ b/frontend/components/layout/Sidebar.jsx
@@ -53,6 +53,11 @@ const navigationGroups = [
                 icon: 'bi bi-graph-up-arrow',
             },
             {
+                title: 'Emotes',
+                href: '/emotes',
+                icon: 'bi bi-emoji-laughing',
+            },
+            {
                 title: 'Copypasta',
                 href: '/copypasta',
                 icon: 'bi bi-chat-quote',
@@ -106,6 +111,11 @@ const navigationGroups = [
                 title: 'Compare',
                 href: '/compare',
                 icon: 'bi bi-columns-gap',
+            },
+            {
+                title: 'Versus',
+                href: '/versus',
+                icon: 'bi bi-intersect',
             },
         ],
     },

--- a/frontend/e2e/scene-surfaces.spec.ts
+++ b/frontend/e2e/scene-surfaces.spec.ts
@@ -302,6 +302,7 @@ test('trending: renders both boards, and the window pill refetches them', async 
           delta_pct: -5,
           trend: 'falling',
           chatter_reach: 210,
+          creator_count: 4,
           first_seen: '2026-05-01T00:00:00Z',
         }],
       })

--- a/frontend/hooks/community/useHeadToHeadQuery.ts
+++ b/frontend/hooks/community/useHeadToHeadQuery.ts
@@ -1,0 +1,80 @@
+import { useQuery } from '@tanstack/react-query'
+import { retrieveCreatorHeadToHead } from '@/lib/api/community'
+import {
+    requireFiniteNumberField,
+    requireNullableFiniteNumberField,
+    requireNullableStringField,
+    requireRecord,
+    requireStringField,
+} from '@/lib/api/contractGuards'
+
+export interface HeadToHeadSide {
+    creatorId: number
+    nick: string
+    displayName: string
+    chatters: number
+    regulars: number
+    /** This side's overlap share of its own audience; null when the audience is empty (unknown, not 0). */
+    sharedChatterShare: number | null
+    sharedRegularShare: number | null
+}
+
+export interface CreatorHeadToHead {
+    /** Side `a` is always the lower creator id — the payload is param-order independent. */
+    a: HeadToHeadSide
+    b: HeadToHeadSide
+    sharedChatters: number
+    sharedRegulars: number
+    jaccardChatters: number | null
+    jaccardRegulars: number | null
+    computedAt: string | null
+}
+
+const headToHeadKeys = {
+    all: ['community', 'head-to-head'] as const,
+    pair: (a: number, b: number) => {
+        // Normalize like the backend cache so (a,b) and (b,a) share one cache entry.
+        const [lo, hi] = a < b ? [a, b] : [b, a]
+        return [...headToHeadKeys.all, { a: lo, b: hi }] as const
+    },
+}
+
+const mapSide = (value: unknown, label: string): HeadToHeadSide => {
+    const side = requireRecord(value, label)
+    return {
+        creatorId: requireFiniteNumberField(side, 'creator_id', label),
+        nick: requireStringField(side, 'nick', label),
+        displayName: requireStringField(side, 'display_name', label),
+        chatters: requireFiniteNumberField(side, 'chatters', label),
+        regulars: requireFiniteNumberField(side, 'regulars', label),
+        sharedChatterShare: requireNullableFiniteNumberField(side, 'shared_chatter_share', label),
+        sharedRegularShare: requireNullableFiniteNumberField(side, 'shared_regular_share', label),
+    }
+}
+
+export const mapCreatorHeadToHead = (value: unknown): CreatorHeadToHead => {
+    const data = requireRecord(value, 'creator head-to-head')
+    return {
+        a: mapSide(data.a, 'creator head-to-head.a'),
+        b: mapSide(data.b, 'creator head-to-head.b'),
+        sharedChatters: requireFiniteNumberField(data, 'shared_chatters', 'creator head-to-head'),
+        sharedRegulars: requireFiniteNumberField(data, 'shared_regulars', 'creator head-to-head'),
+        jaccardChatters: requireNullableFiniteNumberField(data, 'jaccard_chatters', 'creator head-to-head'),
+        jaccardRegulars: requireNullableFiniteNumberField(data, 'jaccard_regulars', 'creator head-to-head'),
+        computedAt: requireNullableStringField(data, 'computed_at', 'creator head-to-head'),
+    }
+}
+
+export const useCreatorHeadToHead = (
+    creatorA: number | null,
+    creatorB: number | null,
+    { enabled = true }: { enabled?: boolean } = {},
+) => useQuery({
+    queryKey: creatorA && creatorB
+        ? headToHeadKeys.pair(creatorA, creatorB)
+        : [...headToHeadKeys.all, { a: creatorA, b: creatorB }],
+    queryFn: async () => mapCreatorHeadToHead(
+        (await retrieveCreatorHeadToHead(creatorA as number, creatorB as number)).data,
+    ),
+    enabled: enabled && Boolean(creatorA) && Boolean(creatorB) && creatorA !== creatorB,
+})

--- a/frontend/hooks/scene/useSceneTrendingQueries.ts
+++ b/frontend/hooks/scene/useSceneTrendingQueries.ts
@@ -46,6 +46,8 @@ export interface TrendingEmote {
     deltaPct: number | null
     trend: string
     chatterReach: number
+    /** Distinct channels the emote appeared in during the current window. */
+    creatorCount: number
     firstSeen: string | null
 }
 
@@ -93,6 +95,7 @@ export const mapTrendingEmotes = (value: unknown): TrendingEmotes => {
                 deltaPct: requireNullableFiniteNumberField(row, 'delta_pct', label),
                 trend: requireStringField(row, 'trend', label),
                 chatterReach: requireFiniteNumberField(row, 'chatter_reach', label),
+                creatorCount: requireFiniteNumberField(row, 'creator_count', label),
                 firstSeen: requireNullableStringField(row, 'first_seen', label),
             }
         }),

--- a/frontend/lib/api/community.ts
+++ b/frontend/lib/api/community.ts
@@ -37,6 +37,27 @@ export interface CreatorNeighborsDto {
   neighbors: CreatorNeighborDto[]
 }
 
+export interface HeadToHeadCreatorDto {
+  creator_id: number
+  nick: string
+  display_name: string
+  chatters: number
+  regulars: number
+  shared_chatter_share: number | null
+  shared_regular_share: number | null
+}
+
+export interface CreatorHeadToHeadDto {
+  /** Side `a` is always the lower creator id — the payload is param-order independent. */
+  a: HeadToHeadCreatorDto
+  b: HeadToHeadCreatorDto
+  shared_chatters: number
+  shared_regulars: number
+  jaccard_chatters: number | null
+  jaccard_regulars: number | null
+  computed_at: string | null
+}
+
 export const retrieveCommunityOverlap = (limit = 40) =>
   api.get<CommunityOverlapDto>(`/community/overlap?${buildQuery({ limit })}`)
 
@@ -47,3 +68,9 @@ export const retrieveCreatorNeighbors = (
   metric: request.metric,
   limit: request.limit,
 })}`)
+
+export const retrieveCreatorHeadToHead = (creatorA: number, creatorB: number) =>
+  api.get<CreatorHeadToHeadDto>(`/community/head-to-head?${buildQuery({
+    creator_a: creatorA,
+    creator_b: creatorB,
+  })}`)

--- a/frontend/lib/api/scene.ts
+++ b/frontend/lib/api/scene.ts
@@ -277,6 +277,7 @@ export interface TrendingEmotesDto {
     delta_pct: number | null
     trend: string
     chatter_reach: number
+    creator_count: number
     first_seen: string | null
   }>
 }

--- a/frontend/styles/_emotes.scss
+++ b/frontend/styles/_emotes.scss
@@ -1,0 +1,25 @@
+// Emote economy board — night-ops styling.
+// Extends the trending primitives (.trending-board, .trending-table); only the
+// economy-specific bits live here.
+
+.emote-economy-board {
+    .trending-board-head {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.15rem;
+    }
+}
+
+.emote-board-sub {
+    margin: 0;
+    font-size: 0.78rem;
+    color: $gray-500;
+}
+
+.emote-economy-table {
+    .emote-first-seen {
+        font-size: 0.78rem;
+        color: $gray-500;
+        white-space: nowrap;
+    }
+}

--- a/frontend/styles/_versus.scss
+++ b/frontend/styles/_versus.scss
@@ -1,0 +1,108 @@
+// Creator head-to-head (Versus) — night-ops styling.
+// Reuses .stat-tile / .toolbar / .chatter-tabs primitives from _theme.scss.
+
+.versus-toolbar {
+    flex-wrap: wrap;
+    row-gap: 0.6rem;
+
+    // Two creator pickers share the row; keep them usable on narrow screens.
+    > [class*="-container"] {
+        min-width: 14rem;
+        flex: 1 1 14rem;
+    }
+
+    .chatter-tabs {
+        margin-bottom: 0;
+        border-bottom: 0;
+    }
+}
+
+.versus-toolbar-vs {
+    font-family: $headings-font-family;
+    font-size: 0.75rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: $gray-500;
+}
+
+.versus-grid {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 1rem;
+    align-items: stretch;
+
+    @media (max-width: 991px) {
+        grid-template-columns: 1fr;
+    }
+}
+
+.versus-side,
+.versus-center {
+    border-radius: $border-radius;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.versus-side-name {
+    font-family: $headings-font-family;
+    font-size: 1.05rem;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.versus-side-stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+}
+
+.versus-center {
+    align-items: stretch;
+    justify-content: center;
+    min-width: 11rem;
+}
+
+.versus-vs {
+    text-align: center;
+    font-family: $headings-font-family;
+    font-size: 0.75rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: $gray-500;
+}
+
+.versus-share {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-top: auto;
+}
+
+.versus-share-label {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    font-size: 0.78rem;
+    color: $gray-400;
+}
+
+.versus-share-track {
+    height: 6px;
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+}
+
+.versus-share-fill {
+    height: 100%;
+    border-radius: 3px;
+    background: $phosphor-dim;
+}
+
+.versus-computed {
+    margin: 1rem 0 0;
+    font-size: 0.78rem;
+    color: $gray-500;
+}

--- a/frontend/styles/style.scss
+++ b/frontend/styles/style.scss
@@ -18,5 +18,7 @@
 @import "rankings";
 @import "highlights";
 @import "trending";
+@import "emotes";
+@import "versus";
 @import "wrapped";
 @import "radar";

--- a/frontend/test/trending.test.tsx
+++ b/frontend/test/trending.test.tsx
@@ -51,6 +51,7 @@ const emoteItem = {
   delta_pct: null,
   trend: 'new',
   chatter_reach: 42,
+  creator_count: 6,
   first_seen: null,
 }
 
@@ -110,6 +111,7 @@ describe('scene trending velocity contracts', () => {
         deltaPct: null,
         trend: 'new',
         chatterReach: 42,
+        creatorCount: 6,
         firstSeen: null,
       }],
     })

--- a/frontend/test/versusAndEmotes.test.tsx
+++ b/frontend/test/versusAndEmotes.test.tsx
@@ -1,0 +1,231 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, renderHook, screen, waitFor } from '@testing-library/react'
+import type { PropsWithChildren } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetNavigationMocks, router } from './mocks/navigation'
+
+const api = vi.hoisted(() => ({
+  retrieveCreatorHeadToHead: vi.fn(),
+}))
+
+const sceneHooks = vi.hoisted(() => ({
+  useSceneTrendingEmotes: vi.fn(),
+}))
+
+const creatorHooks = vi.hoisted(() => ({
+  useCreators: vi.fn(),
+}))
+
+vi.mock('@/lib/api/community', () => api)
+vi.mock('@/hooks/scene/useSceneTrendingQueries', () => sceneHooks)
+vi.mock('@/hooks/creator/useCreatorsQuery', async () => ({
+  ...(await vi.importActual<object>('@/hooks/creator/useCreatorsQuery')),
+  useCreators: creatorHooks.useCreators,
+}))
+
+import {
+  mapCreatorHeadToHead,
+  useCreatorHeadToHead,
+} from '@/hooks/community/useHeadToHeadQuery'
+import Versus from '@/views/community/Versus'
+import EmoteEconomy from '@/views/scene/EmoteEconomy'
+
+const createWrapper = (queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})) => function Wrapper({ children }: PropsWithChildren) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+const sideA = {
+  creator_id: 3,
+  nick: 'alpha',
+  display_name: 'Alpha',
+  chatters: 1000,
+  regulars: 120,
+  shared_chatter_share: 0.25,
+  shared_regular_share: 0.1,
+}
+
+const sideB = {
+  creator_id: 9,
+  nick: 'bravo',
+  display_name: 'Bravo',
+  chatters: 500,
+  regulars: 60,
+  shared_chatter_share: 0.5,
+  shared_regular_share: 0.2,
+}
+
+const headToHeadPayload = {
+  a: sideA,
+  b: sideB,
+  shared_chatters: 250,
+  shared_regulars: 12,
+  jaccard_chatters: 0.2,
+  jaccard_regulars: 0.0714,
+  computed_at: '2026-07-18T10:00:00',
+}
+
+describe('creator head-to-head contracts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetNavigationMocks()
+  })
+
+  it('maps a full payload including null share / jaccard edges', () => {
+    expect(mapCreatorHeadToHead(headToHeadPayload)).toEqual({
+      a: {
+        creatorId: 3,
+        nick: 'alpha',
+        displayName: 'Alpha',
+        chatters: 1000,
+        regulars: 120,
+        sharedChatterShare: 0.25,
+        sharedRegularShare: 0.1,
+      },
+      b: {
+        creatorId: 9,
+        nick: 'bravo',
+        displayName: 'Bravo',
+        chatters: 500,
+        regulars: 60,
+        sharedChatterShare: 0.5,
+        sharedRegularShare: 0.2,
+      },
+      sharedChatters: 250,
+      sharedRegulars: 12,
+      jaccardChatters: 0.2,
+      jaccardRegulars: 0.0714,
+      computedAt: '2026-07-18T10:00:00',
+    })
+
+    const empty = mapCreatorHeadToHead({
+      ...headToHeadPayload,
+      a: { ...sideA, chatters: 0, regulars: 0, shared_chatter_share: null, shared_regular_share: null },
+      jaccard_chatters: null,
+      jaccard_regulars: null,
+      computed_at: null,
+    })
+    expect(empty.a.sharedChatterShare).toBeNull()
+    expect(empty.jaccardChatters).toBeNull()
+    expect(empty.computedAt).toBeNull()
+  })
+
+  it('rejects malformed payloads at the boundary', () => {
+    expect(() => mapCreatorHeadToHead({ ...headToHeadPayload, a: null })).toThrow(TypeError)
+    expect(() => mapCreatorHeadToHead({ ...headToHeadPayload, shared_chatters: 'nope' })).toThrow(TypeError)
+    expect(() => mapCreatorHeadToHead({
+      ...headToHeadPayload,
+      b: { ...sideB, shared_chatter_share: undefined },
+    })).toThrow(TypeError)
+  })
+
+  it('fetches when both creators are picked and normalizes the query key', async () => {
+    api.retrieveCreatorHeadToHead.mockResolvedValue({ data: headToHeadPayload })
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { result } = renderHook(
+      () => useCreatorHeadToHead(9, 3),
+      { wrapper: createWrapper(client) },
+    )
+    await waitFor(() => expect((result.current as any).isSuccess).toBe(true))
+
+    expect(api.retrieveCreatorHeadToHead).toHaveBeenCalledWith(9, 3)
+    // Key is (lo, hi) so (9,3) and (3,9) share one cache entry, mirroring the backend cache.
+    expect(client.getQueryCache().find({
+      queryKey: ['community', 'head-to-head', { a: 3, b: 9 }],
+    })).toBeDefined()
+  })
+
+  it('stays idle without two distinct creators', async () => {
+    renderHook(() => useCreatorHeadToHead(null, 3), { wrapper: createWrapper() })
+    renderHook(() => useCreatorHeadToHead(4, 4), { wrapper: createWrapper() })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(api.retrieveCreatorHeadToHead).not.toHaveBeenCalled()
+  })
+})
+
+describe('Versus view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetNavigationMocks()
+    creatorHooks.useCreators.mockReturnValue({
+      data: [
+        { creatorId: 3, nick: 'Alpha' },
+        { creatorId: 9, nick: 'Bravo' },
+      ],
+    })
+  })
+
+  it('renders the matchup oriented to the picker order, not the normalized payload', async () => {
+    api.retrieveCreatorHeadToHead.mockResolvedValue({ data: headToHeadPayload })
+    // Left picker holds creator 9 (Bravo) — the payload's *b* side.
+    render(<Versus initialA={9} initialB={3} />, { wrapper: createWrapper() })
+
+    await waitFor(() => expect(screen.getByText('Shared chatters')).toBeInTheDocument())
+    const names = screen.getAllByRole('link').map(link => link.textContent)
+    expect(names.indexOf('Bravo')).toBeLessThan(names.indexOf('Alpha'))
+    expect(screen.getByText('250')).toBeInTheDocument()
+    expect(screen.getByText('20.0%')).toBeInTheDocument()
+  })
+
+  it('deep-links picker changes into the URL without fetching a half-empty pair', async () => {
+    render(<Versus />, { wrapper: createWrapper() })
+    expect(screen.getByText('Pick two creators')).toBeInTheDocument()
+    expect(api.retrieveCreatorHeadToHead).not.toHaveBeenCalled()
+    expect(router.replace).not.toHaveBeenCalled()
+  })
+
+  it('flags picking the same creator on both sides', () => {
+    api.retrieveCreatorHeadToHead.mockResolvedValue({ data: headToHeadPayload })
+    render(<Versus initialA={3} initialB={3} />, { wrapper: createWrapper() })
+    expect(screen.getByText('Same creator on both sides')).toBeInTheDocument()
+    expect(api.retrieveCreatorHeadToHead).not.toHaveBeenCalled()
+  })
+})
+
+describe('EmoteEconomy view', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  const emote = {
+    emoteId: 11,
+    name: 'PogU',
+    source: '7tv',
+    providerId: null,
+    currentUsage: 90,
+    priorUsage: 40,
+    deltaPct: 125,
+    trend: 'rising',
+    chatterReach: 42,
+    creatorCount: 6,
+    firstSeen: '2026-06-01T00:00:00',
+  }
+
+  it('requests the full 50-row board and renders channels / reach / first seen', () => {
+    sceneHooks.useSceneTrendingEmotes.mockReturnValue({
+      data: { window: 7, items: [emote] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<EmoteEconomy />)
+
+    expect(sceneHooks.useSceneTrendingEmotes).toHaveBeenCalledWith({ window: 7, limit: 50 })
+    expect(screen.getByText('PogU')).toBeInTheDocument()
+    expect(screen.getByText('7tv')).toBeInTheDocument()
+    expect(screen.getByText('▲ +125%')).toBeInTheDocument()
+    expect(screen.getByText('6')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('Jun 1, 2026')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when nothing clears the usage floor', () => {
+    sceneHooks.useSceneTrendingEmotes.mockReturnValue({
+      data: { window: 7, items: [] },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    render(<EmoteEconomy />)
+    expect(screen.getByText('No emotes cleared the floor in this window')).toBeInTheDocument()
+  })
+})

--- a/frontend/views/community/Versus.tsx
+++ b/frontend/views/community/Versus.tsx
@@ -1,0 +1,230 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import { usePathname, useRouter } from 'next/navigation'
+import Select from 'react-select'
+import QueryState from '@/components/common/QueryState'
+import { useCreatorHeadToHead, type CreatorHeadToHead, type HeadToHeadSide } from '@/hooks/community/useHeadToHeadQuery'
+import { mapCreatorOption, useCreators } from '@/hooks/creator/useCreatorsQuery'
+import { formatDate } from '@/utils/dateUtils'
+import { shareBarWidth } from '@/utils/numberUtils'
+
+const formatShare = (share: number | null): string => (
+    share === null ? '—' : `${(share * 100).toFixed(1)}%`
+)
+
+const formatJaccard = (value: number | null): string => (
+    value === null ? '—' : `${(value * 100).toFixed(1)}%`
+)
+
+interface SideCardProps {
+    side: HeadToHeadSide
+    /** Which overlap metric the share bars visualize. */
+    metricLabel: 'chatters' | 'regulars'
+}
+
+const SideCard = ({ side, metricLabel }: SideCardProps) => {
+    const share = metricLabel === 'chatters' ? side.sharedChatterShare : side.sharedRegularShare
+    return (
+        <div className="versus-side card">
+            <Link className="versus-side-name" href={`/creator/${side.creatorId}`}>
+                {side.displayName || side.nick}
+            </Link>
+            <div className="versus-side-stats">
+                <div className="stat-tile">
+                    <div className="stat-label">Chatters</div>
+                    <div className="stat-value">{side.chatters.toLocaleString()}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">Regulars</div>
+                    <div className="stat-value">{side.regulars.toLocaleString()}</div>
+                </div>
+            </div>
+            <div className="versus-share">
+                <div className="versus-share-label">
+                    <span>{`Audience shared (${metricLabel})`}</span>
+                    <span className="mono">{formatShare(share)}</span>
+                </div>
+                <div className="versus-share-track" aria-hidden="true">
+                    <div
+                        className="versus-share-fill"
+                        style={{ width: `${share === null ? 0 : shareBarWidth(share)}%` }}
+                    />
+                </div>
+            </div>
+        </div>
+    )
+}
+
+interface VersusResultProps {
+    data: CreatorHeadToHead
+    /** Creator id picked on the left, so the display order follows the pickers, not the normalized payload. */
+    leftId: number
+    metric: 'chatters' | 'regulars'
+}
+
+const VersusResult = ({ data, leftId, metric }: VersusResultProps) => {
+    // The payload is normalized (side `a` = lower id); re-orient it to the pickers.
+    const [left, right] = data.a.creatorId === leftId ? [data.a, data.b] : [data.b, data.a]
+    return (
+        <>
+            <div className="versus-grid">
+                <SideCard side={left} metricLabel={metric} />
+                <div className="versus-center card">
+                    <div className="versus-vs" aria-hidden="true">vs</div>
+                    <div className="stat-tile">
+                        <div className="stat-label">Shared chatters</div>
+                        <div className="stat-value">{data.sharedChatters.toLocaleString()}</div>
+                    </div>
+                    <div className="stat-tile">
+                        <div className="stat-label">Shared regulars</div>
+                        <div className="stat-value">{data.sharedRegulars.toLocaleString()}</div>
+                    </div>
+                    <div className="stat-tile">
+                        <div className="stat-label">Jaccard (chatters)</div>
+                        <div className="stat-value">{formatJaccard(data.jaccardChatters)}</div>
+                    </div>
+                    <div className="stat-tile">
+                        <div className="stat-label">Jaccard (regulars)</div>
+                        <div className="stat-value">{formatJaccard(data.jaccardRegulars)}</div>
+                    </div>
+                </div>
+                <SideCard side={right} metricLabel={metric} />
+            </div>
+            {data.computedAt ? (
+                <p className="versus-computed">
+                    {`Overlap rollup computed ${formatDate(data.computedAt, 'MMM d, yyyy HH:mm')} UTC.`}
+                </p>
+            ) : null}
+        </>
+    )
+}
+
+interface VersusProps {
+    initialA?: number | null
+    initialB?: number | null
+}
+
+const Versus = ({ initialA = null, initialB = null }: VersusProps) => {
+    const [creatorA, setCreatorA] = useState<number | null>(initialA)
+    const [creatorB, setCreatorB] = useState<number | null>(initialB)
+    const [metric, setMetric] = useState<'chatters' | 'regulars'>('chatters')
+    const router = useRouter()
+    const pathname = usePathname()
+
+    const creatorsQuery = useCreators()
+    const options = useMemo(
+        () => (creatorsQuery.data || []).map(mapCreatorOption),
+        [creatorsQuery.data],
+    )
+    const selectedA = options.find(option => option.value === creatorA) || null
+    const selectedB = options.find(option => option.value === creatorB) || null
+
+    const pickCreator = (side: 'a' | 'b', value: number | null) => {
+        const nextA = side === 'a' ? value : creatorA
+        const nextB = side === 'b' ? value : creatorB
+        if (side === 'a') setCreatorA(value)
+        else setCreatorB(value)
+        // Keep the matchup deep-linkable without triggering a navigation/remount.
+        const params = new URLSearchParams()
+        if (nextA) params.set('a', String(nextA))
+        if (nextB) params.set('b', String(nextB))
+        const query = params.toString()
+        router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+    }
+
+    const samePick = creatorA !== null && creatorA === creatorB
+    const query = useCreatorHeadToHead(creatorA, creatorB)
+
+    return (
+        <>
+            <header className="page-head">
+                <div>
+                    <p className="page-sub">
+                        shared audience, side by side
+                    </p>
+                    <h1 className="page-title">
+                        Head-to-head
+                    </h1>
+                </div>
+            </header>
+            <div className="toolbar versus-toolbar">
+                <Select
+                    classNamePrefix="rs"
+                    instanceId="versus-creator-a"
+                    options={options}
+                    value={selectedA}
+                    onChange={option => pickCreator('a', option?.value || null)}
+                    placeholder="First creator..."
+                    aria-label="First creator"
+                />
+                <span className="versus-toolbar-vs" aria-hidden="true">vs</span>
+                <Select
+                    classNamePrefix="rs"
+                    instanceId="versus-creator-b"
+                    options={options}
+                    value={selectedB}
+                    onChange={option => pickCreator('b', option?.value || null)}
+                    placeholder="Second creator..."
+                    aria-label="Second creator"
+                />
+                <div
+                    className="chatter-tabs"
+                    role="tablist"
+                    aria-label="Share metric"
+                >
+                    {(['chatters', 'regulars'] as const).map(option => (
+                        <button
+                            key={option}
+                            type="button"
+                            role="tab"
+                            aria-selected={metric === option}
+                            className={metric === option ? 'chatter-tab active' : 'chatter-tab'}
+                            onClick={() => setMetric(option)}
+                        >
+                            {option}
+                        </button>
+                    ))}
+                </div>
+            </div>
+            {!creatorA || !creatorB ? (
+                <div className="empty-state">
+                    <p className="empty-title">
+                        Pick two creators
+                    </p>
+                    <p className="empty-hint">
+                        See how much of their audiences overlap — shared chatters, regulars, and each side&apos;s share.
+                    </p>
+                </div>
+            ) : null}
+            {samePick ? (
+                <div className="empty-state">
+                    <p className="empty-title">
+                        Same creator on both sides
+                    </p>
+                    <p className="empty-hint">
+                        Pick two different creators to compare.
+                    </p>
+                </div>
+            ) : null}
+            <QueryState
+                query={query}
+                errorTitle="Head-to-head unavailable"
+                loadingText="Weighing the audiences..."
+                emptyState={null}
+                showErrorDetails={false}
+            >
+                {(data: CreatorHeadToHead) => (
+                    <VersusResult
+                        data={data}
+                        leftId={creatorA as number}
+                        metric={metric}
+                    />
+                )}
+            </QueryState>
+        </>
+    )
+}
+
+export default Versus

--- a/frontend/views/scene/EmoteEconomy.tsx
+++ b/frontend/views/scene/EmoteEconomy.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
+import FilterPills from '@/components/common/FilterPills'
+import QueryState from '@/components/common/QueryState'
+import StatusChip from '@/components/common/StatusChip'
+import { trendIndicator } from '@/components/scene/TrendingRow'
+import {
+    useSceneTrendingEmotes,
+    type TrendingEmote,
+} from '@/hooks/scene/useSceneTrendingQueries'
+import type { TrendingWindow } from '@/lib/api/scene'
+import { formatCompactNumber, magnitudeBarWidth } from '@/utils/numberUtils'
+import { formatDate } from '@/utils/dateUtils'
+
+const WINDOW_TABS: Array<{ key: TrendingWindow, label: string }> = [
+    { key: 7, label: '7 days' },
+    { key: 14, label: '14 days' },
+    { key: 30, label: '30 days' },
+]
+
+// The trending endpoint's hard cap — the economy board wants the full field,
+// not the compact top-20 the Trending page shows.
+const BOARD_LIMIT = 50
+
+const firstSeenLabel = (firstSeen: string | null): string => (
+    firstSeen ? formatDate(firstSeen, 'MMM d, yyyy') : '—'
+)
+
+interface EmoteEconomyRowProps {
+    rank: number
+    item: TrendingEmote
+    maxUsage: number
+}
+
+const EmoteEconomyRow = ({ rank, item, maxUsage }: EmoteEconomyRowProps) => {
+    const indicator = trendIndicator(item.trend, item.deltaPct)
+    const barStyle: CSSProperties = { width: `${magnitudeBarWidth(item.currentUsage, maxUsage)}%` }
+
+    return (
+        <tr>
+            <td className="rank-num">{String(rank).padStart(2, '0')}</td>
+            <td className="trending-primary">
+                <span className="trending-label">{item.name}</span>
+                <span className="trending-source">{item.source}</span>
+            </td>
+            <td className="trending-usage text-end">
+                <span className="mono trending-usage-now">{formatCompactNumber(item.currentUsage)}</span>
+                <span className="data-bar" aria-hidden="true">
+                    <span className="data-bar-fill" style={barStyle} />
+                </span>
+                <span className="mono trending-usage-prior">
+                    was {formatCompactNumber(item.priorUsage)}
+                </span>
+            </td>
+            <td className="trending-trend">
+                <StatusChip variant={indicator.variant}>{indicator.label}</StatusChip>
+            </td>
+            <td className="mono text-end">{formatCompactNumber(item.creatorCount)}</td>
+            <td className="mono text-end">{formatCompactNumber(item.chatterReach)}</td>
+            <td className="emote-first-seen text-end">{firstSeenLabel(item.firstSeen)}</td>
+        </tr>
+    )
+}
+
+const EmoteEconomy = () => {
+    const [windowDays, setWindowDays] = useState<TrendingWindow>(7)
+
+    const emotesQuery = useSceneTrendingEmotes({ window: windowDays, limit: BOARD_LIMIT })
+
+    // Keep `undefined` while pending so QueryState shows its spinner, not an empty board.
+    const items = useMemo(
+        () => (emotesQuery.data ? emotesQuery.data.items : undefined),
+        [emotesQuery.data],
+    )
+
+    return (
+        <>
+            <div className="page-head">
+                <div>
+                    <p className="page-sub">who owns the scene&apos;s vocabulary</p>
+                    <h1 className="page-title">Emote economy</h1>
+                </div>
+            </div>
+
+            <div
+                className="toolbar trending-toolbar"
+                role="search"
+                aria-label="Emote economy controls">
+                <span className="toolbar-label">Window</span>
+                <FilterPills
+                    options={WINDOW_TABS}
+                    activeKey={windowDays}
+                    ariaLabel="Emote economy window"
+                    onChange={setWindowDays}
+                />
+            </div>
+
+            <section className="trending-board emote-economy-board card">
+                <div className="trending-board-head">
+                    <h2 className="trending-board-title">Scene-wide emote usage</h2>
+                    <p className="emote-board-sub">
+                        Usage vs. the prior {windowDays}-day window, with how many channels each emote crossed.
+                    </p>
+                </div>
+                <QueryState
+                    query={{
+                        data: items,
+                        isLoading: emotesQuery.isLoading,
+                        error: emotesQuery.error,
+                        refetch: emotesQuery.refetch,
+                    }}
+                    errorTitle="Unable to load the emote economy"
+                    loadingText="Counting the scene's emotes…"
+                    loadingSize="md"
+                    isEmpty={(rows: TrendingEmote[]) => rows.length === 0}
+                    emptyTitle="No emotes cleared the floor in this window"
+                    emptyHint={`No emote hit meaningful usage across the scene in the last ${windowDays} days.`}
+                >
+                    {(rows: TrendingEmote[]) => {
+                        const maxUsage = Math.max(1, ...rows.map(row => row.currentUsage))
+                        return (
+                            <div className="trending-table-wrap">
+                                <table className="table trending-table emote-economy-table">
+                                    <thead>
+                                        <tr>
+                                            <th className="trending-th-rank">#</th>
+                                            <th>Emote</th>
+                                            <th className="text-end">Now</th>
+                                            <th>Trend</th>
+                                            <th className="text-end">Channels</th>
+                                            <th className="text-end">Reach</th>
+                                            <th className="text-end">First seen</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {rows.map((item, index) => (
+                                            <EmoteEconomyRow
+                                                key={item.emoteId}
+                                                rank={index + 1}
+                                                item={item}
+                                                maxUsage={maxUsage}
+                                            />
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )
+                    }}
+                </QueryState>
+            </section>
+        </>
+    )
+}
+
+export default EmoteEconomy

--- a/frontend/views/scene/Trending.tsx
+++ b/frontend/views/scene/Trending.tsx
@@ -43,6 +43,7 @@ const toEmoteRow = (item: TrendingEmote): TrendingRowModel => ({
     deltaPct: item.deltaPct,
     trend: item.trend,
     context: [
+        { label: 'channels', value: item.creatorCount },
         { label: 'reach', value: item.chatterReach },
     ],
 })


### PR DESCRIPTION
Two of the six ideation features (PR B of 3), built entirely on existing rollups — no migration.

## Emote economy (`/emotes`)
- `GET /scene/trending/emotes` now returns `creator_count` — distinct channels the emote appeared in during the current window (one extra `COUNT(DISTINCT ...) FILTER` in the existing grouped pass).
- New scene page: the full 50-row board with usage bars vs prior window, trend chips, channels, chatter reach, and first-seen. The Trending page's emote board also gains a channels chip.

## Creator head-to-head (`/versus`)
- New `GET /community/head-to-head?creator_a=&creator_b=`: shared chatters/regulars, jaccard, and each side's share of its own audience, assembled from the `creator_audience` / `creator_overlap` rollups.
  - Cache key **and** query normalized to `(lo, hi)` → payload is param-order independent (side `a` = lower id).
  - Missing audience rollup → 404; a pair that never co-attended → legitimate zeros. Shares are null for empty audiences (nullable=unknown).
- New page: two creator pickers, deep-linkable `?a=&b=` (router.replace, no remount), chatters/regulars share-bar metric toggle, side cards re-oriented to picker order.

## Verification
- Backend: full unit suite green (79.28% cov, floor 75); 5 new H2H endpoint tests + updated trending tests.
- **New SQL executed against a scratch Postgres migrated to head** — audiences, reversed-param pair lookup, exact shares/jaccard, 404 path, and `creator_count=2` all asserted on real rows.
- Frontend: vitest 379 passed (10 new), `tsc` + checkJs boundary + ratchet green, production build OK, 12/12 Playwright journeys.

https://claude.ai/code/session_01N6W8wgzD5qPXBXuCTE4PJF