### PR TITLE
Product trio: emote drill-down, chatter versus, and the digest as a page

### DIFF
--- a/backend/stream_sniper/api/features/chatters/chatter_endpoints.py
+++ b/backend/stream_sniper/api/features/chatters/chatter_endpoints.py
@@ -7,6 +7,13 @@ from pydantic import RootModel
 
 from ....application.chatters.passport_models import ChatterPassport
 from ....application.chatters.passport_query import get_chatter_passport as query_chatter_passport
+from ....application.chatters.versus_models import ChatterHeadToHead
+from ....application.chatters.versus_query import (
+    ChatterVersusNotFoundError,
+)
+from ....application.chatters.versus_query import (
+    get_chatter_head_to_head as query_chatter_head_to_head,
+)
 from ....database.gateways.chat.chatter_table_gateway import select_chatters_by_prefix_db
 from ....database.gateways.chat.message_table_gateway import (
     select_chatter_identity_db,
@@ -47,6 +54,49 @@ _CHATTER_ID_CACHE = ModelCachePolicy("chatter_id", CacheTTL.CHATTER_MESSAGES, Ch
 _CHATTER_SEARCH_CACHE = ModelCachePolicy("chatter_search", CacheTTL.CHATTER_SEARCH, _ChatterSearchCache)
 _CHATTER_ACTIVITY_CACHE = ModelCachePolicy("chatter_stream_activity", CacheTTL.STREAM_DETAILS, _ChatterActivityCache)
 _CHATTER_PASSPORT_CACHE = ModelCachePolicy("chatter_passport", CacheTTL.STREAM_ANALYTICS, ChatterPassport)
+_CHATTER_VERSUS_CACHE = ModelCachePolicy("chatter_head_to_head", CacheTTL.STREAM_ANALYTICS, ChatterHeadToHead)
+
+
+@router.get(
+    "/chatters/head-to-head",
+    response_model=ChatterHeadToHead,
+    summary="Compare two chatters head-to-head",
+    description=(
+        "Pairwise chatter comparison: lifetime totals, home channel, and archetype badges per side, "
+        "plus the streams and channels both attended. Side `a` is always the lower chatter id."
+    ),
+    responses={
+        400: {"model": ErrorResponse, "description": "The two chatter ids are identical"},
+        404: {"model": ErrorResponse, "description": "One or both chatters are unknown"},
+        429: {"model": RateLimitErrorResponse, "description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit(rate_limits.ANALYTICS)
+def get_chatter_head_to_head(
+    request: Request,
+    response: Response,
+    chatter_a: int = Query(..., description="First chatter ID", ge=1),
+    chatter_b: int = Query(..., description="Second chatter ID", ge=1),
+) -> ChatterHeadToHead:
+    """Pairwise chatter comparison built from the chatter rollups."""
+    if chatter_a == chatter_b:
+        raise HTTPException(status_code=400, detail="Pick two different chatters to compare.")
+    with _CHATTER_VERSUS_CACHE.record_failures():
+        cache = get_cache(request)
+        # Normalized to (lo, hi) so the cached payload is order-independent:
+        # side `a` is always the lower chatter id, whatever the param order.
+        lo, hi = sorted((chatter_a, chatter_b))
+        cache_key, cached_result = _CHATTER_VERSUS_CACHE.lookup(cache, response, lo, hi, scene_rollup_version())
+        if cached_result is not None:
+            return cached_result
+
+        try:
+            result = query_chatter_head_to_head(lo, hi)
+        except ChatterVersusNotFoundError:
+            raise HTTPException(status_code=404, detail="One of these chatters is not in the corpus.") from None
+
+        _CHATTER_VERSUS_CACHE.store(cache, response, cache_key, result)
+        return result
 
 
 @router.get(

--- a/backend/stream_sniper/api/features/content/scene_trending_endpoints.py
+++ b/backend/stream_sniper/api/features/content/scene_trending_endpoints.py
@@ -6,8 +6,10 @@ slowapi, in-process TTL cache keyed on the query params plus the scene rollup ve
 plain-language 422 copy for an out-of-range window.
 """
 
-from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi import APIRouter, HTTPException, Path, Query, Request, Response
 
+from ....application.scenes.emote_detail_models import EmoteDetail
+from ....application.scenes.emote_detail_query import get_emote_detail as query_emote_detail
 from ....database.gateways.analytics.scene_trends_gateway import (
     select_trending_copypastas_db,
     select_trending_emotes_db,
@@ -33,6 +35,41 @@ router = APIRouter(tags=["Scene"])
 
 _COPYPASTAS_CACHE = ModelCachePolicy("scene_trending_copypastas", CacheTTL.STREAM_ANALYTICS, TrendingCopypastas)
 _EMOTES_CACHE = ModelCachePolicy("scene_trending_emotes", CacheTTL.STREAM_ANALYTICS, TrendingEmotes)
+_EMOTE_DETAIL_CACHE = ModelCachePolicy("scene_emote_detail", CacheTTL.STREAM_ANALYTICS, EmoteDetail)
+
+
+@router.get(
+    "/scene/emotes/{emote_id}",
+    response_model=EmoteDetail,
+    summary="Get one emote's drill-down",
+    description=(
+        "Lifetime story of a single emote: dictionary identity, usage totals, "
+        "the channels it lives in, a trailing weekly trend, and its most recent streams."
+    ),
+    responses={
+        404: {"model": ErrorOrValidationResponse, "description": "Emote not found"},
+        429: {"model": RateLimitErrorResponse, "description": "Rate limit exceeded"},
+    },
+)
+@limiter.limit(rate_limits.ANALYTICS)
+def get_emote_detail(
+    request: Request,
+    response: Response,
+    emote_id: int = Path(..., description="Emote dictionary ID", ge=1),
+) -> EmoteDetail:
+    """Single-emote drill-down assembled from the per-stream emote rollups."""
+    with _EMOTE_DETAIL_CACHE.record_failures():
+        cache = get_cache(request)
+        cache_key, cached = _EMOTE_DETAIL_CACHE.lookup(cache, response, emote_id, scene_rollup_version())
+        if cached is not None:
+            return cached
+
+        result = query_emote_detail(emote_id)
+        if result is None:
+            raise HTTPException(status_code=404, detail="Emote not found")
+
+        _EMOTE_DETAIL_CACHE.store(cache, response, cache_key, result)
+        return result
 
 
 def _validate_window(window: int) -> None:

--- a/backend/stream_sniper/application/chatters/versus_models.py
+++ b/backend/stream_sniper/application/chatters/versus_models.py
@@ -1,0 +1,33 @@
+"""Read contract for the chatter head-to-head (the /versus/chatters page).
+
+Follows the creator head-to-head conventions: the pair is normalized to
+(lo, hi) by the HTTP layer, so side ``a`` is always the lower chatter id.
+"""
+
+from pydantic import BaseModel, Field
+
+from .passport_models import PassportArchetype, PassportHomeChannel
+
+
+class VersusChatter(BaseModel):
+    """One side of the comparison: lifetime aggregates for a single chatter."""
+
+    chatter_id: int
+    nick: str
+    is_bot: bool | None = Field(None, description="Null = not yet classified (nullable-means-unknown)")
+    messages: int
+    streams_attended: int
+    creators_visited: int
+    first_seen: str | None = Field(None, description="Lifetime first MESSAGE time (ISO 8601)")
+    last_seen: str | None = Field(None, description="Lifetime last MESSAGE time (ISO 8601)")
+    home_channel: PassportHomeChannel | None = Field(None, description="The creator they chat in most")
+    archetypes: list[PassportArchetype] = Field(..., description="Same badge rules as the passport")
+
+
+class ChatterHeadToHead(BaseModel):
+    """Pairwise chatter comparison. Never-crossed-paths is a legitimate zero, not an error."""
+
+    a: VersusChatter
+    b: VersusChatter
+    shared_streams: int = Field(..., description="Streams both chatters attended")
+    shared_creators: int = Field(..., description="Distinct channels those shared streams span")

--- a/backend/stream_sniper/application/chatters/versus_query.py
+++ b/backend/stream_sniper/application/chatters/versus_query.py
@@ -1,0 +1,80 @@
+"""Application query assembling a chatter head-to-head from the chatter rollups.
+
+Mirrors the creator ``head_to_head_query`` shape: identity + per-side aggregates
+plus one pairwise co-attendance read. Sides reuse the passport's aggregation
+rules (loyalty rollup for totals, message-time bounds, archetype badges) so the
+comparison never contradicts either chatter's passport.
+"""
+
+from datetime import UTC, datetime
+
+from stream_sniper.database.gateways.analytics.stream_chatter_stats_table_gateway import (
+    select_chatter_message_time_bounds_db,
+)
+from stream_sniper.database.gateways.chat.chatter_table_gateway import select_chatter_profile_db
+from stream_sniper.database.gateways.community.chatter_pair_gateway import select_chatter_pair_shared_db
+from stream_sniper.database.gateways.creators.creator_chatter_stats_table_gateway import select_chatter_loyalty_db
+
+from .archetypes import compute_archetypes
+from .passport_models import PassportHomeChannel
+from .versus_models import ChatterHeadToHead, VersusChatter
+
+
+class ChatterVersusNotFoundError(LookupError):
+    """One or both chatter ids are unknown."""
+
+
+def _side(chatter_id: int, now: datetime) -> VersusChatter | None:
+    identity = select_chatter_profile_db(chatter_id)
+    if identity is None:
+        return None
+
+    loyalty_rows = select_chatter_loyalty_db(chatter_id)
+    total_messages = sum(row.message_count for row in loyalty_rows)
+    home_channel = (
+        PassportHomeChannel.from_row(loyalty_rows[0], total_messages=total_messages) if loyalty_rows else None
+    )
+    time_bounds = select_chatter_message_time_bounds_db(chatter_id)
+    streams_attended = sum(row.streams_attended for row in loyalty_rows)
+
+    return VersusChatter(
+        chatter_id=identity.id,
+        nick=identity.nick,
+        is_bot=identity.is_bot,
+        messages=total_messages,
+        streams_attended=streams_attended,
+        creators_visited=len(loyalty_rows),
+        first_seen=time_bounds.first_message_time,
+        last_seen=time_bounds.last_message_time,
+        home_channel=home_channel,
+        archetypes=compute_archetypes(
+            total_messages=total_messages,
+            streams_attended=streams_attended,
+            creators_visited=len(loyalty_rows),
+            home_share=home_channel.share if home_channel is not None else None,
+            first_seen=time_bounds.first_message_time,
+            now=now,
+        ),
+    )
+
+
+def get_chatter_head_to_head(chatter_a: int, chatter_b: int) -> ChatterHeadToHead:
+    """Assemble the pairwise comparison; raises when either chatter id is unknown.
+
+    A pair that never shared a stream is a legitimate zero. Callers pass a
+    normalized (lo, hi) pair, so side ``a`` is the lower chatter id.
+    """
+    now = datetime.now(UTC)
+    side_a = _side(chatter_a, now)
+    side_b = _side(chatter_b, now)
+    missing = [cid for cid, side in ((chatter_a, side_a), (chatter_b, side_b)) if side is None]
+    if missing or side_a is None or side_b is None:
+        raise ChatterVersusNotFoundError(f"Unknown chatters: {missing}")
+
+    shared = select_chatter_pair_shared_db(chatter_a, chatter_b)
+    return ChatterHeadToHead(
+        a=side_a,
+        b=side_b,
+        shared_streams=shared.shared_streams,
+        shared_creators=shared.shared_creators,
+    )

--- a/backend/stream_sniper/application/scenes/emote_detail_models.py
+++ b/backend/stream_sniper/application/scenes/emote_detail_models.py
@@ -1,0 +1,119 @@
+"""Read contract for the single-emote drill-down (the /emotes/[id] page)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from stream_sniper.database.gateways.analytics.emote_detail_gateway import (
+        EmoteCreatorUsageRow,
+        EmoteMetaRow,
+        EmoteStreamUsageRow,
+        EmoteTotalsRow,
+        EmoteWeeklyUsageRow,
+    )
+
+
+class EmoteMeta(BaseModel):
+    emote_id: int
+    name: str
+    source: str = Field(..., description="Emote provider: bttv or twitch")
+    provider_id: str | None = None
+    first_seen: str | None = Field(None, description="Dictionary first-seen time (ISO 8601), if known")
+
+    @classmethod
+    def from_row(cls, row: EmoteMetaRow) -> EmoteMeta:
+        return cls(
+            emote_id=row.emote_id,
+            name=row.name,
+            source=row.source,
+            provider_id=row.provider_id,
+            first_seen=row.first_seen,
+        )
+
+
+class EmoteTotals(BaseModel):
+    """Lifetime aggregates; all-zero with null last_used when the emote was never used."""
+
+    usage: int
+    chatter_reach: int = Field(..., description="Sum of per-stream chatter counts (attendance-weighted)")
+    stream_count: int
+    creator_count: int
+    last_used: str | None = Field(None, description="Start time of the newest stream it appeared in")
+
+    @classmethod
+    def from_row(cls, row: EmoteTotalsRow) -> EmoteTotals:
+        return cls(
+            usage=row.usage,
+            chatter_reach=row.chatter_reach,
+            stream_count=row.stream_count,
+            creator_count=row.creator_count,
+            last_used=row.last_used,
+        )
+
+
+class EmoteCreatorUsage(BaseModel):
+    creator_id: int
+    nick: str
+    display_name: str
+    usage: int
+    chatter_reach: int
+    stream_count: int
+
+    @classmethod
+    def from_row(cls, row: EmoteCreatorUsageRow) -> EmoteCreatorUsage:
+        return cls(
+            creator_id=row.creator_id,
+            nick=row.nick,
+            display_name=row.display_name,
+            usage=row.usage,
+            chatter_reach=row.chatter_reach,
+            stream_count=row.stream_count,
+        )
+
+
+class EmoteWeeklyUsage(BaseModel):
+    week_start: str = Field(..., description="ISO date of the week's Monday")
+    usage: int
+
+    @classmethod
+    def from_row(cls, row: EmoteWeeklyUsageRow) -> EmoteWeeklyUsage:
+        return cls(week_start=row.week_start, usage=row.usage)
+
+
+class EmoteStreamUsage(BaseModel):
+    stream_id: int
+    title: str | None = None
+    start: str | None = None
+    creator_id: int
+    creator_nick: str
+    creator_display_name: str
+    usage: int
+    chatter_count: int
+
+    @classmethod
+    def from_row(cls, row: EmoteStreamUsageRow) -> EmoteStreamUsage:
+        return cls(
+            stream_id=row.stream_id,
+            title=row.title,
+            start=row.start,
+            creator_id=row.creator_id,
+            creator_nick=row.creator_nick,
+            creator_display_name=row.creator_display_name,
+            usage=row.usage,
+            chatter_count=row.chatter_count,
+        )
+
+
+class EmoteDetail(BaseModel):
+    """The full drill-down; list sections are empty (not null) for an unused emote."""
+
+    meta: EmoteMeta
+    totals: EmoteTotals
+    top_creators: list[EmoteCreatorUsage]
+    weekly_usage: list[EmoteWeeklyUsage] = Field(
+        ..., description="Trailing weeks with any usage, oldest first; absent weeks mean zero"
+    )
+    recent_streams: list[EmoteStreamUsage]

--- a/backend/stream_sniper/application/scenes/emote_detail_query.py
+++ b/backend/stream_sniper/application/scenes/emote_detail_query.py
@@ -1,0 +1,45 @@
+"""Application query assembling the single-emote drill-down from the emote rollups."""
+
+from stream_sniper.database.gateways.analytics.emote_detail_gateway import (
+    select_emote_meta_db,
+    select_emote_recent_streams_db,
+    select_emote_top_creators_db,
+    select_emote_totals_db,
+    select_emote_weekly_usage_db,
+)
+
+from .emote_detail_models import (
+    EmoteCreatorUsage,
+    EmoteDetail,
+    EmoteMeta,
+    EmoteStreamUsage,
+    EmoteTotals,
+    EmoteWeeklyUsage,
+)
+
+_TOP_CREATORS_LIMIT = 10
+_RECENT_STREAMS_LIMIT = 10
+_TREND_WEEKS = 12
+
+
+def get_emote_detail(emote_id: int) -> EmoteDetail | None:
+    """Assemble the drill-down, or None when the emote id is not in the dictionary.
+
+    A dictionary emote with no recorded usage is a legitimate result (zero totals,
+    empty sections) — only an unknown id returns None so the HTTP layer can 404.
+    """
+    meta = select_emote_meta_db(emote_id)
+    if meta is None:
+        return None
+
+    return EmoteDetail(
+        meta=EmoteMeta.from_row(meta),
+        totals=EmoteTotals.from_row(select_emote_totals_db(emote_id)),
+        top_creators=[
+            EmoteCreatorUsage.from_row(row) for row in select_emote_top_creators_db(emote_id, _TOP_CREATORS_LIMIT)
+        ],
+        weekly_usage=[EmoteWeeklyUsage.from_row(row) for row in select_emote_weekly_usage_db(emote_id, _TREND_WEEKS)],
+        recent_streams=[
+            EmoteStreamUsage.from_row(row) for row in select_emote_recent_streams_db(emote_id, _RECENT_STREAMS_LIMIT)
+        ],
+    )

--- a/backend/stream_sniper/database/gateways/analytics/emote_detail_gateway.py
+++ b/backend/stream_sniper/database/gateways/analytics/emote_detail_gateway.py
@@ -133,8 +133,11 @@ def select_emote_top_creators_db(cursor: Cursor, emote_id: int, limit: int) -> l
 def select_emote_weekly_usage_db(cursor: Cursor, emote_id: int, weeks: int) -> list[EmoteWeeklyUsageRow]:
     """Usage per ISO week over the trailing ``weeks`` weeks, oldest first.
 
-    Weeks with no usage are absent (the chart treats missing weeks as zero);
-    bucketing keys on ``stream.start`` like every other scene aggregate.
+    Exactly ``weeks`` Monday buckets are eligible: the current (partial) week
+    plus the ``weeks - 1`` before it — not ``weeks`` full weeks back, which
+    would yield ``weeks + 1`` buckets. Weeks with no usage are absent (the
+    chart treats missing weeks as zero); bucketing keys on ``stream.start``
+    like every other scene aggregate.
     """
     cursor.execute(
         """
@@ -143,7 +146,7 @@ def select_emote_weekly_usage_db(cursor: Cursor, emote_id: int, weeks: int) -> l
         FROM stream_emote_stats ses
         JOIN stream s ON s.id = ses.stream_id
         WHERE ses.emote_id = %s
-          AND s.start >= DATE_TRUNC('week', (now() AT TIME ZONE 'UTC')) - (%s * interval '1 week')
+          AND s.start >= DATE_TRUNC('week', (now() AT TIME ZONE 'UTC')) - ((%s - 1) * interval '1 week')
         GROUP BY DATE_TRUNC('week', s.start)
         ORDER BY week_start ASC
         """,

--- a/backend/stream_sniper/database/gateways/analytics/emote_detail_gateway.py
+++ b/backend/stream_sniper/database/gateways/analytics/emote_detail_gateway.py
@@ -1,0 +1,172 @@
+"""Single-emote drill-down reads over the per-stream emote rollup.
+
+All queries aggregate ``stream_emote_stats`` (joined to ``emote_dictionary`` /
+``stream`` / ``creator``) — the raw ``message`` table is never scanned. Lifetime
+scope (no window): the detail page answers "what is this emote's story here",
+not "is it trending" (that's ``scene_trends_gateway``).
+"""
+
+from typing import NamedTuple
+
+from psycopg2.extensions import cursor as Cursor
+
+from ...core.decorators import with_cursor
+from ...core.wire_format import to_char_wire
+
+
+class EmoteMetaRow(NamedTuple):
+    """Dictionary identity for one emote; ``first_seen`` is the global dictionary time."""
+
+    emote_id: int
+    name: str
+    source: str
+    provider_id: str | None
+    first_seen: str | None
+
+
+class EmoteTotalsRow(NamedTuple):
+    """Lifetime aggregates across every stream the emote appeared in.
+
+    ``chatter_reach`` SUMs per-stream chatter_count (a chatter attending N streams
+    counts N times — same contract as the trending endpoint's reach).
+    """
+
+    usage: int
+    chatter_reach: int
+    stream_count: int
+    creator_count: int
+    last_used: str | None
+
+
+class EmoteCreatorUsageRow(NamedTuple):
+    """One channel's lifetime usage of the emote."""
+
+    creator_id: int
+    nick: str
+    display_name: str
+    usage: int
+    chatter_reach: int
+    stream_count: int
+
+
+class EmoteWeeklyUsageRow(NamedTuple):
+    """Usage summed per ISO week (``week_start`` = Monday, ISO 8601 date)."""
+
+    week_start: str
+    usage: int
+
+
+class EmoteStreamUsageRow(NamedTuple):
+    """One recent stream the emote appeared in."""
+
+    stream_id: int
+    title: str | None
+    start: str | None
+    creator_id: int
+    creator_nick: str
+    creator_display_name: str
+    usage: int
+    chatter_count: int
+
+
+@with_cursor
+def select_emote_meta_db(cursor: Cursor, emote_id: int) -> EmoteMetaRow | None:
+    """Dictionary identity for one emote, or None when the id is unknown."""
+    cursor.execute(
+        f"""
+        SELECT d.id, d.name, d.source, d.provider_id,
+               {to_char_wire("d.first_seen AT TIME ZONE 'UTC'")} AS first_seen
+        FROM emote_dictionary d
+        WHERE d.id = %s
+        """,
+        (emote_id,),
+    )
+    row = cursor.fetchone()
+    return EmoteMetaRow(*row) if row else None
+
+
+@with_cursor
+def select_emote_totals_db(cursor: Cursor, emote_id: int) -> EmoteTotalsRow:
+    """Lifetime usage totals; all-zero (last_used None) when the emote was never used."""
+    cursor.execute(
+        f"""
+        SELECT COALESCE(SUM(ses.usage_count), 0)::bigint AS usage,
+               COALESCE(SUM(ses.chatter_count), 0)::bigint AS chatter_reach,
+               COUNT(DISTINCT ses.stream_id)::int AS stream_count,
+               COUNT(DISTINCT s.creator_id)::int AS creator_count,
+               {to_char_wire("MAX(s.start)")} AS last_used
+        FROM stream_emote_stats ses
+        JOIN stream s ON s.id = ses.stream_id
+        WHERE ses.emote_id = %s
+        """,
+        (emote_id,),
+    )
+    row = cursor.fetchone()
+    if row is None:  # aggregate always yields one row; guard for the type checker
+        return EmoteTotalsRow(usage=0, chatter_reach=0, stream_count=0, creator_count=0, last_used=None)
+    return EmoteTotalsRow(*row)
+
+
+@with_cursor
+def select_emote_top_creators_db(cursor: Cursor, emote_id: int, limit: int) -> list[EmoteCreatorUsageRow]:
+    """Channels ranked by lifetime usage of the emote."""
+    cursor.execute(
+        """
+        SELECT s.creator_id, c.nick, c.display_name,
+               SUM(ses.usage_count)::bigint AS usage,
+               SUM(ses.chatter_count)::bigint AS chatter_reach,
+               COUNT(DISTINCT ses.stream_id)::int AS stream_count
+        FROM stream_emote_stats ses
+        JOIN stream s ON s.id = ses.stream_id
+        JOIN creator c ON c.id = s.creator_id
+        WHERE ses.emote_id = %s
+        GROUP BY s.creator_id, c.nick, c.display_name
+        ORDER BY usage DESC, c.nick ASC
+        LIMIT %s
+        """,
+        (emote_id, limit),
+    )
+    return [EmoteCreatorUsageRow(*row) for row in cursor.fetchall()]
+
+
+@with_cursor
+def select_emote_weekly_usage_db(cursor: Cursor, emote_id: int, weeks: int) -> list[EmoteWeeklyUsageRow]:
+    """Usage per ISO week over the trailing ``weeks`` weeks, oldest first.
+
+    Weeks with no usage are absent (the chart treats missing weeks as zero);
+    bucketing keys on ``stream.start`` like every other scene aggregate.
+    """
+    cursor.execute(
+        """
+        SELECT TO_CHAR(DATE_TRUNC('week', s.start), 'YYYY-MM-DD') AS week_start,
+               SUM(ses.usage_count)::bigint AS usage
+        FROM stream_emote_stats ses
+        JOIN stream s ON s.id = ses.stream_id
+        WHERE ses.emote_id = %s
+          AND s.start >= DATE_TRUNC('week', (now() AT TIME ZONE 'UTC')) - (%s * interval '1 week')
+        GROUP BY DATE_TRUNC('week', s.start)
+        ORDER BY week_start ASC
+        """,
+        (emote_id, weeks),
+    )
+    return [EmoteWeeklyUsageRow(*row) for row in cursor.fetchall()]
+
+
+@with_cursor
+def select_emote_recent_streams_db(cursor: Cursor, emote_id: int, limit: int) -> list[EmoteStreamUsageRow]:
+    """Most recent streams the emote appeared in, newest first."""
+    cursor.execute(
+        f"""
+        SELECT s.id, s.title, {to_char_wire("s.start")} AS start,
+               s.creator_id, c.nick, c.display_name,
+               ses.usage_count, ses.chatter_count
+        FROM stream_emote_stats ses
+        JOIN stream s ON s.id = ses.stream_id
+        JOIN creator c ON c.id = s.creator_id
+        WHERE ses.emote_id = %s
+        ORDER BY s.start DESC NULLS LAST, s.id DESC
+        LIMIT %s
+        """,
+        (emote_id, limit),
+    )
+    return [EmoteStreamUsageRow(*row) for row in cursor.fetchall()]

--- a/backend/stream_sniper/database/gateways/community/chatter_pair_gateway.py
+++ b/backend/stream_sniper/database/gateways/community/chatter_pair_gateway.py
@@ -1,0 +1,41 @@
+"""Pairwise co-attendance for two specific chatters.
+
+Self-joins ``stream_chatter_stats`` on stream_id (the same shape as
+``chat_companions_gateway`` but anchored on an explicit pair instead of
+ranking companions). A pair that never shared a stream is a legitimate
+all-zero row, not an error.
+"""
+
+from typing import NamedTuple
+
+from psycopg2.extensions import cursor as Cursor
+
+from ...core.decorators import with_cursor
+
+
+class ChatterPairSharedRow(NamedTuple):
+    """Streams (and distinct channels) both chatters attended."""
+
+    shared_streams: int
+    shared_creators: int
+
+
+@with_cursor
+def select_chatter_pair_shared_db(cursor: Cursor, chatter_a: int, chatter_b: int) -> ChatterPairSharedRow:
+    """Count streams both chatters attended and the distinct creators those span."""
+    cursor.execute(
+        """
+        SELECT COUNT(*)::int AS shared_streams,
+               COUNT(DISTINCT s.creator_id)::int AS shared_creators
+        FROM stream_chatter_stats a
+        JOIN stream_chatter_stats b
+            ON b.stream_id = a.stream_id AND b.chatter_id = %s
+        JOIN stream s ON s.id = a.stream_id
+        WHERE a.chatter_id = %s
+        """,
+        (chatter_b, chatter_a),
+    )
+    row = cursor.fetchone()
+    if row is None:  # aggregate always yields one row; guard for the type checker
+        return ChatterPairSharedRow(shared_streams=0, shared_creators=0)
+    return ChatterPairSharedRow(*row)

--- a/backend/tests/unit/application/test_chatter_versus_query.py
+++ b/backend/tests/unit/application/test_chatter_versus_query.py
@@ -1,0 +1,96 @@
+"""Contract tests for chatter head-to-head application orchestration."""
+
+import pytest
+
+from stream_sniper.application.chatters import versus_query
+from stream_sniper.application.chatters.versus_query import (
+    ChatterVersusNotFoundError,
+    get_chatter_head_to_head,
+)
+from stream_sniper.database.gateways.analytics.records import ChatterTimeBoundsRow
+from stream_sniper.database.gateways.chat.records import ChatterProfileRow
+from stream_sniper.database.gateways.community.chatter_pair_gateway import ChatterPairSharedRow
+from stream_sniper.database.gateways.creators.records import ChatterLoyaltyRow
+
+
+def _patch(monkeypatch, *, profiles, loyalty, bounds=None, shared=None) -> None:
+    """Patch the versus gateways with per-chatter-id dict lookups."""
+    monkeypatch.setattr(versus_query, "select_chatter_profile_db", lambda cid: profiles.get(cid))
+    monkeypatch.setattr(versus_query, "select_chatter_loyalty_db", lambda cid: loyalty.get(cid, []))
+    monkeypatch.setattr(
+        versus_query,
+        "select_chatter_message_time_bounds_db",
+        lambda cid: (bounds or {}).get(cid, ChatterTimeBoundsRow(None, None)),
+    )
+    monkeypatch.setattr(
+        versus_query,
+        "select_chatter_pair_shared_db",
+        lambda _a, _b: shared if shared is not None else ChatterPairSharedRow(0, 0),
+    )
+
+
+def test_unknown_chatter_raises(monkeypatch) -> None:
+    _patch(monkeypatch, profiles={1: ChatterProfileRow(1, "known", None, None)}, loyalty={})
+    with pytest.raises(ChatterVersusNotFoundError):
+        get_chatter_head_to_head(1, 999)
+
+
+def test_assembles_both_sides_and_shared(monkeypatch) -> None:
+    profiles = {
+        1: ChatterProfileRow(1, "alpha", False, None),
+        2: ChatterProfileRow(2, "beta", None, None),
+    }
+    loyalty = {
+        1: [
+            ChatterLoyaltyRow(5, "homie", "Homie", 900, 12, "2024-01-01T00:00:00", "2024-06-01T00:00:00"),
+            ChatterLoyaltyRow(9, "other", "Other", 100, 3, "2024-02-01T00:00:00", "2024-05-01T00:00:00"),
+        ],
+        2: [ChatterLoyaltyRow(5, "homie", "Homie", 40, 4, "2024-03-01T00:00:00", "2024-04-01T00:00:00")],
+    }
+    bounds = {
+        1: ChatterTimeBoundsRow("2024-01-01T20:00:00", "2024-06-01T13:37:00"),
+        2: ChatterTimeBoundsRow("2024-03-01T10:00:00", "2024-04-01T11:00:00"),
+    }
+    _patch(monkeypatch, profiles=profiles, loyalty=loyalty, bounds=bounds, shared=ChatterPairSharedRow(6, 2))
+
+    result = get_chatter_head_to_head(1, 2)
+
+    assert result.a.chatter_id == 1
+    assert result.a.nick == "alpha"
+    assert result.a.is_bot is False
+    assert result.a.messages == 1000
+    assert result.a.streams_attended == 15
+    assert result.a.creators_visited == 2
+    assert result.a.first_seen == "2024-01-01T20:00:00"
+    # Home channel follows the passport rules: top loyalty row, share of total messages.
+    assert result.a.home_channel is not None
+    assert result.a.home_channel.creator_id == 5
+    assert result.a.home_channel.share == 0.9
+    assert result.a.archetypes  # aggregates above the badge thresholds must yield badges
+
+    assert result.b.chatter_id == 2
+    assert result.b.is_bot is None  # nullable-means-unknown passes through
+    assert result.b.messages == 40
+    assert result.b.creators_visited == 1
+    assert result.b.home_channel is not None
+    assert result.b.home_channel.share == 1.0
+
+    assert result.shared_streams == 6
+    assert result.shared_creators == 2
+
+
+def test_never_crossed_paths_is_zero_not_error(monkeypatch) -> None:
+    profiles = {
+        1: ChatterProfileRow(1, "alpha", None, None),
+        2: ChatterProfileRow(2, "beta", None, None),
+    }
+    _patch(monkeypatch, profiles=profiles, loyalty={}, shared=ChatterPairSharedRow(0, 0))
+
+    result = get_chatter_head_to_head(1, 2)
+
+    assert result.shared_streams == 0
+    assert result.shared_creators == 0
+    # A chatter with no rollup rows is a legitimate all-zero side, not a 404.
+    assert result.a.messages == 0
+    assert result.a.home_channel is None
+    assert result.a.first_seen is None

--- a/backend/tests/unit/application/test_emote_detail_query.py
+++ b/backend/tests/unit/application/test_emote_detail_query.py
@@ -1,0 +1,67 @@
+"""Contract tests for the single-emote drill-down application orchestration."""
+
+from stream_sniper.application.scenes import emote_detail_query
+from stream_sniper.application.scenes.emote_detail_query import get_emote_detail
+from stream_sniper.database.gateways.analytics.emote_detail_gateway import (
+    EmoteCreatorUsageRow,
+    EmoteMetaRow,
+    EmoteStreamUsageRow,
+    EmoteTotalsRow,
+    EmoteWeeklyUsageRow,
+)
+
+
+def _patch(monkeypatch, *, meta, totals=None, creators=None, weekly=None, streams=None) -> None:
+    monkeypatch.setattr(emote_detail_query, "select_emote_meta_db", lambda _eid: meta)
+    monkeypatch.setattr(
+        emote_detail_query,
+        "select_emote_totals_db",
+        lambda _eid: totals if totals is not None else EmoteTotalsRow(0, 0, 0, 0, None),
+    )
+    monkeypatch.setattr(emote_detail_query, "select_emote_top_creators_db", lambda _eid, _limit: creators or [])
+    monkeypatch.setattr(emote_detail_query, "select_emote_weekly_usage_db", lambda _eid, _weeks: weekly or [])
+    monkeypatch.setattr(emote_detail_query, "select_emote_recent_streams_db", lambda _eid, _limit: streams or [])
+
+
+def test_unknown_emote_returns_none(monkeypatch) -> None:
+    _patch(monkeypatch, meta=None)
+    assert get_emote_detail(999) is None
+
+
+def test_dictionary_emote_with_no_usage_is_zero_not_none(monkeypatch) -> None:
+    _patch(monkeypatch, meta=EmoteMetaRow(7, "agrPls", "bttv", "abc123", "2024-01-01T00:00:00"))
+
+    result = get_emote_detail(7)
+
+    assert result is not None
+    assert result.meta.name == "agrPls"
+    assert result.totals.usage == 0
+    assert result.totals.last_used is None
+    assert result.top_creators == []
+    assert result.weekly_usage == []
+    assert result.recent_streams == []
+
+
+def test_assembles_all_sections(monkeypatch) -> None:
+    _patch(
+        monkeypatch,
+        meta=EmoteMetaRow(7, "agrPls", "bttv", "abc123", "2024-01-01T00:00:00"),
+        totals=EmoteTotalsRow(5000, 800, 42, 6, "2026-07-18T19:00:00"),
+        creators=[
+            EmoteCreatorUsageRow(1, "agraelus", "Agraelus", 4200, 700, 30),
+            EmoteCreatorUsageRow(2, "claina", "Claina", 800, 100, 12),
+        ],
+        weekly=[EmoteWeeklyUsageRow("2026-07-06", 300), EmoteWeeklyUsageRow("2026-07-13", 450)],
+        streams=[EmoteStreamUsageRow(99, "Finale", "2026-07-18T17:00:00", 1, "agraelus", "Agraelus", 150, 40)],
+    )
+
+    result = get_emote_detail(7)
+
+    assert result is not None
+    assert result.totals.usage == 5000
+    assert result.totals.creator_count == 6
+    assert [c.creator_id for c in result.top_creators] == [1, 2]
+    assert result.top_creators[0].usage == 4200
+    assert [w.week_start for w in result.weekly_usage] == ["2026-07-06", "2026-07-13"]
+    assert result.recent_streams[0].stream_id == 99
+    assert result.recent_streams[0].creator_display_name == "Agraelus"

--- a/frontend/app/(app)/digest/page.tsx
+++ b/frontend/app/(app)/digest/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next'
+import SceneDigest from '@/views/scene/SceneDigest'
+
+// Server wrapper so the page carries a real title/description; the view stays
+// a client component.
+export const metadata: Metadata = {
+  title: 'Scene digest',
+  description: 'The Czech Twitch scene summarized: events, trending copypastas and emotes, top chatters, and the biggest moments.',
+}
+
+export default function DigestPage() {
+  return <SceneDigest />
+}

--- a/frontend/app/(app)/emotes/[id]/page.tsx
+++ b/frontend/app/(app)/emotes/[id]/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import EmoteDetail from '@/views/scene/EmoteDetail'
+
+// Server wrapper: validates the id (real 404 for garbage), static metadata —
+// the emote name arrives client-side with the drill-down payload.
+export const metadata: Metadata = {
+  title: 'Emote drill-down',
+  description: 'The lifetime story of one emote: usage, the channels it lives in, and its weekly trend.',
+}
+
+type PageProps = { params: Promise<{ id: string }> }
+
+const parseEmoteId = (raw: string): number | null => {
+  const id = Number(raw)
+  return Number.isSafeInteger(id) && id > 0 ? id : null
+}
+
+export default async function EmoteDetailPage({ params }: PageProps) {
+  const { id } = await params
+  const emoteId = parseEmoteId(id)
+
+  if (emoteId == null) {
+    notFound()
+  }
+
+  return <EmoteDetail emoteId={emoteId} />
+}

--- a/frontend/app/(app)/versus/chatters/page.tsx
+++ b/frontend/app/(app)/versus/chatters/page.tsx
@@ -1,0 +1,13 @@
+'use client'
+import { use } from 'react'
+import ChatterVersus from '@/views/community/ChatterVersus'
+
+const parseChatterId = (raw: string | undefined): number | null => {
+  const id = Number(raw)
+  return Number.isInteger(id) && id > 0 ? id : null
+}
+
+export default function ChatterVersusPage({ searchParams }: { searchParams: Promise<{ a?: string, b?: string }> }) {
+  const { a, b } = use(searchParams)
+  return <ChatterVersus initialA={parseChatterId(a)} initialB={parseChatterId(b)} />
+}

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -60,6 +60,11 @@ const navigationGroups: NavGroup[] = [
                 icon: 'bi bi-activity',
             },
             {
+                title: 'Digest',
+                href: '/digest',
+                icon: 'bi bi-journal-text',
+            },
+            {
                 title: 'Trending',
                 href: '/trending',
                 icon: 'bi bi-graph-up-arrow',

--- a/frontend/components/scene/DigestMarkdown.tsx
+++ b/frontend/components/scene/DigestMarkdown.tsx
@@ -46,14 +46,21 @@ export const renderInline = (text: string, keyBase: string): ReactNode[] => {
     return nodes
 }
 
-const LIST_ITEM_RE = /^(?:-|\d+\.)\s+/
+const BULLET_ITEM_RE = /^-\s+/
+const ORDERED_ITEM_RE = /^\d+\.\s+/
 
 interface DigestBlock {
     kind: 'h2' | 'h3' | 'list' | 'paragraph'
     lines: string[]
+    /** For list blocks: true = numbered run (rendered <ol> to keep the ranks). */
+    ordered?: boolean
 }
 
-/** Group the digest's lines into heading / list / paragraph blocks. */
+/** Group the digest's lines into heading / list / paragraph blocks.
+
+    Bullet ("- ") and numbered ("1. ") runs stay separate blocks so an ordered
+    section (Most active chatters) keeps its rank numbers instead of collapsing
+    into bullets. */
 export const parseDigestBlocks = (markdown: string): DigestBlock[] => {
     const blocks: DigestBlock[] = []
     for (const rawLine of markdown.split('\n')) {
@@ -63,11 +70,12 @@ export const parseDigestBlocks = (markdown: string): DigestBlock[] => {
             blocks.push({ kind: 'h2', lines: [line.slice(3)] })
         } else if (line.startsWith('### ')) {
             blocks.push({ kind: 'h3', lines: [line.slice(4)] })
-        } else if (LIST_ITEM_RE.test(line)) {
+        } else if (BULLET_ITEM_RE.test(line) || ORDERED_ITEM_RE.test(line)) {
+            const ordered = ORDERED_ITEM_RE.test(line)
             const previous = blocks[blocks.length - 1]
-            const text = line.replace(LIST_ITEM_RE, '')
-            if (previous?.kind === 'list') previous.lines.push(text)
-            else blocks.push({ kind: 'list', lines: [text] })
+            const text = line.replace(ordered ? ORDERED_ITEM_RE : BULLET_ITEM_RE, '')
+            if (previous?.kind === 'list' && previous.ordered === ordered) previous.lines.push(text)
+            else blocks.push({ kind: 'list', ordered, lines: [text] })
         } else {
             blocks.push({ kind: 'paragraph', lines: [line] })
         }
@@ -86,12 +94,13 @@ const DigestMarkdown = ({ markdown }: { markdown: string }): JSX.Element => (
                 return <h3 key={key} className="digest-h3">{renderInline(block.lines[0], key)}</h3>
             }
             if (block.kind === 'list') {
+                const ListTag = block.ordered ? 'ol' : 'ul'
                 return (
-                    <ul key={key} className="digest-list">
+                    <ListTag key={key} className={block.ordered ? 'digest-list digest-list-ordered' : 'digest-list'}>
                         {block.lines.map((line, itemIndex) => (
                             <li key={`${key}-i${itemIndex}`}>{renderInline(line, `${key}-i${itemIndex}`)}</li>
                         ))}
-                    </ul>
+                    </ListTag>
                 )
             }
             return <p key={key} className="digest-p">{renderInline(block.lines[0], key)}</p>

--- a/frontend/components/scene/DigestMarkdown.tsx
+++ b/frontend/components/scene/DigestMarkdown.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import type { JSX, ReactNode } from 'react'
+
+/**
+ * Renderer for the scene digest's narrow markdown dialect — exactly the
+ * constructs `build_digest` emits (## / ### headings, "-" and "1." list lines,
+ * `**bold**` spans, bare https:// URLs) and nothing more. Deliberately not a
+ * general markdown engine: unknown syntax degrades to plain text instead of
+ * pulling in a renderer dependency for one page.
+ */
+
+const URL_RE = /https?:\/\/\S+/g
+const BOLD_RE = /\*\*([^*]+)\*\*/g
+
+/** Split one already-bold-free text run into text + anchor nodes. */
+const linkify = (text: string, keyBase: string): ReactNode[] => {
+    const nodes: ReactNode[] = []
+    let cursor = 0
+    for (const match of text.matchAll(URL_RE)) {
+        const start = match.index
+        if (start > cursor) nodes.push(text.slice(cursor, start))
+        const href = match[0]
+        nodes.push(
+            <a key={`${keyBase}-a${start}`} href={href} target="_blank" rel="noreferrer">
+                {href.replace(/^https?:\/\//, '')}
+            </a>,
+        )
+        cursor = start + href.length
+    }
+    if (cursor < text.length) nodes.push(text.slice(cursor))
+    return nodes
+}
+
+/** Render **bold** spans and bare URLs inside one line of digest text. */
+export const renderInline = (text: string, keyBase: string): ReactNode[] => {
+    const nodes: ReactNode[] = []
+    let cursor = 0
+    for (const match of text.matchAll(BOLD_RE)) {
+        const start = match.index
+        if (start > cursor) nodes.push(...linkify(text.slice(cursor, start), `${keyBase}-t${cursor}`))
+        nodes.push(<strong key={`${keyBase}-b${start}`}>{match[1]}</strong>)
+        cursor = start + match[0].length
+    }
+    if (cursor < text.length) nodes.push(...linkify(text.slice(cursor), `${keyBase}-t${cursor}`))
+    return nodes
+}
+
+const LIST_ITEM_RE = /^(?:-|\d+\.)\s+/
+
+interface DigestBlock {
+    kind: 'h2' | 'h3' | 'list' | 'paragraph'
+    lines: string[]
+}
+
+/** Group the digest's lines into heading / list / paragraph blocks. */
+export const parseDigestBlocks = (markdown: string): DigestBlock[] => {
+    const blocks: DigestBlock[] = []
+    for (const rawLine of markdown.split('\n')) {
+        const line = rawLine.trimEnd()
+        if (!line.trim()) continue
+        if (line.startsWith('## ') && !line.startsWith('### ')) {
+            blocks.push({ kind: 'h2', lines: [line.slice(3)] })
+        } else if (line.startsWith('### ')) {
+            blocks.push({ kind: 'h3', lines: [line.slice(4)] })
+        } else if (LIST_ITEM_RE.test(line)) {
+            const previous = blocks[blocks.length - 1]
+            const text = line.replace(LIST_ITEM_RE, '')
+            if (previous?.kind === 'list') previous.lines.push(text)
+            else blocks.push({ kind: 'list', lines: [text] })
+        } else {
+            blocks.push({ kind: 'paragraph', lines: [line] })
+        }
+    }
+    return blocks
+}
+
+const DigestMarkdown = ({ markdown }: { markdown: string }): JSX.Element => (
+    <div className="digest-body">
+        {parseDigestBlocks(markdown).map((block, index) => {
+            const key = `block-${index}`
+            if (block.kind === 'h2') {
+                return <h2 key={key} className="digest-h2">{renderInline(block.lines[0], key)}</h2>
+            }
+            if (block.kind === 'h3') {
+                return <h3 key={key} className="digest-h3">{renderInline(block.lines[0], key)}</h3>
+            }
+            if (block.kind === 'list') {
+                return (
+                    <ul key={key} className="digest-list">
+                        {block.lines.map((line, itemIndex) => (
+                            <li key={`${key}-i${itemIndex}`}>{renderInline(line, `${key}-i${itemIndex}`)}</li>
+                        ))}
+                    </ul>
+                )
+            }
+            return <p key={key} className="digest-p">{renderInline(block.lines[0], key)}</p>
+        })}
+    </div>
+)
+
+export default DigestMarkdown

--- a/frontend/hooks/chatter/useChatterVersusQuery.ts
+++ b/frontend/hooks/chatter/useChatterVersusQuery.ts
@@ -1,0 +1,112 @@
+import { useQuery } from '@tanstack/react-query'
+import { retrieveChatterHeadToHead } from '@/lib/api/chatter'
+import {
+    requireArrayField,
+    requireFiniteNumberField,
+    requireNullableBooleanField,
+    requireNullableStringField,
+    requireRecord,
+    requireStringField,
+} from '@/lib/api/contractGuards'
+
+export interface ChatterVersusHomeChannel {
+    creatorId: number
+    creatorNick: string
+    creatorDisplayName: string
+    messages: number
+    /** messages / side total, rounded server-side to 4 places. */
+    share: number
+}
+
+export interface ChatterVersusArchetype {
+    key: string
+    label: string
+    description: string
+}
+
+export interface ChatterVersusSide {
+    chatterId: number
+    nick: string
+    /** Null = not yet classified (nullable-means-unknown). */
+    isBot: boolean | null
+    messages: number
+    streamsAttended: number
+    creatorsVisited: number
+    firstSeen: string | null
+    lastSeen: string | null
+    homeChannel: ChatterVersusHomeChannel | null
+    archetypes: ChatterVersusArchetype[]
+}
+
+export interface ChatterHeadToHead {
+    /** Side `a` is always the lower chatter id — the payload is param-order independent. */
+    a: ChatterVersusSide
+    b: ChatterVersusSide
+    sharedStreams: number
+    sharedCreators: number
+}
+
+const chatterVersusKeys = {
+    all: ['chatter', 'head-to-head'] as const,
+    pair: (a: number, b: number) => {
+        // Normalize like the backend cache so (a,b) and (b,a) share one cache entry.
+        const [lo, hi] = a < b ? [a, b] : [b, a]
+        return [...chatterVersusKeys.all, { a: lo, b: hi }] as const
+    },
+}
+
+const mapSide = (value: unknown, label: string): ChatterVersusSide => {
+    const side = requireRecord(value, label)
+    const homeChannel = side.home_channel === null || side.home_channel === undefined
+        ? null
+        : requireRecord(side.home_channel, `${label}.home_channel`)
+    return {
+        chatterId: requireFiniteNumberField(side, 'chatter_id', label),
+        nick: requireStringField(side, 'nick', label),
+        isBot: requireNullableBooleanField(side, 'is_bot', label),
+        messages: requireFiniteNumberField(side, 'messages', label),
+        streamsAttended: requireFiniteNumberField(side, 'streams_attended', label),
+        creatorsVisited: requireFiniteNumberField(side, 'creators_visited', label),
+        firstSeen: requireNullableStringField(side, 'first_seen', label),
+        lastSeen: requireNullableStringField(side, 'last_seen', label),
+        homeChannel: homeChannel === null ? null : {
+            creatorId: requireFiniteNumberField(homeChannel, 'creator_id', `${label}.home_channel`),
+            creatorNick: requireStringField(homeChannel, 'creator_nick', `${label}.home_channel`),
+            creatorDisplayName: requireStringField(homeChannel, 'creator_display_name', `${label}.home_channel`),
+            messages: requireFiniteNumberField(homeChannel, 'messages', `${label}.home_channel`),
+            share: requireFiniteNumberField(homeChannel, 'share', `${label}.home_channel`),
+        },
+        archetypes: requireArrayField(side, 'archetypes', label).map((entry, index) => {
+            const badgeLabel = `${label}.archetypes[${index}]`
+            const badge = requireRecord(entry, badgeLabel)
+            return {
+                key: requireStringField(badge, 'key', badgeLabel),
+                label: requireStringField(badge, 'label', badgeLabel),
+                description: requireStringField(badge, 'description', badgeLabel),
+            }
+        }),
+    }
+}
+
+export const mapChatterHeadToHead = (value: unknown): ChatterHeadToHead => {
+    const data = requireRecord(value, 'chatter head-to-head')
+    return {
+        a: mapSide(data.a, 'chatter head-to-head.a'),
+        b: mapSide(data.b, 'chatter head-to-head.b'),
+        sharedStreams: requireFiniteNumberField(data, 'shared_streams', 'chatter head-to-head'),
+        sharedCreators: requireFiniteNumberField(data, 'shared_creators', 'chatter head-to-head'),
+    }
+}
+
+export const useChatterHeadToHead = (
+    chatterA: number | null,
+    chatterB: number | null,
+) => useQuery({
+    queryKey: chatterA && chatterB
+        ? chatterVersusKeys.pair(chatterA, chatterB)
+        : [...chatterVersusKeys.all, { a: chatterA, b: chatterB }],
+    queryFn: async () => mapChatterHeadToHead(
+        (await retrieveChatterHeadToHead(chatterA as number, chatterB as number)).data,
+    ),
+    enabled: Boolean(chatterA) && Boolean(chatterB) && chatterA !== chatterB,
+})

--- a/frontend/hooks/scene/sceneKeys.ts
+++ b/frontend/hooks/scene/sceneKeys.ts
@@ -76,6 +76,7 @@ export const sceneKeys = {
     highlights: (filters: HighlightsFilters) => [...sceneKeys.all, 'highlights', filters] as const,
     trendingCopypastas: (filters: TrendingFilters) => [...sceneKeys.all, 'trending', 'copypastas', filters] as const,
     trendingEmotes: (filters: TrendingFilters) => [...sceneKeys.all, 'trending', 'emotes', filters] as const,
+    emoteDetail: (emoteId: number) => [...sceneKeys.all, 'emote', { emoteId }] as const,
     wrapped: (days: number) => [...sceneKeys.all, 'wrapped', { days }] as const,
     radar: () => [...sceneKeys.all, 'radar'] as const,
     searchMessages: (filters: SearchMessagesKeyFilters) => [...sceneKeys.all, 'search', 'messages', filters] as const,

--- a/frontend/hooks/scene/useEmoteDetailQuery.ts
+++ b/frontend/hooks/scene/useEmoteDetailQuery.ts
@@ -1,0 +1,123 @@
+import { useQuery } from '@tanstack/react-query'
+import { retrieveEmoteDetail } from '@/lib/api/scene'
+import {
+    requireArrayField,
+    requireFiniteNumberField,
+    requireNullableStringField,
+    requireRecord,
+    requireStringField,
+} from '@/lib/api/contractGuards'
+import { sceneKeys } from './sceneKeys'
+
+export interface EmoteMeta {
+    emoteId: number
+    name: string
+    source: string
+    providerId: string | null
+    firstSeen: string | null
+}
+
+export interface EmoteTotals {
+    usage: number
+    /** Sum of per-stream chatter counts (attendance-weighted reach). */
+    chatterReach: number
+    streamCount: number
+    creatorCount: number
+    lastUsed: string | null
+}
+
+export interface EmoteCreatorUsage {
+    creatorId: number
+    nick: string
+    displayName: string
+    usage: number
+    chatterReach: number
+    streamCount: number
+}
+
+export interface EmoteWeeklyUsage {
+    /** ISO date of the week's Monday; absent weeks mean zero usage. */
+    weekStart: string
+    usage: number
+}
+
+export interface EmoteStreamUsage {
+    streamId: number
+    title: string | null
+    start: string | null
+    creatorId: number
+    creatorNick: string
+    creatorDisplayName: string
+    usage: number
+    chatterCount: number
+}
+
+export interface EmoteDetail {
+    meta: EmoteMeta
+    totals: EmoteTotals
+    topCreators: EmoteCreatorUsage[]
+    weeklyUsage: EmoteWeeklyUsage[]
+    recentStreams: EmoteStreamUsage[]
+}
+
+export const mapEmoteDetail = (value: unknown): EmoteDetail => {
+    const data = requireRecord(value, 'emote detail')
+    const meta = requireRecord(data.meta, 'emote detail.meta')
+    const totals = requireRecord(data.totals, 'emote detail.totals')
+    return {
+        meta: {
+            emoteId: requireFiniteNumberField(meta, 'emote_id', 'emote detail.meta'),
+            name: requireStringField(meta, 'name', 'emote detail.meta'),
+            source: requireStringField(meta, 'source', 'emote detail.meta'),
+            providerId: requireNullableStringField(meta, 'provider_id', 'emote detail.meta'),
+            firstSeen: requireNullableStringField(meta, 'first_seen', 'emote detail.meta'),
+        },
+        totals: {
+            usage: requireFiniteNumberField(totals, 'usage', 'emote detail.totals'),
+            chatterReach: requireFiniteNumberField(totals, 'chatter_reach', 'emote detail.totals'),
+            streamCount: requireFiniteNumberField(totals, 'stream_count', 'emote detail.totals'),
+            creatorCount: requireFiniteNumberField(totals, 'creator_count', 'emote detail.totals'),
+            lastUsed: requireNullableStringField(totals, 'last_used', 'emote detail.totals'),
+        },
+        topCreators: requireArrayField(data, 'top_creators', 'emote detail').map((entry, index) => {
+            const label = `emote detail.top_creators[${index}]`
+            const row = requireRecord(entry, label)
+            return {
+                creatorId: requireFiniteNumberField(row, 'creator_id', label),
+                nick: requireStringField(row, 'nick', label),
+                displayName: requireStringField(row, 'display_name', label),
+                usage: requireFiniteNumberField(row, 'usage', label),
+                chatterReach: requireFiniteNumberField(row, 'chatter_reach', label),
+                streamCount: requireFiniteNumberField(row, 'stream_count', label),
+            }
+        }),
+        weeklyUsage: requireArrayField(data, 'weekly_usage', 'emote detail').map((entry, index) => {
+            const label = `emote detail.weekly_usage[${index}]`
+            const row = requireRecord(entry, label)
+            return {
+                weekStart: requireStringField(row, 'week_start', label),
+                usage: requireFiniteNumberField(row, 'usage', label),
+            }
+        }),
+        recentStreams: requireArrayField(data, 'recent_streams', 'emote detail').map((entry, index) => {
+            const label = `emote detail.recent_streams[${index}]`
+            const row = requireRecord(entry, label)
+            return {
+                streamId: requireFiniteNumberField(row, 'stream_id', label),
+                title: requireNullableStringField(row, 'title', label),
+                start: requireNullableStringField(row, 'start', label),
+                creatorId: requireFiniteNumberField(row, 'creator_id', label),
+                creatorNick: requireStringField(row, 'creator_nick', label),
+                creatorDisplayName: requireStringField(row, 'creator_display_name', label),
+                usage: requireFiniteNumberField(row, 'usage', label),
+                chatterCount: requireFiniteNumberField(row, 'chatter_count', label),
+            }
+        }),
+    }
+}
+
+export const useEmoteDetail = (emoteId: number | null) => useQuery({
+    queryKey: sceneKeys.emoteDetail(emoteId ?? 0),
+    queryFn: async () => mapEmoteDetail((await retrieveEmoteDetail(emoteId as number)).data),
+    enabled: emoteId !== null && emoteId > 0,
+})

--- a/frontend/lib/api/chatter.ts
+++ b/frontend/lib/api/chatter.ts
@@ -91,3 +91,36 @@ export interface ChatterPassportDto {
 
 export const retrieveChatterPassport = (chatterId: number) =>
   api.get<ChatterPassportDto>(`/chatters/${chatterId}/passport`)
+
+// ---------------------------------------------------------------------------
+// Chatter head-to-head — GET /chatters/head-to-head
+// ---------------------------------------------------------------------------
+
+interface ChatterHeadToHeadSideDto {
+  chatter_id: number
+  nick: string
+  is_bot: boolean | null
+  messages: number
+  streams_attended: number
+  creators_visited: number
+  first_seen: string | null
+  last_seen: string | null
+  home_channel: {
+    creator_id: number
+    creator_nick: string
+    creator_display_name: string
+    messages: number
+    share: number
+  } | null
+  archetypes: Array<{ key: string, label: string, description: string }>
+}
+
+export interface ChatterHeadToHeadDto {
+  a: ChatterHeadToHeadSideDto
+  b: ChatterHeadToHeadSideDto
+  shared_streams: number
+  shared_creators: number
+}
+
+export const retrieveChatterHeadToHead = (chatterA: number, chatterB: number) =>
+  api.get<ChatterHeadToHeadDto>(`/chatters/head-to-head?${buildQuery({ chatter_a: chatterA, chatter_b: chatterB })}`)

--- a/frontend/lib/api/scene.ts
+++ b/frontend/lib/api/scene.ts
@@ -391,3 +391,46 @@ export interface SceneRadarDto {
 
 export const retrieveSceneRadar = () =>
   api.get<SceneRadarDto>('/scene/radar')
+
+// ---------------------------------------------------------------------------
+// Emote drill-down (lifetime story of one emote) — GET /scene/emotes/{id}
+// ---------------------------------------------------------------------------
+
+export interface EmoteDetailDto {
+  meta: {
+    emote_id: number
+    name: string
+    source: string
+    provider_id: string | null
+    first_seen: string | null
+  }
+  totals: {
+    usage: number
+    chatter_reach: number
+    stream_count: number
+    creator_count: number
+    last_used: string | null
+  }
+  top_creators: Array<{
+    creator_id: number
+    nick: string
+    display_name: string
+    usage: number
+    chatter_reach: number
+    stream_count: number
+  }>
+  weekly_usage: Array<{ week_start: string, usage: number }>
+  recent_streams: Array<{
+    stream_id: number
+    title: string | null
+    start: string | null
+    creator_id: number
+    creator_nick: string
+    creator_display_name: string
+    usage: number
+    chatter_count: number
+  }>
+}
+
+export const retrieveEmoteDetail = (emoteId: number) =>
+  api.get<EmoteDetailDto>(`/scene/emotes/${emoteId}`)

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/styles/_digest.scss
+++ b/frontend/styles/_digest.scss
@@ -38,6 +38,23 @@
         }
     }
 
+    // Numbered runs (Most active chatters) keep their ranks: same hairline
+    // styling, with a mono counter instead of a hidden marker.
+    .digest-list-ordered {
+        counter-reset: digest-rank;
+
+        li {
+            counter-increment: digest-rank;
+
+            &::before {
+                content: counter(digest-rank, decimal-leading-zero) " ";
+                font-family: var(--bs-font-monospace);
+                color: $phosphor-dim;
+                margin-right: 0.35rem;
+            }
+        }
+    }
+
     .digest-p {
         font-size: 0.85rem;
         color: $gray-500;

--- a/frontend/styles/_digest.scss
+++ b/frontend/styles/_digest.scss
@@ -1,0 +1,46 @@
+// Scene digest page (/digest) — renders the Discord digest markdown as HTML.
+// Reuses .card, .toolbar, .page-head primitives from _theme.scss.
+
+.digest-card {
+    padding: 1.25rem 1.5rem;
+}
+
+.digest-body {
+    max-width: 720px;
+
+    .digest-h2 {
+        font-size: 1.1rem;
+        margin: 0 0 0.75rem;
+        color: $phosphor;
+    }
+
+    .digest-h3 {
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        margin: 1.25rem 0 0.5rem;
+        color: $phosphor-dim;
+    }
+
+    .digest-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+
+        li {
+            font-size: 0.85rem;
+            line-height: 1.5;
+            padding-left: 0.9rem;
+            border-left: 2px solid $hairline;
+        }
+    }
+
+    .digest-p {
+        font-size: 0.85rem;
+        color: $gray-500;
+        margin: 0 0 0.5rem;
+    }
+}

--- a/frontend/styles/_emotes.scss
+++ b/frontend/styles/_emotes.scss
@@ -23,3 +23,88 @@
         white-space: nowrap;
     }
 }
+
+// --- Emote drill-down (/emotes/[id]) -----------------------------------------
+// Reuses .stat-tile, .data-bar, .section-label, .card from _theme.scss.
+
+.emote-detail-title {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.emote-detail-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+
+    .stat-value-date {
+        font-size: 0.95rem;
+    }
+}
+
+.emote-detail-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 1rem;
+
+    @media (max-width: 900px) {
+        grid-template-columns: 1fr;
+    }
+}
+
+.emote-detail-card {
+    padding: 1rem 1.25rem;
+    margin-bottom: 1rem;
+
+    .section-label {
+        margin-bottom: 0.75rem;
+    }
+}
+
+.emote-detail-table {
+    margin-bottom: 0;
+
+    .data-bar {
+        display: inline-block;
+        width: 70px;
+        margin-left: 0.5rem;
+        vertical-align: middle;
+    }
+}
+
+.emote-detail-stream {
+    max-width: 320px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.emote-detail-quiet {
+    margin: 0;
+    font-size: 0.85rem;
+    color: $gray-500;
+}
+
+.emote-weeks {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.emote-week-row {
+    display: grid;
+    grid-template-columns: 64px 1fr 56px;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.82rem;
+}
+
+.emote-week-label {
+    color: $gray-500;
+}

--- a/frontend/styles/_versus.scss
+++ b/frontend/styles/_versus.scss
@@ -106,3 +106,26 @@
     font-size: 0.78rem;
     color: $gray-500;
 }
+
+// --- Chatter versus (/versus/chatters) ---------------------------------------
+// Shares the .versus-* layout above; only chatter-specific bits live here.
+
+.chatter-versus-name {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.chatter-versus-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    min-height: 1.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.chatter-versus-era {
+    margin: 0.75rem 0 0;
+    font-size: 0.78rem;
+    color: $gray-500;
+}

--- a/frontend/styles/style.scss
+++ b/frontend/styles/style.scss
@@ -20,5 +20,6 @@
 @import "trending";
 @import "emotes";
 @import "versus";
+@import "digest";
 @import "wrapped";
 @import "radar";

--- a/frontend/test/emoteDetailAndChatterVersus.test.tsx
+++ b/frontend/test/emoteDetailAndChatterVersus.test.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import { mapEmoteDetail } from '@/hooks/scene/useEmoteDetailQuery'
+import { mapChatterHeadToHead } from '@/hooks/chatter/useChatterVersusQuery'
+import { parseDigestBlocks, renderInline } from '@/components/scene/DigestMarkdown'
+
+const emoteDetailPayload = {
+    meta: { emote_id: 7, name: 'agrPls', source: 'bttv', provider_id: 'abc', first_seen: '2024-01-01T00:00:00' },
+    totals: { usage: 400, chatter_reach: 70, stream_count: 3, creator_count: 2, last_used: '2026-07-18T19:00:00' },
+    top_creators: [
+        {
+            creator_id: 1, nick: 'agraelus', display_name: 'Agraelus',
+            usage: 350, chatter_reach: 60, stream_count: 2,
+        },
+    ],
+    weekly_usage: [{ week_start: '2026-07-13', usage: 250 }],
+    recent_streams: [
+        {
+            stream_id: 12, title: 'S3', start: '2026-07-18T17:00:00',
+            creator_id: 2, creator_nick: 'claina', creator_display_name: 'Claina',
+            usage: 50, chatter_count: 10,
+        },
+    ],
+}
+
+describe('mapEmoteDetail', () => {
+    it('maps the full wire payload to camelCase', () => {
+        const detail = mapEmoteDetail(emoteDetailPayload)
+        expect(detail.meta.emoteId).toBe(7)
+        expect(detail.totals.chatterReach).toBe(70)
+        expect(detail.topCreators[0].displayName).toBe('Agraelus')
+        expect(detail.weeklyUsage[0].weekStart).toBe('2026-07-13')
+        expect(detail.recentStreams[0].creatorDisplayName).toBe('Claina')
+    })
+
+    it('accepts an unused emote (zero totals, empty sections)', () => {
+        const detail = mapEmoteDetail({
+            ...emoteDetailPayload,
+            totals: { usage: 0, chatter_reach: 0, stream_count: 0, creator_count: 0, last_used: null },
+            top_creators: [],
+            weekly_usage: [],
+            recent_streams: [],
+        })
+        expect(detail.totals.usage).toBe(0)
+        expect(detail.totals.lastUsed).toBeNull()
+        expect(detail.topCreators).toEqual([])
+    })
+
+    it('rejects a payload missing a totals field', () => {
+        const brokenTotals: Record<string, unknown> = { ...emoteDetailPayload.totals }
+        delete brokenTotals.chatter_reach
+        expect(() => mapEmoteDetail({ ...emoteDetailPayload, totals: brokenTotals }))
+            .toThrow(/chatter_reach/)
+    })
+})
+
+const versusPayload = {
+    a: {
+        chatter_id: 100, nick: 'alpha', is_bot: false,
+        messages: 1000, streams_attended: 15, creators_visited: 2,
+        first_seen: '2024-01-01T20:00:00', last_seen: '2026-06-01T13:37:00',
+        home_channel: {
+            creator_id: 5, creator_nick: 'homie', creator_display_name: 'Homie',
+            messages: 900, share: 0.9,
+        },
+        archetypes: [{ key: 'loyalist', label: 'Loyalist', description: 'Home share above 80%' }],
+    },
+    b: {
+        chatter_id: 200, nick: 'beta', is_bot: null,
+        messages: 0, streams_attended: 0, creators_visited: 0,
+        first_seen: null, last_seen: null,
+        home_channel: null,
+        archetypes: [],
+    },
+    shared_streams: 6,
+    shared_creators: 2,
+}
+
+describe('mapChatterHeadToHead', () => {
+    it('maps both sides including nested home channel and archetypes', () => {
+        const data = mapChatterHeadToHead(versusPayload)
+        expect(data.a.homeChannel?.creatorDisplayName).toBe('Homie')
+        expect(data.a.archetypes[0].key).toBe('loyalist')
+        expect(data.a.isBot).toBe(false)
+        expect(data.sharedStreams).toBe(6)
+    })
+
+    it('accepts a zero side with null home channel (never-crossed-paths contract)', () => {
+        const data = mapChatterHeadToHead(versusPayload)
+        expect(data.b.homeChannel).toBeNull()
+        expect(data.b.isBot).toBeNull()
+        expect(data.b.messages).toBe(0)
+        expect(data.b.firstSeen).toBeNull()
+    })
+
+    it('rejects a side missing shared counters', () => {
+        const broken: Record<string, unknown> = { ...versusPayload }
+        delete broken.shared_streams
+        expect(() => mapChatterHeadToHead(broken)).toThrow(/shared_streams/)
+    })
+})
+
+describe('digest markdown parsing', () => {
+    it('groups headings, list runs, and paragraphs', () => {
+        const markdown = [
+            '## Stream Sniper · 7-day scene pulse',
+            '- **Agraelus finished a stream** — 17,739 messages',
+            '- **A copypasta reached Claina** — catJAM',
+            '',
+            '### Biggest moments',
+            '- **Agraelus** — spike → https://stream-sniper.slanycukr.com/stream/99',
+            'No notable captured events in this window.',
+        ].join('\n')
+
+        const blocks = parseDigestBlocks(markdown)
+        expect(blocks.map(block => block.kind)).toEqual(['h2', 'list', 'h3', 'list', 'paragraph'])
+        expect(blocks[1].lines).toHaveLength(2)
+        expect(blocks[1].lines[0]).toContain('**Agraelus finished a stream**')
+    })
+
+    it('renders bold spans and bare URLs as nodes', () => {
+        const nodes = renderInline('**Agraelus** — spike → https://example.com/stream/99', 'k')
+        // strong element + anchor element among the nodes
+        const hasStrong = nodes.some(node => typeof node === 'object' && node !== null && 'type' in node && node.type === 'strong')
+        const hasAnchor = nodes.some(node => typeof node === 'object' && node !== null && 'type' in node && node.type === 'a')
+        expect(hasStrong).toBe(true)
+        expect(hasAnchor).toBe(true)
+    })
+
+    it('parses numbered chatter lines as list items', () => {
+        const blocks = parseDigestBlocks('### Most active chatters\n1. **rybicka** — 4200 msgs\n2. **karel** — 900 msgs')
+        expect(blocks[1].kind).toBe('list')
+        expect(blocks[1].lines).toEqual(['**rybicka** — 4200 msgs', '**karel** — 900 msgs'])
+    })
+})

--- a/frontend/test/emoteDetailAndChatterVersus.test.tsx
+++ b/frontend/test/emoteDetailAndChatterVersus.test.tsx
@@ -126,9 +126,20 @@ describe('digest markdown parsing', () => {
         expect(hasAnchor).toBe(true)
     })
 
-    it('parses numbered chatter lines as list items', () => {
+    it('parses numbered chatter lines as an ORDERED list (ranks preserved)', () => {
         const blocks = parseDigestBlocks('### Most active chatters\n1. **rybicka** — 4200 msgs\n2. **karel** — 900 msgs')
         expect(blocks[1].kind).toBe('list')
+        expect(blocks[1].ordered).toBe(true)
         expect(blocks[1].lines).toEqual(['**rybicka** — 4200 msgs', '**karel** — 900 msgs'])
+    })
+
+    it('keeps bullet and numbered runs as separate blocks', () => {
+        const blocks = parseDigestBlocks('- bullet one\n1. ranked one\n2. ranked two\n- bullet two')
+        expect(blocks.map(block => [block.kind, block.ordered ?? false])).toEqual([
+            ['list', false],
+            ['list', true],
+            ['list', false],
+        ])
+        expect(blocks[1].lines).toHaveLength(2)
     })
 })

--- a/frontend/views/community/ChatterVersus.tsx
+++ b/frontend/views/community/ChatterVersus.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import Link from 'next/link'
+import { usePathname, useRouter } from 'next/navigation'
+import AsyncSearchSelect from '@/components/common/search/AsyncSearchSelect'
+import ArchetypeBadges from '@/components/chatter/ArchetypeBadges'
+import QueryState from '@/components/common/QueryState'
+import StatusChip from '@/components/common/StatusChip'
+import {
+    useChatterHeadToHead,
+    type ChatterHeadToHead,
+    type ChatterVersusSide,
+} from '@/hooks/chatter/useChatterVersusQuery'
+import type { ChatterOption } from '@/hooks/chatter/useChatterExplorer'
+import { retrieveChatterSearch } from '@/lib/api/chatter'
+import { formatCompactNumber, shareBarWidth } from '@/utils/numberUtils'
+import { formatDate } from '@/utils/dateUtils'
+
+const dateLabel = (value: string | null): string => (
+    value ? formatDate(value, 'MMM d, yyyy') : '—'
+)
+
+const SideCard = ({ side }: { side: ChatterVersusSide }) => (
+    <div className="versus-side card">
+        <div className="chatter-versus-name">
+            <Link className="versus-side-name" href={`/chatter/${side.chatterId}`}>
+                {side.nick}
+            </Link>
+            {side.isBot === true ? <StatusChip variant="warn">BOT</StatusChip> : null}
+        </div>
+        <div className="chatter-versus-badges">
+            <ArchetypeBadges archetypes={side.archetypes} />
+        </div>
+        <div className="versus-side-stats">
+            <div className="stat-tile">
+                <div className="stat-label">Messages</div>
+                <div className="stat-value">{formatCompactNumber(side.messages)}</div>
+            </div>
+            <div className="stat-tile">
+                <div className="stat-label">Streams</div>
+                <div className="stat-value">{formatCompactNumber(side.streamsAttended)}</div>
+            </div>
+            <div className="stat-tile">
+                <div className="stat-label">Channels</div>
+                <div className="stat-value">{formatCompactNumber(side.creatorsVisited)}</div>
+            </div>
+        </div>
+        {side.homeChannel ? (
+            <div className="versus-share">
+                <div className="versus-share-label">
+                    <span>
+                        {'Home: '}
+                        <Link href={`/creator/${side.homeChannel.creatorId}`}>
+                            {side.homeChannel.creatorDisplayName || side.homeChannel.creatorNick}
+                        </Link>
+                    </span>
+                    <span className="mono">{`${(side.homeChannel.share * 100).toFixed(1)}%`}</span>
+                </div>
+                <div className="versus-share-track" aria-hidden="true">
+                    <div
+                        className="versus-share-fill"
+                        style={{ width: `${shareBarWidth(side.homeChannel.share)}%` }}
+                    />
+                </div>
+            </div>
+        ) : null}
+        <p className="chatter-versus-era">
+            {`Active ${dateLabel(side.firstSeen)} → ${dateLabel(side.lastSeen)}`}
+        </p>
+    </div>
+)
+
+interface VersusResultProps {
+    data: ChatterHeadToHead
+    /** Chatter id picked on the left, so display order follows the pickers, not the normalized payload. */
+    leftId: number
+}
+
+const VersusResult = ({ data, leftId }: VersusResultProps) => {
+    // The payload is normalized (side `a` = lower id); re-orient it to the pickers.
+    const [left, right] = data.a.chatterId === leftId ? [data.a, data.b] : [data.b, data.a]
+    return (
+        <div className="versus-grid">
+            <SideCard side={left} />
+            <div className="versus-center card">
+                <div className="versus-vs" aria-hidden="true">vs</div>
+                <div className="stat-tile">
+                    <div className="stat-label">Shared streams</div>
+                    <div className="stat-value">{formatCompactNumber(data.sharedStreams)}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">Shared channels</div>
+                    <div className="stat-value">{formatCompactNumber(data.sharedCreators)}</div>
+                </div>
+            </div>
+            <SideCard side={right} />
+        </div>
+    )
+}
+
+interface ChatterVersusProps {
+    initialA?: number | null
+    initialB?: number | null
+}
+
+const ChatterVersus = ({ initialA = null, initialB = null }: ChatterVersusProps) => {
+    // Deep-linked ids arrive without nicks; the pickers show a plain #id label
+    // until the user changes them (the comparison itself only needs the id).
+    const [pickA, setPickA] = useState<ChatterOption | null>(
+        initialA ? { value: initialA, label: `#${initialA}`, isBot: null } : null,
+    )
+    const [pickB, setPickB] = useState<ChatterOption | null>(
+        initialB ? { value: initialB, label: `#${initialB}`, isBot: null } : null,
+    )
+    const router = useRouter()
+    const pathname = usePathname()
+
+    const loadChatterOptions = useCallback(async (query: string): Promise<ChatterOption[]> => {
+        const trimmed = query.trim()
+        if (trimmed.length < 2) return []
+        const { data } = await retrieveChatterSearch(trimmed)
+        return (data || []).map(result => ({
+            value: result.chatter_id,
+            label: result.nick,
+            isBot: result.is_bot,
+        }))
+    }, [])
+    const noOptionsMessage = useCallback(({ inputValue }: { inputValue: string }) => (
+        inputValue && inputValue.trim().length >= 2
+            ? `No chatters matching "${inputValue}"`
+            : 'Type at least 2 characters to search'
+    ), [])
+
+    const pickChatter = (side: 'a' | 'b', option: ChatterOption | null) => {
+        const nextA = side === 'a' ? option : pickA
+        const nextB = side === 'b' ? option : pickB
+        if (side === 'a') setPickA(option)
+        else setPickB(option)
+        // Keep the matchup deep-linkable without triggering a navigation/remount.
+        const params = new URLSearchParams()
+        if (nextA) params.set('a', String(nextA.value))
+        if (nextB) params.set('b', String(nextB.value))
+        const query = params.toString()
+        router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+    }
+
+    const chatterA = pickA?.value ?? null
+    const chatterB = pickB?.value ?? null
+    const samePick = chatterA !== null && chatterA === chatterB
+    const query = useChatterHeadToHead(chatterA, chatterB)
+
+    return (
+        <>
+            <header className="page-head">
+                <div>
+                    <p className="page-sub">two chatters, side by side</p>
+                    <h1 className="page-title">Chatter versus</h1>
+                </div>
+                <Link className="btn btn-outline-secondary btn-sm" href="/versus">
+                    Creator versus →
+                </Link>
+            </header>
+            <div className="toolbar versus-toolbar">
+                <AsyncSearchSelect
+                    instanceId="chatter-versus-a"
+                    inputId="chatter-versus-a-input"
+                    loadOptions={loadChatterOptions}
+                    value={pickA}
+                    onChange={(newValue: unknown) => pickChatter('a', newValue as ChatterOption | null)}
+                    noOptionsMessage={noOptionsMessage}
+                    placeholder="First chatter..."
+                    isClearable
+                    aria-label="First chatter"
+                />
+                <span className="versus-toolbar-vs" aria-hidden="true">vs</span>
+                <AsyncSearchSelect
+                    instanceId="chatter-versus-b"
+                    inputId="chatter-versus-b-input"
+                    loadOptions={loadChatterOptions}
+                    value={pickB}
+                    onChange={(newValue: unknown) => pickChatter('b', newValue as ChatterOption | null)}
+                    noOptionsMessage={noOptionsMessage}
+                    placeholder="Second chatter..."
+                    isClearable
+                    aria-label="Second chatter"
+                />
+            </div>
+            {chatterA === null || chatterB === null ? (
+                <div className="empty-state">
+                    <p className="empty-title">Pick two chatters</p>
+                    <p className="empty-hint">
+                        Compare lifetime footprints — messages, streams, home channels, and how often they crossed paths.
+                    </p>
+                </div>
+            ) : null}
+            {samePick ? (
+                <div className="empty-state">
+                    <p className="empty-title">Same chatter on both sides</p>
+                    <p className="empty-hint">Pick two different chatters to compare.</p>
+                </div>
+            ) : null}
+            <QueryState
+                query={query}
+                errorTitle="Chatter versus unavailable"
+                loadingText="Weighing the chat logs..."
+                emptyState={null}
+                showErrorDetails={false}
+            >
+                {(data: ChatterHeadToHead) => (
+                    <VersusResult data={data} leftId={chatterA as number} />
+                )}
+            </QueryState>
+        </>
+    )
+}
+
+export default ChatterVersus

--- a/frontend/views/community/Versus.tsx
+++ b/frontend/views/community/Versus.tsx
@@ -148,6 +148,9 @@ const Versus = ({ initialA = null, initialB = null }: VersusProps) => {
                         Head-to-head
                     </h1>
                 </div>
+                <Link className="btn btn-outline-secondary btn-sm" href="/versus/chatters">
+                    Chatter versus →
+                </Link>
             </header>
             <div className="toolbar versus-toolbar">
                 <Select

--- a/frontend/views/scene/EmoteDetail.tsx
+++ b/frontend/views/scene/EmoteDetail.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+import Link from 'next/link'
+import QueryState from '@/components/common/QueryState'
+import StatusChip from '@/components/common/StatusChip'
+import {
+    useEmoteDetail,
+    type EmoteDetail as EmoteDetailData,
+    type EmoteWeeklyUsage,
+} from '@/hooks/scene/useEmoteDetailQuery'
+import { formatCompactNumber, magnitudeBarWidth } from '@/utils/numberUtils'
+import { formatDate } from '@/utils/dateUtils'
+
+const dateLabel = (value: string | null, mask = 'MMM d, yyyy'): string => (
+    value ? formatDate(value, mask) : '—'
+)
+
+/** Weekly bars keyed off the busiest week so the trend reads at a glance. */
+const WeeklyTrend = ({ weeks }: { weeks: EmoteWeeklyUsage[] }) => {
+    if (weeks.length === 0) {
+        return <p className="emote-detail-quiet">No usage in the trailing 12 weeks.</p>
+    }
+    const peak = Math.max(1, ...weeks.map(week => week.usage))
+    return (
+        <ul className="emote-weeks" aria-label="Usage per week">
+            {weeks.map(week => {
+                const barStyle: CSSProperties = { width: `${magnitudeBarWidth(week.usage, peak)}%` }
+                return (
+                    <li key={week.weekStart} className="emote-week-row">
+                        <span className="emote-week-label mono">{formatDate(week.weekStart, 'MMM d')}</span>
+                        <span className="data-bar" aria-hidden="true">
+                            <span className="data-bar-fill" style={barStyle} />
+                        </span>
+                        <span className="mono text-end">{formatCompactNumber(week.usage)}</span>
+                    </li>
+                )
+            })}
+        </ul>
+    )
+}
+
+const EmoteDetailBody = ({ data }: { data: EmoteDetailData }) => {
+    const maxCreatorUsage = Math.max(1, ...data.topCreators.map(row => row.usage))
+    return (
+        <>
+            <div className="page-head">
+                <div>
+                    <p className="page-sub">one emote, its whole story</p>
+                    <h1 className="page-title emote-detail-title">
+                        {data.meta.name}
+                        <StatusChip variant="neutral">{data.meta.source}</StatusChip>
+                    </h1>
+                </div>
+                <Link className="btn btn-outline-secondary btn-sm" href="/emotes">
+                    ← Emote economy
+                </Link>
+            </div>
+
+            <div className="emote-detail-tiles">
+                <div className="stat-tile">
+                    <div className="stat-label">Lifetime uses</div>
+                    <div className="stat-value">{formatCompactNumber(data.totals.usage)}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">Reach</div>
+                    <div className="stat-value">{formatCompactNumber(data.totals.chatterReach)}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">Streams</div>
+                    <div className="stat-value">{formatCompactNumber(data.totals.streamCount)}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">Channels</div>
+                    <div className="stat-value">{formatCompactNumber(data.totals.creatorCount)}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">First seen</div>
+                    <div className="stat-value stat-value-date">{dateLabel(data.meta.firstSeen)}</div>
+                </div>
+                <div className="stat-tile">
+                    <div className="stat-label">Last used</div>
+                    <div className="stat-value stat-value-date">{dateLabel(data.totals.lastUsed)}</div>
+                </div>
+            </div>
+
+            <div className="emote-detail-grid">
+                <section className="card emote-detail-card">
+                    <h2 className="section-label">Where it lives</h2>
+                    {data.topCreators.length === 0 ? (
+                        <p className="emote-detail-quiet">Not used in any tracked channel yet.</p>
+                    ) : (
+                        <table className="table emote-detail-table">
+                            <thead>
+                                <tr>
+                                    <th>Channel</th>
+                                    <th className="text-end">Uses</th>
+                                    <th className="text-end">Streams</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {data.topCreators.map(row => {
+                                    const barStyle: CSSProperties = {
+                                        width: `${magnitudeBarWidth(row.usage, maxCreatorUsage)}%`,
+                                    }
+                                    return (
+                                        <tr key={row.creatorId}>
+                                            <td>
+                                                <Link href={`/creator/${row.creatorId}`}>
+                                                    {row.displayName || row.nick}
+                                                </Link>
+                                            </td>
+                                            <td className="text-end">
+                                                <span className="mono">{formatCompactNumber(row.usage)}</span>
+                                                <span className="data-bar" aria-hidden="true">
+                                                    <span className="data-bar-fill" style={barStyle} />
+                                                </span>
+                                            </td>
+                                            <td className="mono text-end">{row.streamCount}</td>
+                                        </tr>
+                                    )
+                                })}
+                            </tbody>
+                        </table>
+                    )}
+                </section>
+
+                <section className="card emote-detail-card">
+                    <h2 className="section-label">Last 12 weeks</h2>
+                    <WeeklyTrend weeks={data.weeklyUsage} />
+                </section>
+            </div>
+
+            <section className="card emote-detail-card">
+                <h2 className="section-label">Recent streams</h2>
+                {data.recentStreams.length === 0 ? (
+                    <p className="emote-detail-quiet">No streams recorded for this emote yet.</p>
+                ) : (
+                    <table className="table emote-detail-table">
+                        <thead>
+                            <tr>
+                                <th>Stream</th>
+                                <th>Channel</th>
+                                <th className="text-end">Date</th>
+                                <th className="text-end">Uses</th>
+                                <th className="text-end">Chatters</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {data.recentStreams.map(row => (
+                                <tr key={row.streamId}>
+                                    <td className="emote-detail-stream">
+                                        <Link href={`/stream/${row.streamId}`}>
+                                            {row.title || `Stream #${row.streamId}`}
+                                        </Link>
+                                    </td>
+                                    <td>{row.creatorDisplayName || row.creatorNick}</td>
+                                    <td className="mono text-end">{dateLabel(row.start, 'MMM d')}</td>
+                                    <td className="mono text-end">{formatCompactNumber(row.usage)}</td>
+                                    <td className="mono text-end">{formatCompactNumber(row.chatterCount)}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </section>
+        </>
+    )
+}
+
+const EmoteDetail = ({ emoteId }: { emoteId: number }) => {
+    const query = useEmoteDetail(emoteId)
+    return (
+        <QueryState
+            query={query}
+            errorTitle="Emote unavailable"
+            loadingText="Tracing the emote…"
+            emptyState={null}
+            showErrorDetails={false}
+        >
+            {(data: EmoteDetailData) => <EmoteDetailBody data={data} />}
+        </QueryState>
+    )
+}
+
+export default EmoteDetail

--- a/frontend/views/scene/EmoteEconomy.tsx
+++ b/frontend/views/scene/EmoteEconomy.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import type { CSSProperties } from 'react'
+import Link from 'next/link'
 import FilterPills from '@/components/common/FilterPills'
 import QueryState from '@/components/common/QueryState'
 import StatusChip from '@/components/common/StatusChip'
@@ -42,7 +43,7 @@ const EmoteEconomyRow = ({ rank, item, maxUsage }: EmoteEconomyRowProps) => {
         <tr>
             <td className="rank-num">{String(rank).padStart(2, '0')}</td>
             <td className="trending-primary">
-                <span className="trending-label">{item.name}</span>
+                <Link className="trending-label" href={`/emotes/${item.emoteId}`}>{item.name}</Link>
                 <span className="trending-source">{item.source}</span>
             </td>
             <td className="trending-usage text-end">

--- a/frontend/views/scene/SceneDigest.tsx
+++ b/frontend/views/scene/SceneDigest.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useState } from 'react'
+import DigestMarkdown from '@/components/scene/DigestMarkdown'
+import FilterPills from '@/components/common/FilterPills'
+import QueryState from '@/components/common/QueryState'
+import { useSceneDigest } from '@/hooks/scene/useScenePulseQueries'
+
+const WINDOW_TABS: Array<{ key: number, label: string }> = [
+    { key: 7, label: '7 days' },
+    { key: 14, label: '14 days' },
+    { key: 30, label: '30 days' },
+]
+
+/**
+ * The web mirror of the Discord scene digest: the same markdown payload the
+ * weekly webhook delivers, rendered as a page with a window selector and a
+ * copy button (for pasting into chats that don't get the webhook).
+ */
+const SceneDigest = () => {
+    const [days, setDays] = useState(7)
+    const [copied, setCopied] = useState(false)
+    const query = useSceneDigest({ days })
+
+    const copyDigest = async () => {
+        if (!query.data) return
+        await navigator.clipboard.writeText(query.data)
+        setCopied(true)
+        window.setTimeout(() => setCopied(false), 2000)
+    }
+
+    return (
+        <>
+            <header className="page-head">
+                <div>
+                    <p className="page-sub">the scene, summarized</p>
+                    <h1 className="page-title">Digest</h1>
+                </div>
+                <button
+                    type="button"
+                    className="btn btn-outline-secondary btn-sm"
+                    onClick={copyDigest}
+                    disabled={!query.data}
+                >
+                    {copied ? 'Copied' : 'Copy as markdown'}
+                </button>
+            </header>
+            <div className="toolbar" role="search" aria-label="Digest controls">
+                <span className="toolbar-label">Window</span>
+                <FilterPills
+                    options={WINDOW_TABS}
+                    activeKey={days}
+                    ariaLabel="Digest window"
+                    onChange={setDays}
+                />
+            </div>
+            <section className="card digest-card">
+                <QueryState
+                    query={query}
+                    errorTitle="Digest unavailable"
+                    loadingText="Compiling the scene digest…"
+                    isEmpty={(markdown: string) => !markdown.trim()}
+                    emptyTitle="Nothing to report"
+                    emptyHint={`No notable scene activity in the last ${days} days.`}
+                >
+                    {(markdown: string) => <DigestMarkdown markdown={markdown} />}
+                </QueryState>
+            </section>
+        </>
+    )
+}
+
+export default SceneDigest


### PR DESCRIPTION
Emote drill-down (/emotes/[id], GET /scene/emotes/{id}): the lifetime
story of one emote — dictionary identity, usage totals, the channels it
lives in (ranked, with bars), a trailing 12-week trend, and its most
recent streams. Economy board names now link into it. Unknown id is a
real 404; a dictionary emote with no usage is a legitimate zero page.

Chatter versus (/versus/chatters, GET /chatters/head-to-head): two
chatters side by side — lifetime totals, home channel + share bar, and
archetype badges per side (same aggregation rules as the passport, so
the comparison never contradicts it), plus streams/channels both
attended from a pairwise stream_chatter_stats self-join. Same (lo,hi)
normalization contract as the creator head-to-head; deep-linkable via
?a=&b=; cross-linked with creator Versus both ways.

Digest page (/digest): the web mirror of the Discord scene digest —
same markdown payload, rendered by a deliberately narrow parser that
handles exactly the dialect build_digest emits (##/### headings, -/N.
list runs, **bold**, bare URLs) instead of pulling in a markdown
dependency. Window pills (7/14/30) + copy-as-markdown; sidebar entry
under Scene analytics.

Verification: gateway SQL executed against a scratch Postgres at head
(totals/ordering/symmetry asserted), endpoints smoke-tested via
TestClient (200/400/404 + lo-hi normalization), backend suite 79.4%,
frontend tsc 0 / 396 tests / build with the 3 new routes / 12 e2e.

Claude-Session: https://claude.ai/code/session_01N6W8wgzD5qPXBXuCTE4PJF
