### PR TITLE
Type-honest fixes for Codex review findings on the TS migration

### DIFF
--- a/frontend/components/stream/replay/ChatReplayLine.tsx
+++ b/frontend/components/stream/replay/ChatReplayLine.tsx
@@ -16,10 +16,7 @@ interface ChatReplayLineProps {
 const ChatReplayLine = ({
     message, isFlashing,
 }: ChatReplayLineProps) => {
-    // badges is wire-typed as unknown[], but parseBadges's declared string param
-    // relies on String()-coercion (Array#toString comma-joins) — pre-existing
-    // mismatch between chatRender.tsx and useStreamMessagesQuery.ts, not fixed here.
-    const badges = parseBadges(message.badges as unknown as string)
+    const badges = parseBadges(message.badges)
     return (
         <div className={`chat-line${isFlashing ? ' chat-line--flash' : ''}`} role="listitem">
             <span className="chat-timestamp" aria-hidden="true">{clockFromTs(message.ts)}</span>

--- a/frontend/components/stream/timeline/StreamTimeline.tsx
+++ b/frontend/components/stream/timeline/StreamTimeline.tsx
@@ -3,7 +3,7 @@ import {
     useCallback, useMemo, useState, type MouseEvent,
 } from 'react'
 import { Card } from 'react-bootstrap'
-import { vodDeepLink, type buildVodChapters } from '@/utils/vodChapters'
+import { vodDeepLink } from '@/utils/vodChapters'
 import { useAuth } from '@/contexts/AuthContext'
 import { useMomentReview } from '@/hooks/moments/useMomentsQueries'
 import { getHoverIndex, useTimelineGeometry } from '@/hooks/stream/timeline/useTimelineGeometry'
@@ -89,15 +89,7 @@ const StreamTimeline = ({ timeline, onJump }: StreamTimelineProps) => {
     if (geometry.bucketCount === 0) return null
 
     const vodHref = activeMoment
-        // vodDeepLink's declared params don't include `undefined` (only
-        // null/string), but `timeline` itself can be undefined while loading.
-        // The casts are type-only — the underlying runtime value (undefined,
-        // null, or a string) flows through unchanged.
-        ? vodDeepLink(
-            timeline?.twitchVodId as string | number | null,
-            timeline?.streamStart as string,
-            activeMoment.t,
-        )
+        ? vodDeepLink(timeline?.twitchVodId, timeline?.streamStart, activeMoment.t)
         : null
 
     return (
@@ -106,14 +98,7 @@ const StreamTimeline = ({ timeline, onJump }: StreamTimelineProps) => {
                 <div className="timeline-head">
                     <h3 id="timeline-heading" className="section-label mb-0">Chat activity</h3>
                     <span className="timeline-subtitle">messages / minute</span>
-                    <CopyChaptersButton
-                        // buildVodChapters expects `topPhrases: string[] | null` and a
-                        // non-null `streamStart`; the timeline query mapper types these
-                        // more loosely (unknown[] | null, string | null) since it can't
-                        // guarantee the API shape. The cast is type-only — the same
-                        // `timeline` object flows through unchanged (see also
-                        // TimelineSelection.tsx, which documents the same API shape).
-                        timeline={timeline as Parameters<typeof buildVodChapters>[0]} />
+                    <CopyChaptersButton timeline={timeline} />
                 </div>
                 <TimelineLanes
                     buckets={buckets}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/test/vodChapters.test.ts
+++ b/frontend/test/vodChapters.test.ts
@@ -1,7 +1,7 @@
 import {
     describe, expect, it,
 } from 'vitest'
-import { buildVodChapters } from '@/utils/vodChapters'
+import { buildVodChapters, vodDeepLink } from '@/utils/vodChapters'
 
 const timeline = {
     twitchVodId: 123456,
@@ -38,6 +38,22 @@ describe('buildVodChapters', () => {
             ...timeline,
             twitchVodId: null,
         })).toBeNull()
+    })
+
+    it('returns null without a stream start (offset would be nonsense)', () => {
+        expect(buildVodChapters({
+            ...timeline,
+            streamStart: null,
+        })).toBeNull()
+        expect(vodDeepLink(123456, null, '2026-07-16T17:12:00')).toBeNull()
+    })
+
+    it('labels non-string phrase payloads as chat spike instead of stringifying', () => {
+        const chapters = buildVodChapters({
+            ...timeline,
+            moments: [{ t: '2026-07-16T17:12:00', count: 9, topPhrases: [{ phrase: 'obj' }] }],
+        })
+        expect(chapters).toContain('— chat spike (9 msgs)')
     })
 
     it('returns null without moments', () => {

--- a/frontend/utils/chatRender.tsx
+++ b/frontend/utils/chatRender.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX } from 'react'
+import { type JSX } from 'react'
 import Image from 'next/image'
 import { EMOTES } from '@/lib/bettertv_emotes'
 
@@ -80,11 +80,13 @@ export interface ParsedBadge {
 }
 
 /**
- * Parses a raw Twitch badges string ("moderator/1,subscriber/12") into structured,
- * render-ready entries. Returns [] for null/empty (legacy rows collected before
- * badge capture) so callers render nothing rather than a placeholder.
+ * Parses raw Twitch badges into structured, render-ready entries. The wire
+ * sends an array of badge tokens ("moderator/1"); legacy call sites pass the
+ * comma-joined string form — both stringify to the same "a/1,b/2" shape.
+ * Returns [] for null/empty (legacy rows collected before badge capture) so
+ * callers render nothing rather than a placeholder.
  */
-export const parseBadges = (badges: string | null | undefined): ParsedBadge[] => {
+export const parseBadges = (badges: unknown[] | string | null | undefined): ParsedBadge[] => {
     if (!badges) {
         return []
     }

--- a/frontend/utils/vodChapters.ts
+++ b/frontend/utils/vodChapters.ts
@@ -1,23 +1,25 @@
 /**
- * Twitch VOD deep-link + chapter-list helpers. Kept separate from
- * chatRender.jsx so checkJs boundary files can import them without pulling the
- * (unchecked) chat-render module into the typecheck graph.
+ * Twitch VOD deep-link + chapter-list helpers, typed to the timeline wire
+ * contract (nullable stream start, unknown-typed phrase payloads) so callers
+ * never need casts.
  */
 
 /**
  * Build a twitch.tv VOD deep link that seeks to a moment's offset.
  *
  * @param twitchVodId - The VOD id
- * @param streamStart - ISO timestamp of the stream start
+ * @param streamStart - ISO timestamp of the stream start (nullable on the wire)
  * @param momentTs - ISO timestamp of the moment to seek to
- * @returns A twitch.tv/videos deep-link, or null when there is no VOD id
+ * @returns A twitch.tv/videos deep-link, or null when there is no VOD id or no
+ *   usable start time (an offset computed against a missing start would seek
+ *   to a nonsense position).
  */
 export const vodDeepLink = (
-    twitchVodId: string | number | null,
-    streamStart: string,
+    twitchVodId: string | number | null | undefined,
+    streamStart: string | null | undefined,
     momentTs: string,
 ): string | null => {
-    if (!twitchVodId) {
+    if (!twitchVodId || !streamStart) {
         return null
     }
     const startMs = new Date(streamStart).getTime()
@@ -34,8 +36,14 @@ export const vodDeepLink = (
 
 interface VodChaptersTimeline {
     twitchVodId: string | number | null
-    streamStart: string
-    moments: Array<{ t: string, count: number, topPhrases?: string[] | null }>
+    streamStart: string | null
+    moments: Array<{ t: string, count: number, topPhrases?: unknown[] | null }>
+}
+
+/** First phrase of a moment when it is a non-empty string; the wire types phrases as unknown[]. */
+const momentLabel = (topPhrases: unknown[] | null | undefined): string => {
+    const first = topPhrases?.[0]
+    return typeof first === 'string' && first ? first : 'chat spike'
 }
 
 /**
@@ -43,10 +51,10 @@ interface VodChaptersTimeline {
  * moment with its VOD offset, a label (top chat phrase when available), the
  * message count, and a Twitch deep link.
  *
- * @returns Chapter text, or null when there is no VOD or no moments
+ * @returns Chapter text, or null when there is no VOD, no start time, or no moments
  */
 export const buildVodChapters = (timeline: VodChaptersTimeline | null | undefined): string | null => {
-    if (!timeline?.twitchVodId || !timeline.moments?.length) {
+    if (!timeline?.twitchVodId || !timeline.streamStart || !timeline.moments?.length) {
         return null
     }
     const startMs = new Date(timeline.streamStart).getTime()
@@ -59,7 +67,7 @@ export const buildVodChapters = (timeline: VodChaptersTimeline | null | undefine
         const m = Math.floor((offset % 3600) / 60)
         const s = offset % 60
         const stamp = `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-        const label = moment.topPhrases?.[0] || 'chat spike'
+        const label = momentLabel(moment.topPhrases)
         const link = vodDeepLink(timeline.twitchVodId, timeline.streamStart, moment.t)
         return `${stamp} — ${label} (${moment.count} msgs) ${link}`
     })


### PR DESCRIPTION
Follow-up to #80. A Codex review of the migration commit flagged two production casts that papered over real wire-contract mismatches; both verified and fixed honestly instead of cast away:

1. **`vodChapters` helpers vs the timeline contract** — `vodDeepLink`/`buildVodChapters` demanded `streamStart: string` while the mapper types it `string | null`. Now they accept the real contract and return `null` when there's no usable start (previously a null start computed an epoch-based nonsense offset — dead path since `stream.start` is NOT NULL, but now modelled). `topPhrases` accepts the wire's `unknown[]`; non-string payloads label as `chat spike`. Both `StreamTimeline` casts deleted.
2. **`parseBadges` vs `StreamMessage.badges`** — the wire sends `unknown[]`, the parser demanded `string`, and `ChatReplayLine` bridged with `as unknown as string`. Parser now accepts the array form (identical comma-join semantics); cast deleted.

Verification: tsc 0 errors, vitest 387 passed (+2 guard tests), lint 0 errors, production build green.

https://claude.ai/code/session_01N6W8wgzD5qPXBXuCTE4PJF