### PR TITLE
Prod ops: memory limits on all containers + scene-digest prod wiring

### DIFF
--- a/.env.prod.template
+++ b/.env.prod.template
@@ -13,3 +13,10 @@ SECRET_KEY=your_very_long_secure_secret_key_for_jwt_signing_change_this_in_produ
 # Twitch API Configuration
 TWITCH_CLIENT_ID=your_twitch_client_id
 TWITCH_CLIENT_SECRET=your_twitch_client_secret
+
+# Discord (optional — features stay dormant while empty)
+# Weekly scene digest destination; the Pi cron only fires when this is set:
+#   docker exec stream-sniper-api sh -c 'test -n "$SCENE_DIGEST_WEBHOOK_URL" && stream-sniper-digest --send'
+SCENE_DIGEST_WEBHOOK_URL=
+# Went-live alerts from the tracking service:
+TRACKING_DISCORD_WEBHOOK_URL=

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,11 @@ services:
     environment:
       - API_PROXY_TARGET=http://stream-sniper-api:5002
       - NODE_ENV=production
+    # OOM containment: the Pi hosts ~19 containers; a runaway process gets
+    # killed and restarted instead of taking the host down. memswap = mem
+    # so a hit means kill+restart, not swap-thrash.
+    mem_limit: 512m
+    memswap_limit: 512m
     restart: unless-stopped
     container_name: stream-sniper-frontend
     networks:
@@ -37,6 +42,11 @@ services:
       # lookup), so the api process needs Twitch creds too — not just tracking.
       - TWITCH_CLIENT_ID=${TWITCH_CLIENT_ID}
       - TWITCH_CLIENT_SECRET=${TWITCH_CLIENT_SECRET}
+      # Weekly scene digest (cron on the host runs stream-sniper-digest in this
+      # container; empty URL = digest stays dormant).
+      - SCENE_DIGEST_WEBHOOK_URL=${SCENE_DIGEST_WEBHOOK_URL:-}
+    mem_limit: 768m
+    memswap_limit: 768m
     restart: unless-stopped
     container_name: stream-sniper-api
     networks:
@@ -61,6 +71,8 @@ services:
       - TWITCH_CLIENT_SECRET=${TWITCH_CLIENT_SECRET}
       # Optional Discord "went live" alerts (unset = disabled).
       - TRACKING_DISCORD_WEBHOOK_URL=${TRACKING_DISCORD_WEBHOOK_URL:-}
+    mem_limit: 1g
+    memswap_limit: 1g
     restart: unless-stopped
     container_name: stream-sniper-tracking
     networks:
@@ -87,6 +99,8 @@ services:
       - TWITCH_BOT_TOKEN_FILE=/tokens/refresh-token
     volumes:
       - live_tokens:/tokens
+    mem_limit: 512m
+    memswap_limit: 512m
     restart: unless-stopped
     container_name: stream-sniper-live
     networks:


### PR DESCRIPTION
OOM containment: mem_limit/memswap_limit on all four prod services
(frontend 512m, api 768m, tracking 1g for collection bursts, live 512m).
The Pi hosts ~19 containers and these ran unlimited; a runaway process
now gets killed+restarted (restart: unless-stopped) instead of taking
the host down. memswap = mem so the limit means kill, not swap-thrash.
A mid-job kill self-heals: processing-job leases expire after 30 min
and the claim query recovers them with retries.

Scene digest: api service now passes SCENE_DIGEST_WEBHOOK_URL through
(empty = dormant), .env.prod.template documents both Discord webhook
vars. Host side already prepared: weekly cron (Mon 09:00) on the Pi is
installed and guarded on the var being non-empty, and .env.prod carries
the empty placeholder — pasting a webhook URL + compose up -d activates it.

Claude-Session: https://claude.ai/code/session_01N6W8wgzD5qPXBXuCTE4PJF
